### PR TITLE
Application.mk remove _main suffix from REGLIST

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -184,7 +184,7 @@ ifneq ($(PROGNAME),)
 ifneq ($(PRIORITY),)
 ifneq ($(STACKSIZE),)
 
-REGLIST := $(addprefix $(BUILTIN_REGISTRY)$(DELIM),$(addsuffix _main.bdat,$(PROGNAME)))
+REGLIST := $(addprefix $(BUILTIN_REGISTRY)$(DELIM),$(addsuffix .bdat,$(PROGNAME)))
 APPLIST := $(PROGNAME)
 
 $(REGLIST): $(DEPCONFIG) Makefile


### PR DESCRIPTION
since the file generated by REGISTER macro don't have such suffix

Change-Id: I6814f5bd257563f897c63d9698f8892d9649dcef
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>