### PR TITLE
fix builtin_list.c:58:10: fatal error: builtin_proto.h: No such file …

### DIFF
--- a/builtin/Makefile
+++ b/builtin/Makefile
@@ -47,7 +47,7 @@ BDATLIST = $(strip $(call RWILDCARD, registry, *.bdat))
 registry$(DELIM).updated:
 	$(Q) $(MAKE) -C registry .updated TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
 
-builtin_list$(OBJEXT): builtin_list.h builtin_proto.h
+builtin_list.c: builtin_list.h builtin_proto.h
 
 builtin_list.h: registry$(DELIM).updated
 	$(call DELFILE, .xx_builtin_list.h)

--- a/builtin/registry/Makefile
+++ b/builtin/registry/Makefile
@@ -41,16 +41,11 @@ include $(APPDIR)/Make.defs
 all:
 .PHONY: context depend clean distclean
 
-.updated: $(DEPCONFIG)
-	$(call DELFILE, *.bdat)
-	$(call DELFILE, *.pdat)
-	$(Q) touch .updated
-
 # This must run before any other context target
 
 install:
 
-context: .updated
+context:
 
 depend:
 


### PR DESCRIPTION
…or directory

Make builtin_list.c instead of builtin_list.o depend on builtin_proto.h and builtin_proto.c

Change-Id: I1ac6c9b7172d433f5d74c9dd248869adf1f5e387
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>