### PR TITLE
Unify the void cast usage

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -217,15 +217,15 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
    * be set appropriately).
    */
 
-  (void)posix_spawn_file_actions_destroy(&file_actions);
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawn_file_actions_destroy(&file_actions);
+  posix_spawnattr_destroy(&attr);
   return pid;
 
 errout_with_actions:
-  (void)posix_spawn_file_actions_destroy(&file_actions);
+  posix_spawn_file_actions_destroy(&file_actions);
 
 errout_with_attrs:
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawnattr_destroy(&attr);
 
 errout_with_errno:
   set_errno(ret);

--- a/examples/ajoystick/ajoy_main.c
+++ b/examples/ajoystick/ajoy_main.c
@@ -203,8 +203,8 @@ static int ajoy_wait(int fd, FAR const struct timespec *timeout)
 
   /* Wait for a signal */
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, CONFIG_EXAMPLES_AJOYSTICK_SIGNO);
+  sigemptyset(&set);
+  sigaddset(&set, CONFIG_EXAMPLES_AJOYSTICK_SIGNO);
   ret = sigtimedwait(&set, &value, timeout);
   if (ret < 0)
     {

--- a/examples/alarm/alarm_main.c
+++ b/examples/alarm/alarm_main.c
@@ -93,8 +93,8 @@ static int alarm_daemon(int argc, FAR char *argv[])
 
   /* Make sure that the alarm signal is unmasked */
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, CONFIG_EXAMPLES_ALARM_SIGNO);
+  sigemptyset(&set);
+  sigaddset(&set, CONFIG_EXAMPLES_ALARM_SIGNO);
   ret = sigprocmask(SIG_UNBLOCK, &set, NULL);
   if (ret != OK)
     {
@@ -109,8 +109,8 @@ static int alarm_daemon(int argc, FAR char *argv[])
   act.sa_sigaction = alarm_handler;
   act.sa_flags     = SA_SIGINFO;
 
-  (void)sigfillset(&act.sa_mask);
-  (void)sigdelset(&act.sa_mask, CONFIG_EXAMPLES_ALARM_SIGNO);
+  sigfillset(&act.sa_mask);
+  sigdelset(&act.sa_mask, CONFIG_EXAMPLES_ALARM_SIGNO);
 
   ret = sigaction(CONFIG_EXAMPLES_ALARM_SIGNO, &act, NULL);
   if (ret < 0)
@@ -325,7 +325,7 @@ int main(int argc, FAR char *argv[])
           fprintf(stderr, "ERROR: RTC_RD_ALARM ioctl failed: %d\n",
                   errcode);
 
-          (void)close(fd);
+          close(fd);
           return EXIT_FAILURE;
         }
 
@@ -380,7 +380,7 @@ int main(int argc, FAR char *argv[])
           fprintf(stderr, "ERROR: RTC_CANCEL_ALARM ioctl failed: %d\n",
                   errcode);
 
-          (void)close(fd);
+          close(fd);
           return EXIT_FAILURE;
         }
 
@@ -409,13 +409,13 @@ int main(int argc, FAR char *argv[])
           fprintf(stderr, "ERROR: RTC_SET_RELATIVE ioctl failed: %d\n",
                   errcode);
 
-          (void)close(fd);
+          close(fd);
           return EXIT_FAILURE;
         }
 
       printf("Alarm %d set in %lu seconds\n", alarmid, seconds);
     }
 
-  (void)close(fd);
+  close(fd);
   return EXIT_SUCCESS;
 }

--- a/examples/buttons/buttons_main.c
+++ b/examples/buttons/buttons_main.c
@@ -249,8 +249,8 @@ static int button_daemon(int argc, char *argv[])
 #ifdef CONFIG_EXAMPLES_BUTTONS_SIGNAL
       /* Wait for a signal */
 
-      (void)sigemptyset(&set);
-      (void)sigaddset(&set, CONFIG_EXAMPLES_BUTTONS_SIGNO);
+      sigemptyset(&set);
+      sigaddset(&set, CONFIG_EXAMPLES_BUTTONS_SIGNO);
       ret = sigwaitinfo(&set, &value);
       if (ret < 0)
         {
@@ -366,7 +366,7 @@ static int button_daemon(int argc, char *argv[])
     }
 
 errout_with_fd:
-  (void)close(fd);
+  close(fd);
 
 errout:
   g_button_daemon_started = false;

--- a/examples/calib_udelay/calib_udelay_main.c
+++ b/examples/calib_udelay/calib_udelay_main.c
@@ -78,7 +78,7 @@ static uint64_t gettime_nsecs(void)
   struct timespec ts;
   uint64_t nsecs;
 
-  (void)clock_gettime(CLOCK_MONOTONIC, &ts);
+  clock_gettime(CLOCK_MONOTONIC, &ts);
 
   nsecs  = ts.tv_sec;
   nsecs *= 1000 * 1000 * 1000;

--- a/examples/canard/canard_main.c
+++ b/examples/canard/canard_main.c
@@ -233,8 +233,8 @@ static void onTransferReceived(CanardInstance *ins,
                                (uint16_t) total_size);
       if (resp_res <= 0)
         {
-          (void)fprintf(stderr, "Could not respond to GetNodeInfo; error %d\n",
-                        resp_res);
+          fprintf(stderr, "Could not respond to GetNodeInfo; error %d\n",
+                  resp_res);
         }
     }
 }
@@ -257,8 +257,6 @@ static bool shouldAcceptTransfer(const CanardInstance * ins,
                                  CanardTransferType transfer_type,
                                  uint8_t source_node_id)
 {
-  (void)source_node_id;
-
   if (canardGetLocalNodeID(ins) == CANARD_BROADCAST_NODE_ID)
     {
       /* If we're in the process of allocation of dynamic node ID, accept
@@ -335,8 +333,8 @@ void process1HzTasks(uint64_t timestamp_usec)
                       buffer, UAVCAN_NODE_STATUS_MESSAGE_SIZE);
     if (bc_res <= 0)
       {
-        (void)fprintf(stderr, "Could not broadcast node status; error %d\n",
-                      bc_res);
+        fprintf(stderr, "Could not broadcast node status; error %d\n",
+                bc_res);
       }
   }
 
@@ -352,8 +350,8 @@ void process1HzTasks(uint64_t timestamp_usec)
                              payload, 0);
     if (resp_res <= 0)
       {
-        (void)fprintf(stderr, "Could not request GetNodeInfo; error %d\n",
-                      resp_res);
+        fprintf(stderr, "Could not request GetNodeInfo; error %d\n",
+                resp_res);
       }
   }
 
@@ -380,9 +378,9 @@ void processTxRxOnce(CanardNuttXInstance * nuttxcan, int timeout_msec)
       if (tx_res < 0)           /* Failure - drop the frame and report */
         {
           canardPopTxQueue(&canard);
-          (void)fprintf(stderr,
-                        "Transmit error %d, frame dropped, errno '%s'\n",
-                        tx_res, strerror(errno));
+          fprintf(stderr,
+                  "Transmit error %d, frame dropped, errno '%s'\n",
+                  tx_res, strerror(errno));
         }
       else if (tx_res > 0)      /* Success - just drop the frame */
         {
@@ -402,8 +400,8 @@ void processTxRxOnce(CanardNuttXInstance * nuttxcan, int timeout_msec)
 
   if (rx_res < 0)               /* Failure - report */
     {
-      (void)fprintf(stderr, "Receive error %d, errno '%s'\n", rx_res,
-                    strerror(errno));
+      fprintf(stderr, "Receive error %d, errno '%s'\n", rx_res,
+              strerror(errno));
     }
   else if (rx_res > 0)          /* Success - process the frame */
     {

--- a/examples/chrono/chrono_main.c
+++ b/examples/chrono/chrono_main.c
@@ -186,8 +186,8 @@ static int button_daemon(int argc, char *argv[])
 
       /* Wait for a signal */
 
-      (void)sigemptyset(&set);
-      (void)sigaddset(&set, BUTTON_SIGNO);
+      sigemptyset(&set);
+      sigaddset(&set, BUTTON_SIGNO);
       ret = sigwaitinfo(&set, &value);
       if (ret < 0)
         {
@@ -198,7 +198,7 @@ static int button_daemon(int argc, char *argv[])
 
       if (priv->state == CHRONO_STOPPED)
         {
-          (void)clock_gettime(CLOCK_MONOTONIC, &priv->ts_start);
+          clock_gettime(CLOCK_MONOTONIC, &priv->ts_start);
           priv->state = CHRONO_RUNNING;
         }
       else
@@ -214,7 +214,7 @@ static int button_daemon(int argc, char *argv[])
     }
 
 errout_with_fd:
-  (void)close(fd);
+  close(fd);
 
 errout:
 
@@ -284,7 +284,7 @@ static void slcd_putc(FAR struct lib_outstream_s *stream, int ch)
 
   if (stream->nput >= CONFIG_EXAMPLES_SLCD_BUFSIZE)
     {
-      (void)slcd_flush(stream);
+      slcd_flush(stream);
     }
 }
 
@@ -427,7 +427,7 @@ int main(int argc, FAR char *argv[])
         {
           /* Get the current time */
 
-          (void)clock_gettime(CLOCK_MONOTONIC, &priv->ts_end);
+          clock_gettime(CLOCK_MONOTONIC, &priv->ts_end);
 
           /* How many seconds passed from initial time? */
 

--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -179,7 +179,7 @@ static void configdata_loopmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous loop */
@@ -206,7 +206,7 @@ static void configdata_endmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
   printf("\nFinal memory usage:\n");
   configdata_showmemusage(&g_mmbefore, &g_mmafter);
@@ -682,7 +682,7 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmbefore = mallinfo();
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
 #endif
 
   /* Loop seveal times ... create some config data items, delete them
@@ -706,7 +706,7 @@ int main(int argc, FAR char *argv[])
 #ifndef CONFIG_EXAMPLES_CONFIGDATA_SILENT
       printf("\n=== FILLING %u =============================\n", i);
 #endif
-      (void)configdata_fillconfig();
+      configdata_fillconfig();
 #ifndef CONFIG_EXAMPLES_CONFIGDATA_SILENT
       printf("Filled /dev/config\n");
       printf("  Number of entries: %d\n", g_nentries);

--- a/examples/discover/discover_main.c
+++ b/examples/discover/discover_main.c
@@ -153,7 +153,7 @@ int main(int argc, FAR char *argv[])
   if (handle)
     {
       struct dhcpc_state ds;
-      (void)dhcpc_request(handle, &ds);
+      dhcpc_request(handle, &ds);
       netlib_set_ipv4addr("eth0", &ds.ipaddr);
 
       if (ds.netmask.s_addr != 0)

--- a/examples/djoystick/djoy_main.c
+++ b/examples/djoystick/djoy_main.c
@@ -201,8 +201,8 @@ int main(int argc, FAR char *argv[])
 
       /* Wait for a signal */
 
-      (void)sigemptyset(&set);
-      (void)sigaddset(&set, CONFIG_EXAMPLES_DJOYSTICK_SIGNO);
+      sigemptyset(&set);
+      sigaddset(&set, CONFIG_EXAMPLES_DJOYSTICK_SIGNO);
       ret = sigwaitinfo(&set, &value);
       if (ret < 0)
         {

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -182,7 +182,7 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -207,7 +207,7 @@ static void mm_initmonitor(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mminitial = mmcurrent.uordblks;
@@ -362,7 +362,7 @@ int main(int argc, FAR char *argv[])
    * the ROMFS mountpoint.
    */
 
-  (void)setenv("PATH", MOUNTPT, 1);
+  setenv("PATH", MOUNTPT, 1);
 #endif
 
   /* Now exercise every program in the ROMFS file system */

--- a/examples/elf/tests/signal/signal.c
+++ b/examples/elf/tests/signal/signal.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
   act.sa_sigaction = siguser_action;
   act.sa_flags     = SA_SIGINFO;
 
-  (void)sigemptyset(&act.sa_mask);
+  sigemptyset(&act.sa_mask);
 
   status = sigaction(SIGUSR1, &act, &oact1);
   if (status != 0)

--- a/examples/flash_test/flash_test.c
+++ b/examples/flash_test/flash_test.c
@@ -107,8 +107,8 @@ int main(int argc, FAR char *argv[])
     {
       /* Perform a low-level format */
 
-      (void)inode->u.i_bops->ioctl(inode, BIOC_LLFORMAT, 0);
-      (void)inode->u.i_bops->ioctl(inode, BIOC_GETFORMAT, (unsigned long) &fmt);
+      inode->u.i_bops->ioctl(inode, BIOC_LLFORMAT, 0);
+      inode->u.i_bops->ioctl(inode, BIOC_GETFORMAT, (unsigned long) &fmt);
     }
 
   if (!(fmt.flags & SMART_FMT_ISFORMATTED))
@@ -137,7 +137,7 @@ int main(int argc, FAR char *argv[])
   seqs = (uint16_t *) malloc(fmt.nsectors << 1);
   if (seqs == NULL)
     {
-      (void) free(buffer);
+      free(buffer);
       fprintf(stderr, "Error allocating seqs buffer\n");
       goto errout_with_driver;
     }
@@ -145,8 +145,8 @@ int main(int argc, FAR char *argv[])
   sectors = (uint16_t *) malloc(fmt.nsectors << 1);
   if (sectors == NULL)
     {
-      (void) free(seqs);
-      (void) free(buffer);
+      free(seqs);
+      free(buffer);
       fprintf(stderr, "Error allocating sectors buffer\n");
       goto errout_with_driver;
     }
@@ -182,8 +182,8 @@ int main(int argc, FAR char *argv[])
       readwrite.offset = 0;
       readwrite.count = strlen(buffer) + 1;
       readwrite.buffer = (uint8_t *) buffer;
-      (void)inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
-                                   &readwrite);
+      inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
+                             &readwrite);
 
       /* Print the logical sector number */
 
@@ -241,8 +241,8 @@ int main(int argc, FAR char *argv[])
       readwrite.offset = 0;
       readwrite.count = strlen(buffer) + 1;
       readwrite.buffer = (uint8_t *) buffer;
-      (void)inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
-                                   &readwrite);
+      inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
+                             &readwrite);
 
       /* Print the logical sector number */
 
@@ -266,8 +266,8 @@ int main(int argc, FAR char *argv[])
       readwrite.offset = 64;
       readwrite.count = strlen(buffer) + 1;
       readwrite.buffer = (uint8_t *) buffer;
-      (void)inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
-                                   &readwrite);
+      inode->u.i_bops->ioctl(inode, BIOC_WRITESECT, (unsigned long)
+                             &readwrite);
 
       /* Print the logical sector number */
 
@@ -284,22 +284,22 @@ int main(int argc, FAR char *argv[])
 
       if (sectors[x] != 0xFFFF)
         {
-          (void)inode->u.i_bops->ioctl(inode, BIOC_FREESECT, (unsigned long)
-                                       sectors[x]);
+          inode->u.i_bops->ioctl(inode, BIOC_FREESECT, (unsigned long)
+                                 sectors[x]);
         }
     }
 
 errout_with_buffers:
   /* Free the allocated buffers */
 
-  (void) free(seqs);
-  (void) free(sectors);
-  (void) free(buffer);
+  free(seqs);
+  free(sectors);
+  free(buffer);
 
 errout_with_driver:
   /* Now close the block device and exit */
 
-  (void)close_blockdriver(inode);
+  close_blockdriver(inode);
 
 errout:
 

--- a/examples/ft80x/ft80x_main.c
+++ b/examples/ft80x/ft80x_main.c
@@ -183,7 +183,7 @@ static int ft80x_showname(int fd, FAR struct ft80x_dlbuffer_s *buffer,
 
   /* Mkae sure that the backlight off */
 
-  (void)ft80x_backlight_set(fd, 0);
+  ft80x_backlight_set(fd, 0);
 
   /* Create the display list */
 
@@ -235,8 +235,8 @@ static int ft80x_showname(int fd, FAR struct ft80x_dlbuffer_s *buffer,
 
   /* Fade on then wait bit so that the user can read the example name */
 
-  (void)ft80x_backlight_fade(fd, 100, 2000);
-  (void)sleep(1);
+  ft80x_backlight_fade(fd, 100, 2000);
+  sleep(1);
   return OK;
 }
 
@@ -276,7 +276,7 @@ static int ft80x_example(int fd, FAR struct ft80x_dlbuffer_s *buffer,
   /* Wait a bit, then fade out */
 
   sleep(2);
-  (void)ft80x_backlight_fade(fd, 0, 2000);
+  ft80x_backlight_fade(fd, 0, 2000);
   return OK;
 }
 
@@ -325,7 +325,7 @@ int main(int argc, FAR char *argv[])
 
   for (i = 0; i < NPRIMITIVES; i++)
     {
-      (void)ft80x_example(fd, buffer, &g_primitives[i]);
+      ft80x_example(fd, buffer, &g_primitives[i]);
     }
 #endif
 
@@ -335,7 +335,7 @@ int main(int argc, FAR char *argv[])
 
   for (i = 0; i < NCOPROC; i++)
     {
-      (void)ft80x_example(fd, buffer, &g_coproc[i]);
+      ft80x_example(fd, buffer, &g_coproc[i]);
     }
 
   free(buffer);

--- a/examples/ft80x/ft80x_primitives.c
+++ b/examples/ft80x/ft80x_primitives.c
@@ -735,7 +735,7 @@ int ft80x_prim_stencil(int fd, FAR struct ft80x_dlbuffer_s *buffer)
     }
 
 errout_with_sound:
-  (void)ft80x_audio_enable(fd, false);
+  ft80x_audio_enable(fd, false);
   return ret;
 }
 

--- a/examples/ftpc/ftpc_main.c
+++ b/examples/ftpc/ftpc_main.c
@@ -488,7 +488,7 @@ int main(int argc, FAR char *argv[])
         {
           /* Parse and process the command */
 
-          (void)ftpc_parse(handle, g_line);
+          ftpc_parse(handle, g_line);
           FFLUSH();
         }
     }

--- a/examples/ftpd/ftpd_main.c
+++ b/examples/ftpd/ftpd_main.c
@@ -196,7 +196,7 @@ int ftpd_daemon(int s_argc, char **s_argv)
 
   /* Configure acounts */
 
-  (void)ftpd_accounts(handle);
+  ftpd_accounts(handle);
 
   /* Then drive the FTPD server. */
 

--- a/examples/gpio/gpio_main.c
+++ b/examples/gpio/gpio_main.c
@@ -268,14 +268,14 @@ int main(int argc, FAR char *argv[])
 
               /* Wait up to 5 seconds for the signal */
 
-              (void)sigemptyset(&set);
-              (void)sigaddset(&set, signo);
+              sigemptyset(&set);
+              sigaddset(&set, signo);
 
               ts.tv_sec  = 5;
               ts.tv_nsec = 0;
 
               ret = sigtimedwait(&set, NULL, &ts);
-              (void)ioctl(fd, GPIOC_UNREGISTER, 0);
+              ioctl(fd, GPIOC_UNREGISTER, 0);
 
               if (ret < 0)
                 {

--- a/examples/hidkbd/hidkbd_main.c
+++ b/examples/hidkbd/hidkbd_main.c
@@ -242,7 +242,7 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_EXAMPLES_HIDKBD_ENCODED
               hidkbd_decode(buffer, nbytes);
 #else
-              (void)write(1, buffer, nbytes);
+              write(1, buffer, nbytes);
 #endif
             }
         }

--- a/examples/i2schar/i2schar_main.c
+++ b/examples/i2schar/i2schar_main.c
@@ -293,14 +293,14 @@ int main(int argc, FAR char *argv[])
    * is in place for each transmission.
     */
 
-  (void)pthread_attr_getschedparam(&attr, &param);
+  pthread_attr_getschedparam(&attr, &param);
   param.sched_priority++;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 #endif
 
   /* Set the receiver stack size */
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_I2SCHAR_RXSTACKSIZE);
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_I2SCHAR_RXSTACKSIZE);
 
   /* Start the receiver */
 
@@ -323,7 +323,7 @@ int main(int argc, FAR char *argv[])
 
   /* Set the transmitter stack size */
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_I2SCHAR_TXSTACKSIZE);
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_I2SCHAR_TXSTACKSIZE);
 
   /* Start the transmitter */
 
@@ -334,7 +334,7 @@ int main(int argc, FAR char *argv[])
       printf("i2schar_main: ERROR: failed to Start transmitter thread: %d\n", ret);
 #ifdef CONFIG_EXAMPLES_I2SCHAR_RX
       printf("i2schar_main: Waiting for the receiver thread\n");
-      (void)pthread_join(receiver, &result);
+      pthread_join(receiver, &result);
 #endif
       return EXIT_FAILURE;
     }

--- a/examples/leds/leds_main.c
+++ b/examples/leds/leds_main.c
@@ -174,7 +174,7 @@ static int led_daemon(int argc, char *argv[])
     }
 
 errout_with_fd:
-  (void)close(fd);
+  close(fd);
 
 errout:
   g_led_daemon_started = false;

--- a/examples/lvgldemo/demo.c
+++ b/examples/lvgldemo/demo.c
@@ -177,8 +177,6 @@ static lv_res_t keyboard_open_close(lv_obj_t *text_area)
 {
   lv_obj_t *parent;
 
-  (void)text_area; /* Unused */
-
   /* Text area is on the scrollable part of the page but we need
    * the page itself
    */
@@ -235,8 +233,6 @@ static lv_res_t keyboard_open_close(lv_obj_t *text_area)
 
 static lv_res_t keyboard_hide_action(lv_obj_t *keyboard)
 {
-  (void)keyboard; /* Unused */
-
 #if USE_LV_ANIMATION
   lv_obj_animate(kb, LV_ANIM_FLOAT_BOTTOM | LV_ANIM_OUT, 300, 0,
                  kb_hide_anim_end);

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -151,12 +151,12 @@ int main(int argc, FAR char *argv[])
 #ifdef NEED_BOARDINIT
   /* Perform board-specific driver initialization */
 
-  (void)boardctl(BOARDIOC_INIT, 0);
+  boardctl(BOARDIOC_INIT, 0);
 
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 #endif
 

--- a/examples/mld/mld_main.c
+++ b/examples/mld/mld_main.c
@@ -181,7 +181,7 @@ void mld_catfile(FAR const char *filepath, FAR char **iobuffer)
       *iobuffer = (FAR char *)malloc(IOBUFFERSIZE);
       if (*iobuffer == NULL)
         {
-          (void)close(fd);
+          close(fd);
           fprintf(stderr, "Failed to allocation I/O buffer\n");
           return;
         }
@@ -244,7 +244,7 @@ void mld_catfile(FAR const char *filepath, FAR char **iobuffer)
         }
     }
 
-  (void)close(fd);
+  close(fd);
 }
 #endif
 

--- a/examples/modbus/modbus_main.c
+++ b/examples/modbus/modbus_main.c
@@ -232,13 +232,13 @@ static inline int modbus_initialize(void)
 errout_with_modbus:
   /* Release hardware resources. */
 
-  (void)eMBClose();
+  eMBClose();
 
 errout_with_mutex:
 
   /* Free/uninitialize data structures */
 
-  (void)pthread_mutex_destroy(&g_modbus.lock);
+  pthread_mutex_destroy(&g_modbus.lock);
 
   g_modbus.threadstate = STOPPED;
   return status;
@@ -289,15 +289,15 @@ static void *modbus_pollthread(void *pvarg)
 
   /* Disable */
 
-  (void)eMBDisable();
+  eMBDisable();
 
   /* Release hardware resources. */
 
-  (void)eMBClose();
+  eMBClose();
 
   /* Free/uninitialize data structures */
 
-  (void)pthread_mutex_destroy(&g_modbus.lock);
+  pthread_mutex_destroy(&g_modbus.lock);
   g_modbus.threadstate = STOPPED;
   return NULL;
 }
@@ -373,9 +373,9 @@ int main(int argc, FAR char *argv[])
       switch (option)
         {
           case 'd': /* Disable protocol stack */
-            (void)pthread_mutex_lock(&g_modbus.lock);
+            pthread_mutex_lock(&g_modbus.lock);
             g_modbus.threadstate = SHUTDOWN;
-            (void)pthread_mutex_unlock(&g_modbus.lock);
+            pthread_mutex_unlock(&g_modbus.lock);
             break;
 
           case 'e': /* Enable the protocol stack */

--- a/examples/modbusmaster/mbmaster_main.c
+++ b/examples/modbusmaster/mbmaster_main.c
@@ -169,11 +169,11 @@ static inline void mbmaster_deinitialize(void)
 {
   /* Disable modbus stack */
 
-  (void)eMBMasterDisable();
+  eMBMasterDisable();
 
   /* Release hardware resources */
 
-  (void)eMBMasterClose();
+  eMBMasterClose();
 }
 
 /****************************************************************************

--- a/examples/netlink_route/netlink_route_main.c
+++ b/examples/netlink_route/netlink_route_main.c
@@ -155,7 +155,7 @@ static void dump_neighbor(void)
     {
       FAR struct neighbor_entry_s *nb = &nbtab[i];
 
-      (void)inet_ntop(AF_INET6, &nb->ne_ipaddr, buffer, INET6_ADDRSTRLEN);
+      inet_ntop(AF_INET6, &nb->ne_ipaddr, buffer, INET6_ADDRSTRLEN);
       printf("  Dest: %s MAC Type: %2u Size: %3u Addr: ",
              buffer, nb->ne_addr.na_lltype, nb->ne_addr.na_llsize);
 
@@ -234,7 +234,7 @@ static void dump_arp(void)
     {
       FAR struct arp_entry_s *arp = &arptab[i];
 
-      (void)inet_ntop(AF_INET, &arp->at_ipaddr, buffer, INET_ADDRSTRLEN);
+      inet_ntop(AF_INET, &arp->at_ipaddr, buffer, INET_ADDRSTRLEN);
       printf("  Dest: %s MAC Addr: ", buffer);
 
       for (j = 0; j < ETHER_ADDR_LEN; j++)
@@ -301,16 +301,16 @@ static void dump_route(sa_family_t family)
     {
       FAR struct rtentry *rte = &rttab[i];
 
-      (void)inet_ntop(rte->rt_dst.ss_family, &rte->rt_dst.ss_data, buffer,
-                      ROUTE_BUFSIZE);
+      inet_ntop(rte->rt_dst.ss_family, &rte->rt_dst.ss_data, buffer,
+                ROUTE_BUFSIZE);
       printf("  Dest: %s ", buffer);
 
-      (void)inet_ntop(rte->rt_gateway.ss_family, &rte->rt_gateway.ss_data,
-                      buffer, ROUTE_BUFSIZE);
+      inet_ntop(rte->rt_gateway.ss_family, &rte->rt_gateway.ss_data,
+                buffer, ROUTE_BUFSIZE);
       printf("Gateway: %s ", buffer);
 
-      (void)inet_ntop(rte->rt_genmask.ss_family, &rte->rt_genmask.ss_data,
-                      buffer, ROUTE_BUFSIZE);
+      inet_ntop(rte->rt_genmask.ss_family, &rte->rt_genmask.ss_data,
+                buffer, ROUTE_BUFSIZE);
       printf("GenMASK: %s ", buffer);
       printf("Flags: %04x\n", rte->rt_flags);
     }

--- a/examples/netloop/lo_listener.c
+++ b/examples/netloop/lo_listener.c
@@ -367,7 +367,7 @@ void *lo_listener(pthread_addr_t pvarg)
               nsds--;
               if (i == nls.listensd)
                 {
-                  (void)net_connection(&nls);
+                  net_connection(&nls);
                 }
               else
                 {

--- a/examples/nettest/nettest_target1.c
+++ b/examples/nettest/nettest_target1.c
@@ -117,7 +117,7 @@ int main(int argc, FAR char *argv[])
 
 #if defined(CONFIG_EXAMPLES_NETTEST_LOOPBACK) && defined(CONFIG_SCHED_WAITPID)
   printf("main: Waiting for the server to exit\n");
-  (void)waitpid(child, &statloc, 0);
+  waitpid(child, &statloc, 0);
 #endif
 
   return EXIT_SUCCESS;

--- a/examples/nx/nx_main.c
+++ b/examples/nx/nx_main.c
@@ -143,7 +143,7 @@ static void nxeg_drivemouse(void)
       for (y = 0; y < g_yres; y += ystep)
         {
           printf("nxeg_drivemouse: Mouse left button at (%d,%d)\n", x, y);
-          (void)nx_mousein(g_hnx, x, y, NX_MOUSE_LEFTBUTTON);
+          nx_mousein(g_hnx, x, y, NX_MOUSE_LEFTBUTTON);
         }
     }
 }
@@ -475,10 +475,10 @@ static int nxeg_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NX_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NX_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NX_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nx_listenerthread, NULL);
        if (ret != 0)
@@ -496,7 +496,7 @@ static int nxeg_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_semevent);
+           sem_wait(&g_semevent);
          }
     }
   else
@@ -574,7 +574,7 @@ int main(int argc, FAR char *argv[])
 
   while (!b_haveresolution)
     {
-      (void)sem_wait(&g_semevent);
+      sem_wait(&g_semevent);
     }
   printf("nx_main: Screen resolution (%d,%d)\n", g_xres, g_yres);
 
@@ -775,13 +775,13 @@ int main(int argc, FAR char *argv[])
 
 errout_with_hwnd2:
   printf("nx_main: Close window #2\n");
-  (void)nxeg_closewindow(hwnd2, &g_wstate[1]);
+  nxeg_closewindow(hwnd2, &g_wstate[1]);
 
   /* Close the window1 */
 
 errout_with_hwnd1:
   printf("nx_main: Close window #1\n");
-  (void)nxeg_closewindow(hwnd1, &g_wstate[0]);
+  nxeg_closewindow(hwnd1, &g_wstate[0]);
 
 errout_with_nx:
   /* Disconnect from the server */

--- a/examples/nxdemo/nxdemo_main.c
+++ b/examples/nxdemo/nxdemo_main.c
@@ -164,10 +164,10 @@ static inline int nxdemo_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NXDEMO_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXDEMO_LISTENER_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXDEMO_LISTENER_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nxdemo_listener, NULL);
        if (ret != 0)
@@ -184,7 +184,7 @@ static inline int nxdemo_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_nxdemo.eventsem);
+           sem_wait(&g_nxdemo.eventsem);
          }
     }
   else
@@ -237,7 +237,7 @@ int main(int argc, FAR char *argv[])
 
   while (!g_nxdemo.havepos)
     {
-      (void)sem_wait(&g_nxdemo.eventsem);
+      sem_wait(&g_nxdemo.eventsem);
     }
 
   printf("nxdemo_main: Screen resolution (%d,%d)\n",
@@ -247,7 +247,7 @@ int main(int argc, FAR char *argv[])
 
   /* Release background */
 
-  (void)nx_releasebkgd(g_nxdemo.hbkgd);
+  nx_releasebkgd(g_nxdemo.hbkgd);
 
   /* Close NX */
 

--- a/examples/nxflat/nxflat_main.c
+++ b/examples/nxflat/nxflat_main.c
@@ -187,7 +187,7 @@ int main(int argc, FAR char *argv[])
    * the ROMFS mountpoint.
    */
 
-  (void)setenv("PATH", MOUNTPT, 1);
+  setenv("PATH", MOUNTPT, 1);
 #endif
 
   /* Now excercise every progrm in the ROMFS file system */

--- a/examples/nxflat/tests/signal/signal.c
+++ b/examples/nxflat/tests/signal/signal.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
   act.sa_sigaction = siguser_action;
   act.sa_flags     = SA_SIGINFO;
 
-  (void)sigemptyset(&act.sa_mask);
+  sigemptyset(&act.sa_mask);
 
   status = sigaction(SIGUSR1, &act, &oact1);
   if (status != 0)

--- a/examples/nxhello/nxhello_bkgd.c
+++ b/examples/nxhello/nxhello_bkgd.c
@@ -402,8 +402,8 @@ void nxhello_hello(NXWINDOW hwnd)
 #if CONFIG_NX_NPLANES > 1
 # warning "More logic is needed for the case where CONFIG_NX_PLANES > 1"
 #endif
-          (void)RENDERER((FAR nxgl_mxpixel_t*)glyph, fheight, fwidth,
-                         fstride, fbm, CONFIG_EXAMPLES_NXHELLO_FONTCOLOR);
+          RENDERER((FAR nxgl_mxpixel_t*)glyph, fheight, fwidth,
+                   fstride, fbm, CONFIG_EXAMPLES_NXHELLO_FONTCOLOR);
 
           /* Describe the destination of the font with a rectangle */
 

--- a/examples/nxhello/nxhello_main.c
+++ b/examples/nxhello/nxhello_main.c
@@ -141,10 +141,10 @@ static inline int nxhello_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NXHELLO_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXHELLO_LISTENER_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXHELLO_LISTENER_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nxhello_listener, NULL);
        if (ret != 0)
@@ -161,7 +161,7 @@ static inline int nxhello_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_nxhello.eventsem);
+           sem_wait(&g_nxhello.eventsem);
          }
     }
   else
@@ -235,7 +235,7 @@ int main(int argc, FAR char *argv[])
 
   while (!g_nxhello.havepos)
     {
-      (void)sem_wait(&g_nxhello.eventsem);
+      sem_wait(&g_nxhello.eventsem);
     }
 
   printf("nxhello_main: Screen resolution (%d,%d)\n", g_nxhello.xres, g_nxhello.yres);
@@ -248,7 +248,7 @@ int main(int argc, FAR char *argv[])
 
   /* Release background */
 
-  (void)nx_releasebkgd(g_nxhello.hbkgd);
+  nx_releasebkgd(g_nxhello.hbkgd);
 
   /* Close NX */
 

--- a/examples/nximage/nximage_main.c
+++ b/examples/nximage/nximage_main.c
@@ -145,10 +145,10 @@ static inline int nximage_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NXIMAGE_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXIMAGE_LISTENER_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXIMAGE_LISTENER_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nximage_listener, NULL);
        if (ret != 0)
@@ -165,7 +165,7 @@ static inline int nximage_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_nximage.eventsem);
+           sem_wait(&g_nximage.eventsem);
          }
     }
   else
@@ -232,7 +232,7 @@ int main(int argc, FAR char *argv[])
 
   while (!g_nximage.havepos)
     {
-      (void)sem_wait(&g_nximage.eventsem);
+      sem_wait(&g_nximage.eventsem);
     }
 
   printf("nximage_main: Screen resolution (%d,%d)\n", g_nximage.xres, g_nximage.yres);
@@ -244,7 +244,7 @@ int main(int argc, FAR char *argv[])
 
   /* Release background */
 
-  (void)nx_releasebkgd(g_nximage.hbkgd);
+  nx_releasebkgd(g_nximage.hbkgd);
 
   /* Close NX */
 

--- a/examples/nxlines/nxlines_main.c
+++ b/examples/nxlines/nxlines_main.c
@@ -167,10 +167,10 @@ static inline int nxlines_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NXLINES_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXLINES_LISTENER_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXLINES_LISTENER_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nxlines_listener, NULL);
        if (ret != 0)
@@ -187,7 +187,7 @@ static inline int nxlines_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_nxlines.eventsem);
+           sem_wait(&g_nxlines.eventsem);
          }
     }
   else
@@ -251,7 +251,7 @@ int main(int argc, FAR char *argv[])
 
   while (!g_nxlines.havepos)
     {
-      (void)sem_wait(&g_nxlines.eventsem);
+      sem_wait(&g_nxlines.eventsem);
     }
 
   printf("nxlines_main: Screen resolution (%d,%d)\n", g_nxlines.xres, g_nxlines.yres);
@@ -264,7 +264,7 @@ int main(int argc, FAR char *argv[])
 
   /* Release background */
 
-  (void)nx_releasebkgd(g_nxlines.hbkgd);
+  nx_releasebkgd(g_nxlines.hbkgd);
 
   /* Close NX */
 

--- a/examples/nxterm/nxterm_main.c
+++ b/examples/nxterm/nxterm_main.c
@@ -160,10 +160,10 @@ static int nxterm_initialize(void)
         * smoothly.
         */
 
-       (void)pthread_attr_init(&attr);
+       pthread_attr_init(&attr);
        param.sched_priority = CONFIG_EXAMPLES_NXTERM_LISTENERPRIO;
-       (void)pthread_attr_setschedparam(&attr, &param);
-       (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXTERM_STACKSIZE);
+       pthread_attr_setschedparam(&attr, &param);
+       pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXTERM_STACKSIZE);
 
        ret = pthread_create(&thread, &attr, nxterm_listener, NULL);
        if (ret != 0)
@@ -180,7 +180,7 @@ static int nxterm_initialize(void)
             * are connected.
             */
 
-           (void)sem_wait(&g_nxterm_vars.eventsem);
+           sem_wait(&g_nxterm_vars.eventsem);
          }
     }
   else
@@ -200,14 +200,14 @@ static int nxterm_task(int argc, char **argv)
   /* If the console front end is selected, then run it on this thread */
 
 #ifdef CONFIG_NSH_CONSOLE
-  (void)nsh_consolemain(0, NULL);
+  nsh_consolemain(0, NULL);
 #endif
 
   printf("nxterm_task: Unlinking the NX console device\n");
-  (void)unlink(CONFIG_EXAMPLES_NXTERM_DEVNAME);
+  unlink(CONFIG_EXAMPLES_NXTERM_DEVNAME);
 
   printf("nxterm_task: Close the window\n");
-  (void)nxtk_closewindow(g_nxterm_vars.hwnd);
+  nxtk_closewindow(g_nxterm_vars.hwnd);
 
   /* Disconnect from the server */
 
@@ -308,7 +308,7 @@ int main(int argc, FAR char *argv[])
 
   while (!g_nxterm_vars.haveres)
     {
-      (void)sem_wait(&g_nxterm_vars.eventsem);
+      sem_wait(&g_nxterm_vars.eventsem);
     }
 
   printf("nxterm_main: Screen resolution (%d,%d)\n",
@@ -409,14 +409,14 @@ int main(int argc, FAR char *argv[])
    printf("nxterm_main: Starting the console task\n");
    fflush(stdout);
 
-  (void)fflush(stdout);
-  (void)fflush(stderr);
+  fflush(stdout);
+  fflush(stderr);
 
-  (void)fclose(stdout);
-  (void)fclose(stderr);
+  fclose(stdout);
+  fclose(stderr);
 
-  (void)dup2(fd, 1);
-  (void)dup2(fd, 2);
+  dup2(fd, 1);
+  dup2(fd, 2);
 
    /* And we can close our original driver file descriptor */
 
@@ -435,10 +435,10 @@ int main(int argc, FAR char *argv[])
   /* Error Exits ************************************************************/
 
 errout_with_driver:
-  (void)unlink(CONFIG_EXAMPLES_NXTERM_DEVNAME);
+  unlink(CONFIG_EXAMPLES_NXTERM_DEVNAME);
 
 errout_with_hwnd:
-  (void)nxtk_closewindow(g_nxterm_vars.hwnd);
+  nxtk_closewindow(g_nxterm_vars.hwnd);
 
 errout_with_nx:
   /* Disconnect from the server */

--- a/examples/nxterm/nxterm_wndo.c
+++ b/examples/nxterm/nxterm_wndo.c
@@ -128,14 +128,14 @@ static void nxwndo_redraw(NXWINDOW hwnd, FAR const struct nxgl_rect_s *rect,
       iocargs.cmd = NXTERMIOC_NXTERM_REDRAW;
       iocargs.arg = (uintptr_t)&redraw;
 
-      (void)boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
+      boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
     }
   else
     {
       /* If the driver has not been opened, then just redraw the window color */
 
       wcolor[0] = CONFIG_EXAMPLES_NXTERM_WCOLOR;
-      (void)nxtk_fillwindow(hwnd, rect, wcolor);
+      nxtk_fillwindow(hwnd, rect, wcolor);
     }
 }
 
@@ -202,7 +202,7 @@ static void nxwndo_kbdin(NXWINDOW hwnd, uint8_t nch, FAR const uint8_t *ch,
                          FAR void *arg)
 {
   ginfo("hwnd=%p nch=%d\n", hwnd, nch);
-  (void)write(1, ch, nch);
+  write(1, ch, nch);
 }
 #endif
 

--- a/examples/nxtext/nxtext_main.c
+++ b/examples/nxtext/nxtext_main.c
@@ -222,10 +222,10 @@ static int nxtext_initialize(void)
        * smoothly.
        */
 
-      (void)pthread_attr_init(&attr);
+      pthread_attr_init(&attr);
       param.sched_priority = CONFIG_EXAMPLES_NXTEXT_LISTENERPRIO;
-      (void)pthread_attr_setschedparam(&attr, &param);
-      (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXTEXT_STACKSIZE);
+      pthread_attr_setschedparam(&attr, &param);
+      pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_NXTEXT_STACKSIZE);
 
       ret = pthread_create(&thread, &attr, nxtext_listener, NULL);
       if (ret != 0)
@@ -244,7 +244,7 @@ static int nxtext_initialize(void)
            * are connected.
            */
 
-          (void)sem_wait(&g_semevent);
+          sem_wait(&g_semevent);
         }
     }
   else
@@ -331,7 +331,7 @@ int main(int argc, FAR char *argv[])
 
   while (!b_haveresolution)
     {
-      (void)sem_wait(&g_semevent);
+      sem_wait(&g_semevent);
     }
 
   printf("nxtext_main: Screen resolution (%d,%d)\n", g_xres, g_yres);
@@ -376,7 +376,7 @@ int main(int argc, FAR char *argv[])
           /* Destroy the pop-up window and restart the sequence */
 
           printf("nxtext_main: Close pop-up\n");
-          (void)nxpu_close(hwnd);
+          nxpu_close(hwnd);
           popcnt = 0;
         }
 
@@ -400,11 +400,11 @@ errout_with_hwnd:
   if (popcnt >= 3)
     {
       printf("nxtext_main: Close pop-up\n");
-     (void)nxpu_close(hwnd);
+     nxpu_close(hwnd);
     }
 
 //errout_with_bkgd:
-  (void)nx_releasebkgd(g_bgwnd);
+  nx_releasebkgd(g_bgwnd);
 
 errout_with_nx:
   /* Disconnect from the server */

--- a/examples/nxtext/nxtext_popup.c
+++ b/examples/nxtext/nxtext_popup.c
@@ -386,7 +386,7 @@ NXWINDOW nxpu_open(void)
   return hwnd;
 
 errout_with_hwnd:
-  (void)nx_closewindow(hwnd);
+  nx_closewindow(hwnd);
 
 errout_with_state:
   return NULL;

--- a/examples/poll/net_listener.c
+++ b/examples/poll/net_listener.c
@@ -413,7 +413,7 @@ void *net_listener(pthread_addr_t pvarg)
               nsds--;
               if (i == nls.listensd)
                 {
-                  (void)net_connection(&nls);
+                  net_connection(&nls);
                 }
               else
                 {

--- a/examples/poll/poll_listener.c
+++ b/examples/poll/poll_listener.c
@@ -111,7 +111,7 @@ void *poll_listener(pthread_addr_t pvarg)
     {
       printf("poll_listener: ERROR Failed to open FIFO %s: %d\n",
              FIFO_PATH1, errno);
-      (void)close(fd);
+      close(fd);
       return (void*)-1;
     }
 
@@ -261,6 +261,6 @@ void *poll_listener(pthread_addr_t pvarg)
 
   /* Won't get here */
 
-  (void)close(fd);
+  close(fd);
   return NULL;
 }

--- a/examples/poll/select_listener.c
+++ b/examples/poll/select_listener.c
@@ -97,7 +97,7 @@ void *select_listener(pthread_addr_t pvarg)
     {
       printf("select_listener: ERROR Failed to open FIFO %s: %d\n",
              FIFO_PATH2, errno);
-      (void)close(fd);
+      close(fd);
       return (void*)-1;
     }
 
@@ -189,6 +189,6 @@ void *select_listener(pthread_addr_t pvarg)
 
   /* Won't get here */
 
-  (void)close(fd);
+  close(fd);
   return NULL;
 }

--- a/examples/popen/popen_main.c
+++ b/examples/popen/popen_main.c
@@ -88,7 +88,7 @@ int main(int argc, FAR char *argv[])
   if (stream == NULL)
     {
       fprintf(stderr, "ERROR: popen() failed: %d\n", errno);
-      (void)timer_delete(timerid);
+      timer_delete(timerid);
       return EXIT_FAILURE;
     }
 
@@ -190,6 +190,6 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-  (void)timer_delete(timerid);
+  timer_delete(timerid);
   return exitcode;
 }

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -175,7 +175,7 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -200,7 +200,7 @@ static void mm_initmonitor(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mminitial = mmcurrent.uordblks;
@@ -272,14 +272,14 @@ int main(int argc, FAR char *argv[])
    */
 
 #if defined(CONFIG_LIB_ENVPATH) && !defined(CONFIG_PATH_INITIAL)
-  (void)setenv("PATH", MOUNTPT, 1);
+  setenv("PATH", MOUNTPT, 1);
 #endif
 
   /* Make sure that we are using our symbol tablee */
 
   symdesc.symtab   = (FAR struct symtab_s *)g_spawn_exports; /* Discard 'const' */
   symdesc.nsymbols = g_spawn_nexports;
-  (void)boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
+  boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
 
   /*************************************************************************
    * Case 1: Simple program with arguments

--- a/examples/powerled/powerled_main.c
+++ b/examples/powerled/powerled_main.c
@@ -465,12 +465,12 @@ int main(int argc, char *argv[])
 #ifndef CONFIG_NSH_ARCHINIT
   /* Perform architecture-specific initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_INIT, 0);
+  boardctl(BOARDIOC_INIT, 0);
 
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 #endif
 

--- a/examples/pty_test/pty_test.c
+++ b/examples/pty_test/pty_test.c
@@ -349,9 +349,9 @@ int main(int argc, FAR char *argv[])
 
   /* Use this pts file as stdin, stdout, and stderr */
 
-  (void)dup2(fd_pts, 0);
-  (void)dup2(fd_pts, 1);
-  (void)dup2(fd_pts, 2);
+  dup2(fd_pts, 0);
+  dup2(fd_pts, 1);
+  dup2(fd_pts, 2);
 
   /* Create a new console using this /dev/pts/N */
 

--- a/examples/pwfb/pwfb_main.c
+++ b/examples/pwfb/pwfb_main.c
@@ -173,10 +173,10 @@ static bool pwfb_listener_initialize(FAR struct pwfb_state_s *st)
    * smoothly.
    */
 
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
   param.sched_priority = CONFIG_EXAMPLES_PWFB_LISTENER_PRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
-  (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_PWFB_LISTENER_STACKSIZE);
+  pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_PWFB_LISTENER_STACKSIZE);
 
   ret = pthread_create(&thread, &attr, pwfb_listener, st);
   if (ret != 0)
@@ -195,7 +195,7 @@ static bool pwfb_listener_initialize(FAR struct pwfb_state_s *st)
        * are connected.
        */
 
-      (void)sem_wait(&st->semevent);
+      sem_wait(&st->semevent);
     }
 
   return true;
@@ -650,7 +650,7 @@ int main(int argc, FAR char *argv[])
 
   while (!wstate.haveres)
     {
-      (void)sem_wait(&wstate.semevent);
+      sem_wait(&wstate.semevent);
     }
 
   printf("pwfb_main: Screen resolution (%d,%d)\n",
@@ -765,7 +765,7 @@ errout_with_cursor:
 #ifdef CONFIG_NX_SWCURSOR
   /* Disable the cursor */
 
-  (void)nxcursor_enable(wstate.hnx, false);
+  nxcursor_enable(wstate.hnx, false);
 
 errout_with_hwnds:
 #endif

--- a/examples/pwlines/pwlines_main.c
+++ b/examples/pwlines/pwlines_main.c
@@ -151,10 +151,10 @@ static bool pwlines_listener_initialize(FAR struct pwlines_state_s *st)
    * smoothly.
    */
 
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
   param.sched_priority = CONFIG_EXAMPLES_PWLINES_LISTENER_PRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
-  (void)pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_PWLINES_LISTENER_STACKSIZE);
+  pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_PWLINES_LISTENER_STACKSIZE);
 
   ret = pthread_create(&thread, &attr, pwlines_listener, st);
   if (ret != 0)
@@ -173,7 +173,7 @@ static bool pwlines_listener_initialize(FAR struct pwlines_state_s *st)
        * are connected.
        */
 
-      (void)sem_wait(&st->semevent);
+      sem_wait(&st->semevent);
     }
 
   return true;
@@ -384,7 +384,7 @@ int main(int argc, FAR char *argv[])
 
   while (!wstate.haveres)
     {
-      (void)sem_wait(&wstate.semevent);
+      sem_wait(&wstate.semevent);
     }
 
   printf("pwlines_main: Screen resolution (%d,%d)\n",

--- a/examples/random/random_main.c
+++ b/examples/random/random_main.c
@@ -125,7 +125,7 @@ int main(int argc, FAR char *argv[])
     {
       int errcode = errno;
       fprintf(stderr, "ERROR: Read from /dev/random failed: %d\n", errcode);
-      (void)close(fd);
+      close(fd);
       exit(EXIT_FAILURE);
     }
 
@@ -133,14 +133,14 @@ int main(int argc, FAR char *argv[])
     {
       fprintf(stderr, "ERROR: Read from /dev/random only produced %d bytes\n",
               (int)nread);
-      (void)close(fd);
+      close(fd);
       exit(EXIT_FAILURE);
     }
 
   /* Dump the sample buffer */
 
   lib_dumpbuffer("Random values", (FAR const uint8_t*)buffer, nread);
-  (void)close(fd);
+  close(fd);
   return EXIT_SUCCESS;
 }
 

--- a/examples/rgbled/rgbled.c
+++ b/examples/rgbled/rgbled.c
@@ -106,7 +106,7 @@ int main(int argc, FAR char *argv[])
       }
 
     sprintf(buffer, "#%02X%02X%02X", red, green, blue);
-    (void)write(fd, buffer, 8);
+    write(fd, buffer, 8);
     usleep(5000);
   }
 

--- a/examples/slcd/slcd_main.c
+++ b/examples/slcd/slcd_main.c
@@ -221,7 +221,7 @@ static void slcd_putc(FAR struct lib_outstream_s *stream, int ch)
 
   if (stream->nput >= CONFIG_EXAMPLES_SLCD_BUFSIZE)
     {
-      (void)slcd_flush(stream);
+      slcd_flush(stream);
     }
 }
 

--- a/examples/smps/smps_main.c
+++ b/examples/smps/smps_main.c
@@ -492,12 +492,12 @@ int main(int argc, char *argv[])
 #ifndef CONFIG_NSH_ARCHINIT
   /* Perform architecture-specific initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_INIT, 0);
+  boardctl(BOARDIOC_INIT, 0);
 
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 #endif
 

--- a/examples/sotest/lib/modprint/modprint.c
+++ b/examples/sotest/lib/modprint/modprint.c
@@ -77,7 +77,7 @@ static void modprint(FAR const char *fmt, ...)
   va_list ap;
 
   va_start(ap, fmt);
-  (void)vsyslog(LOG_INFO, fmt, ap);
+  vsyslog(LOG_INFO, fmt, ap);
   va_end(ap);
 }
 

--- a/examples/sotest/lib/sotest/sotest.c
+++ b/examples/sotest/lib/sotest/sotest.c
@@ -108,7 +108,7 @@ static void modprint(FAR const char *fmt, ...)
   va_list ap;
 
   va_start(ap, fmt);
-  (void)vsyslog(LOG_INFO, fmt, ap);
+  vsyslog(LOG_INFO, fmt, ap);
   va_end(ap);
 }
 #endif

--- a/examples/stat/stat_main.c
+++ b/examples/stat/stat_main.c
@@ -81,7 +81,7 @@ static void stepusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous loop */
@@ -102,7 +102,7 @@ static void endusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
   showusage(&g_mmbefore, &g_mmafter, "End-of-test memory leak");
 }
@@ -255,7 +255,7 @@ int main(int argc, FAR char *argv[])
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
   memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
 #endif
 

--- a/examples/tcpblaster/tcpblaster_client.c
+++ b/examples/tcpblaster/tcpblaster_client.c
@@ -144,7 +144,7 @@ void tcpblaster_client(void)
   partials  = 0;
   totallost = 0;
 
-  (void)clock_gettime(CLOCK_REALTIME, &start);
+  clock_gettime(CLOCK_REALTIME, &start);
 
   for (; ; )
     {
@@ -204,7 +204,7 @@ void tcpblaster_client(void)
           float fkbrecvd;
           float felapsed;
 
-          (void)clock_gettime(CLOCK_REALTIME, &curr);
+          clock_gettime(CLOCK_REALTIME, &curr);
 
           elapsed.tv_sec  = curr.tv_sec - start.tv_sec;
           if (curr.tv_nsec >= start.tv_nsec)
@@ -237,7 +237,7 @@ void tcpblaster_client(void)
           partials   = 0;
           totallost  = 0;
 
-          (void)clock_gettime(CLOCK_REALTIME, &start);
+          clock_gettime(CLOCK_REALTIME, &start);
        }
     }
 

--- a/examples/tcpblaster/tcpblaster_server.c
+++ b/examples/tcpblaster/tcpblaster_server.c
@@ -184,7 +184,7 @@ void tcpblaster_server(void)
   recvcount = 0;
   recvtotal = 0;
 
-  (void)clock_gettime(CLOCK_REALTIME, &start);
+  clock_gettime(CLOCK_REALTIME, &start);
 
   for (; ; )
     {
@@ -233,7 +233,7 @@ void tcpblaster_server(void)
           float fkbsent;
           float felapsed;
 
-          (void)clock_gettime(CLOCK_REALTIME, &curr);
+          clock_gettime(CLOCK_REALTIME, &curr);
 
           elapsed.tv_sec  = curr.tv_sec - start.tv_sec;
           if (curr.tv_nsec >= start.tv_nsec)
@@ -255,7 +255,7 @@ void tcpblaster_server(void)
           recvcount       = 0;
           recvtotal       = 0;
 
-          (void)clock_gettime(CLOCK_REALTIME, &start);
+          clock_gettime(CLOCK_REALTIME, &start);
        }
     }
 

--- a/examples/tcpblaster/tcpblaster_target1.c
+++ b/examples/tcpblaster/tcpblaster_target1.c
@@ -117,7 +117,7 @@ int main(int argc, FAR char *argv[])
 
 #if defined(CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK) && defined(CONFIG_SCHED_WAITPID)
   printf("main: Waiting for the server to exit\n");
-  (void)waitpid(child, &statloc, 0);
+  waitpid(child, &statloc, 0);
 #endif
 
   return EXIT_SUCCESS;

--- a/examples/timer/timer_main.c
+++ b/examples/timer/timer_main.c
@@ -187,8 +187,8 @@ int main(int argc, FAR char *argv[])
   act.sa_sigaction = timer_sighandler;
   act.sa_flags     = SA_SIGINFO;
 
-  (void)sigfillset(&act.sa_mask);
-  (void)sigdelset(&act.sa_mask, CONFIG_EXAMPLES_TIMER_SIGNO);
+  sigfillset(&act.sa_mask);
+  sigdelset(&act.sa_mask, CONFIG_EXAMPLES_TIMER_SIGNO);
 
   ret = sigaction(CONFIG_EXAMPLES_TIMER_SIGNO, &act, NULL);
   if (ret != OK)
@@ -258,7 +258,7 @@ int main(int argc, FAR char *argv[])
   /* Detach the signal handler */
 
   act.sa_handler = SIG_DFL;
-  (void)sigaction(CONFIG_EXAMPLES_TIMER_SIGNO, &act, NULL);
+  sigaction(CONFIG_EXAMPLES_TIMER_SIGNO, &act, NULL);
 
   /* Show the timer status before starting */
 

--- a/examples/udp/udp_target1.c
+++ b/examples/udp/udp_target1.c
@@ -57,7 +57,7 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_EXAMPLES_UDP_NETINIT
   /* Initialize the network */
 
-  (void)udp_netinit();
+  udp_netinit();
 #endif
 
   /* Run the server or client, depending upon how we are configured */

--- a/examples/udp/udp_target2.c
+++ b/examples/udp/udp_target2.c
@@ -57,7 +57,7 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_EXAMPLES_UDP_NETINIT
   /* Initialize the network */
 
-  (void)udp_netinit();
+  udp_netinit();
 #endif
 
   /* Run the server or client, depending upon how target1 was configured */

--- a/examples/usbserial/usbserial_main.c
+++ b/examples/usbserial/usbserial_main.c
@@ -177,7 +177,7 @@ static int trace_callback(struct usbtrace_s *trace, void *arg)
 
 static void dumptrace(void)
 {
-  (void)usbtrace_enumerate(trace_callback, NULL);
+  usbtrace_enumerate(trace_callback, NULL);
 }
 #else
 #  define dumptrace()

--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -557,7 +557,7 @@ static int ufstest_stat(FAR void *volinfo, FAR const char *relpath,
       if (ret >= 0)
         {
           ret = ufstest_fstat(volinfo, openinfo, buf);
-          (void)ufstest_close(volinfo, openinfo);
+          ufstest_close(volinfo, openinfo);
         }
     }
 

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -1614,7 +1614,7 @@ static FAR void *delayed_cmd_thread(FAR void *priv)
 
   usleep(cmd->delay_msec * 1000);
 
-  (void)write(cmd->pipefd, &cmd->cmd, 1);
+  write(cmd->pipefd, &cmd->cmd, 1);
 
   if (!cmd->delay_msec)
     sem_post(&cmd->startsem);
@@ -1718,7 +1718,7 @@ int usrsocktest_daemon_stop(void)
       next = (void *)sq_next(&item->node);
 
       pthread_mutex_unlock(&daemon_mutex);
-      (void)pthread_join(item->tid, &retval);
+      pthread_join(item->tid, &retval);
       pthread_mutex_lock(&daemon_mutex);
       sq_rem(&item->node, &priv->delayed_cmd_threads);
       free(item);
@@ -1881,7 +1881,7 @@ int usrsocktest_daemon_pause_usrsock_handling(bool pause)
 
   priv->do_not_poll_usrsock = pause;
 
-  (void)write(priv->pipefd[1], &cmd, 1);
+  write(priv->pipefd[1], &cmd, 1);
   ret = OK;
 
   pthread_mutex_unlock(&daemon_mutex);
@@ -1916,7 +1916,7 @@ bool usrsocktest_send_delayed_command(const char cmd, unsigned int delay_msec)
   delayed_cmd->delay_msec = delay_msec;
   delayed_cmd->cmd = cmd;
   delayed_cmd->pipefd = priv->pipefd[1];
-  (void)sem_init(&delayed_cmd->startsem, 0, 0);
+  sem_init(&delayed_cmd->startsem, 0, 0);
 
   ret = pthread_attr_init(&attr);
   if (ret != OK)

--- a/examples/usrsocktest/usrsocktest_main.c
+++ b/examples/usrsocktest/usrsocktest_main.c
@@ -100,7 +100,7 @@ static void get_mallinfo(struct mallinfo *mem)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   *mem = mallinfo();
 #else
-  (void)mallinfo(mem);
+  mallinfo(mem);
 #endif
 }
 

--- a/examples/webserver/webserver_main.c
+++ b/examples/webserver/webserver_main.c
@@ -164,7 +164,7 @@ int main(int argc, FAR char *argv[])
   if (handle)
     {
         struct dhcpc_state ds;
-        (void)dhcpc_request(handle, &ds);
+        dhcpc_request(handle, &ds);
         netlib_set_ipv4addr("eth0", &ds.ipaddr);
 
         if (ds.netmask.s_addr != 0)

--- a/examples/wget/wget_main.c
+++ b/examples/wget/wget_main.c
@@ -95,7 +95,7 @@ static char g_iobuffer[512];
 static void callback(FAR char **buffer, int offset, int datend,
                      FAR int *buflen, FAR void *arg)
 {
-  (void)write(1, &((*buffer)[offset]), datend - offset);
+  write(1, &((*buffer)[offset]), datend - offset);
 }
 
 /****************************************************************************

--- a/examples/xmlrpc/xmlrpc_main.c
+++ b/examples/xmlrpc/xmlrpc_main.c
@@ -332,7 +332,7 @@ static int xmlrpc_netinit(void)
   if (handle)
     {
       struct dhcpc_state ds;
-      (void)dhcpc_request(handle, &ds);
+      dhcpc_request(handle, &ds);
       netlib_set_ipv4addr("eth0", &ds.ipaddr);
 
       if (ds.netmask.s_addr != 0)

--- a/examples/zerocross/zerocross_main.c
+++ b/examples/zerocross/zerocross_main.c
@@ -122,8 +122,8 @@ int main(int argc, FAR char *argv[])
 
       /* Wait for a signal */
 
-      (void)sigemptyset(&set);
-      (void)sigaddset(&set, CONFIG_EXAMPLES_ZEROCROSS_SIGNO);
+      sigemptyset(&set);
+      sigaddset(&set, CONFIG_EXAMPLES_ZEROCROSS_SIGNO);
       ret = sigwaitinfo(&set, &value);
       if (ret < 0)
         {

--- a/fsutils/flash_eraseall/flash_eraseall.c
+++ b/fsutils/flash_eraseall/flash_eraseall.c
@@ -90,7 +90,7 @@ int flash_eraseall(FAR const char *driver)
 
       /* Close the block driver */
 
-     (void)close(fd);
+     close(fd);
     }
 
   return ret;

--- a/fsutils/inifile/inifile.c
+++ b/fsutils/inifile/inifile.c
@@ -217,7 +217,7 @@ static int inifile_read_line(FAR struct inifile_state_s *priv)
 
   if (priv->nextch != EOF)
     {
-      (void)inifile_next_line(priv);
+      inifile_next_line(priv);
     }
 
   /* And return the number of bytes read (excluding the NUL terminator and

--- a/fsutils/mkfatfs/mkfatfs.c
+++ b/fsutils/mkfatfs/mkfatfs.c
@@ -366,7 +366,7 @@ int mkfatfs(FAR const char *pathname, FAR struct fat_format_s *fmt)
 errout_with_driver:
   /* Close the driver */
 
-  (void)close(var.fv_fd);
+  close(var.fv_fd);
 
 errout:
   /* Release all allocated memory */

--- a/fsutils/mksmartfs/mksmartfs.c
+++ b/fsutils/mksmartfs/mksmartfs.c
@@ -229,7 +229,7 @@ int mksmartfs(FAR const char *pathname, uint16_t sectorsize)
 errout_with_driver:
   /* Close the driver */
 
-  (void)close(fd);
+  close(fd);
 
 errout:
   /* Release all allocated memory */

--- a/fsutils/passwd/passwd_adduser.c
+++ b/fsutils/passwd/passwd_adduser.c
@@ -102,6 +102,6 @@ int passwd_adduser(FAR const char *username, FAR const char *password)
   ret = OK;
 
 errout_with_lock:
-  (void)passwd_unlock(sem);
+  passwd_unlock(sem);
   return ret;
 }

--- a/fsutils/passwd/passwd_append.c
+++ b/fsutils/passwd/passwd_append.c
@@ -111,6 +111,6 @@ int passwd_append(FAR const char *username, FAR const char *password)
   ret = OK;
 
 errout_with_stream:
-  (void)fclose(stream);
+  fclose(stream);
   return ret;
 }

--- a/fsutils/passwd/passwd_delete.c
+++ b/fsutils/passwd/passwd_delete.c
@@ -298,25 +298,25 @@ int passwd_delete(off_t offset)
   ret = passwd_copyfile(iobuffer, instream, outstream, SIZE_MAX);
 
 errout_with_outstream:
-  (void)fclose(outstream);
+  fclose(outstream);
 
 errout_with_instream:
-  (void)fclose(instream);
+  fclose(instream);
 
 errout_with_tmpfile:
   if (ret < 0)
     {
       /* Restore the previous /etc/passwd file */
 
-      (void)unlink(CONFIG_FSUTILS_PASSWD_PATH);
-      (void)rename(CONFIG_FSUTILS_PASSWD_PATH ".tmp",
-                   CONFIG_FSUTILS_PASSWD_PATH);
+      unlink(CONFIG_FSUTILS_PASSWD_PATH);
+      rename(CONFIG_FSUTILS_PASSWD_PATH ".tmp",
+             CONFIG_FSUTILS_PASSWD_PATH);
     }
   else
     {
       /* Delete the previous /etc/passwd file */
 
-      (void)unlink(CONFIG_FSUTILS_PASSWD_PATH ".tmp");
+      unlink(CONFIG_FSUTILS_PASSWD_PATH ".tmp");
     }
 
 errout_with_iobuffer:

--- a/fsutils/passwd/passwd_deluser.c
+++ b/fsutils/passwd/passwd_deluser.c
@@ -92,6 +92,6 @@ int passwd_deluser(FAR const char *username)
   ret = passwd_delete(passwd.offset);
 
 errout_with_lock:
-  (void)passwd_unlock(sem);
+  passwd_unlock(sem);
   return ret;
 }

--- a/fsutils/passwd/passwd_lock.c
+++ b/fsutils/passwd/passwd_lock.c
@@ -130,7 +130,7 @@ int passwd_unlock(FAR sem_t *sem)
 #ifdef CONFIG_FS_NAMED_SEMAPHORES
   /* Close the named semaphore */
 
-  (void)sem_close(sem);
+  sem_close(sem);
 #endif
 
   return OK;

--- a/fsutils/passwd/passwd_update.c
+++ b/fsutils/passwd/passwd_update.c
@@ -98,6 +98,6 @@ int passwd_update(FAR const char *username, FAR const char *password)
   ret = passwd_append(username, password);
 
 errout_with_lock:
-  (void)passwd_unlock(sem);
+  passwd_unlock(sem);
   return ret;
 }

--- a/fsutils/passwd/passwd_verify.c
+++ b/fsutils/passwd/passwd_verify.c
@@ -101,6 +101,6 @@ int passwd_verify(FAR const char *username, FAR const char *password)
   ret = (strcmp(passwd.encrypted, encrypted) == 0) ? 1 : 0;
 
 errout_with_lock:
-  (void)passwd_unlock(sem);
+  passwd_unlock(sem);
   return ret;
 }

--- a/graphics/ft80x/ft80x_coproc.c
+++ b/graphics/ft80x/ft80x_coproc.c
@@ -146,7 +146,7 @@ int ft80x_coproc_waitlogo(int fd)
 
       /* Wait for a half of a second */
 
-      (void)usleep(HALF_SECOND);
+      usleep(HALF_SECOND);
     }
 
   ft80x_err("ERROR:  Timed out!  Last head/tail = %u/%u\n", head, tail);

--- a/graphics/ft80x/ft80x_ramcmd.c
+++ b/graphics/ft80x/ft80x_ramcmd.c
@@ -264,8 +264,8 @@ int ft80x_ramcmd_waitfifoempty(int fd)
 
   /* Block the signal so that it will pend if received asynchronously */
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, CONFIG_GRAPHICS_FT80X_CMDEMPTY_SIGNAL);
+  sigemptyset(&set);
+  sigaddset(&set, CONFIG_GRAPHICS_FT80X_CMDEMPTY_SIGNAL);
 
   ret = pthread_sigmask(SIG_BLOCK, &set, NULL);
   if (ret < 0)
@@ -335,8 +335,8 @@ int ft80x_ramcmd_waitfifoempty(int fd)
       /* Make sure that the event notification is again disabled */
 
       notify.enable = false;
-      (void)ioctl(fd, FT80X_IOC_EVENTNOTIFY,
-                  (unsigned long)((uintptr_t)&notify));
+      ioctl(fd, FT80X_IOC_EVENTNOTIFY,
+            (unsigned long)((uintptr_t)&notify));
 
       /* Check if the signal was received correctly or if the timeout occurred. */
 
@@ -353,6 +353,6 @@ int ft80x_ramcmd_waitfifoempty(int fd)
         }
     }
 
-  (void)pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+  pthread_sigmask(SIG_UNBLOCK, &set, NULL);
   return ret;
 }

--- a/graphics/ft80x/ft80x_touch.c
+++ b/graphics/ft80x/ft80x_touch.c
@@ -167,8 +167,8 @@ int ft80x_touch_waittag(int fd, uint8_t oldtag)
 
   /* Block the signal so that it will pend if received asynchronously */
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, CONFIG_GRAPHICS_FT80X_TAG_SIGNAL);
+  sigemptyset(&set);
+  sigaddset(&set, CONFIG_GRAPHICS_FT80X_TAG_SIGNAL);
 
   ret = pthread_sigmask(SIG_BLOCK, &set, NULL);
   if (ret < 0)
@@ -236,8 +236,8 @@ int ft80x_touch_waittag(int fd, uint8_t oldtag)
       /* Make sure that the event notification is again disabled */
 
       notify.enable = false;
-      (void)ioctl(fd, FT80X_IOC_EVENTNOTIFY,
-                  (unsigned long)((uintptr_t)&notify));
+      ioctl(fd, FT80X_IOC_EVENTNOTIFY,
+            (unsigned long)((uintptr_t)&notify));
 
       /* Check if the signal was received correctly or if the timeout occurred. */
 
@@ -254,7 +254,7 @@ int ft80x_touch_waittag(int fd, uint8_t oldtag)
         }
     }
 
-  (void)pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+  pthread_sigmask(SIG_UNBLOCK, &set, NULL);
   return tag;
 }
 

--- a/graphics/nxwidgets/UnitTests/CButton/cbuttontest.cxx
+++ b/graphics/nxwidgets/UnitTests/CButton/cbuttontest.cxx
@@ -284,7 +284,7 @@ void CButtonTest::click(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -304,7 +304,7 @@ void CButtonTest::release(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarray_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarray_main.cxx
@@ -102,7 +102,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -132,7 +132,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarraytest.cxx
+++ b/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarraytest.cxx
@@ -255,7 +255,7 @@ void CButtonArrayTest::click(CButtonArray *buttonArray, int column, int row)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -284,7 +284,7 @@ void CButtonArrayTest::release(CButtonArray *buttonArray, int column, int row)
 
   // Then inject the mouse release
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CCheckBox/ccheckbox_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CCheckBox/ccheckbox_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CCheckBox/ccheckboxtest.cxx
+++ b/graphics/nxwidgets/UnitTests/CCheckBox/ccheckboxtest.cxx
@@ -249,7 +249,7 @@ void CCheckBoxTest::clickCheckBox(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, checkboxX, checkboxY, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, checkboxX, checkboxY, NX_MOUSE_LEFTBUTTON);
 
   // Poll for mouse events
   //
@@ -262,7 +262,7 @@ void CCheckBoxTest::clickCheckBox(void)
 
   // Then inject the mouse release
 
-  (void)nx_mousein(handle, checkboxX, checkboxY, 0);
+  nx_mousein(handle, checkboxX, checkboxY, 0);
 
   // And poll for more mouse events
 

--- a/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbutton_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbutton_main.cxx
@@ -92,7 +92,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -119,7 +119,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbuttontest.cxx
+++ b/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbuttontest.cxx
@@ -266,7 +266,7 @@ void CGlyphButtonTest::click(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -286,7 +286,7 @@ void CGlyphButtonTest::release(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/cglyphsliderhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/cglyphsliderhorizontal_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CImage/cimage_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CImage/cimage_main.cxx
@@ -109,7 +109,7 @@ static void updateMemoryUsage(FAR struct mallinfo *previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -136,7 +136,7 @@ static void initMemoryUsage(void)
   g_mmInitial = mallinfo();
   g_mmprevious = g_mmInitial;
 #else
-  (void)mallinfo(&g_mmInitial);
+  mallinfo(&g_mmInitial);
   memcpy(&g_mmprevious, &g_mmInitial, sizeof(struct mallinfo));
 #endif
 }

--- a/graphics/nxwidgets/UnitTests/CKeypad/ckeypad_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CKeypad/ckeypad_main.cxx
@@ -92,7 +92,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -122,7 +122,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CKeypad/ckeypadtest.cxx
+++ b/graphics/nxwidgets/UnitTests/CKeypad/ckeypadtest.cxx
@@ -369,7 +369,7 @@ void CKeypadTest::click(CKeypad *keypad, int column, int row)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -398,7 +398,7 @@ void CKeypadTest::release(CKeypad *keypad, int column, int row)
 
   // Then inject the mouse release
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CLatchButton/clatchbuttontest.cxx
+++ b/graphics/nxwidgets/UnitTests/CLatchButton/clatchbuttontest.cxx
@@ -285,7 +285,7 @@ void CLatchButtonTest::click(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -305,7 +305,7 @@ void CLatchButtonTest::release(void)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, m_center.x, m_center.y, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarray_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarray_main.cxx
@@ -128,7 +128,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -158,7 +158,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarraytest.cxx
+++ b/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarraytest.cxx
@@ -255,7 +255,7 @@ void CLatchButtonArrayTest::click(CLatchButtonArray *buttonArray, int column, in
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
 }
 
 // The counterpart to click.  This simulates a button release through
@@ -284,7 +284,7 @@ void CLatchButtonArrayTest::release(CLatchButtonArray *buttonArray, int column, 
 
   // Then inject the mouse release
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_NOBUTTONS);
 }
 
 // Widget events are normally handled in a modal loop.

--- a/graphics/nxwidgets/UnitTests/CListBox/clistbox_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CListBox/clistbox_main.cxx
@@ -128,7 +128,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -158,7 +158,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CProgressBar/cprogressbar_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CProgressBar/cprogressbar_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CRadioButton/cradiobutton_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CRadioButton/cradiobutton_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CRadioButton/cradiobuttontest.cxx
+++ b/graphics/nxwidgets/UnitTests/CRadioButton/cradiobuttontest.cxx
@@ -264,7 +264,7 @@ void CRadioButtonTest::pushButton(CRadioButton *button)
 
   // Then inject the mouse click
 
-  (void)nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
+  nx_mousein(handle, buttonX, buttonY, NX_MOUSE_LEFTBUTTON);
 
   // Poll for mouse events
   //
@@ -277,7 +277,7 @@ void CRadioButtonTest::pushButton(CRadioButton *button)
 
   // Then inject the mouse release
 
-  (void)nx_mousein(handle, buttonX, buttonY, 0);
+  nx_mousein(handle, buttonX, buttonY, 0);
 
   // And poll for more mouse events
 

--- a/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/cscrollbarhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/cscrollbarhorizontal_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CScrollbarVertical/cscrollbarvertical_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CScrollbarVertical/cscrollbarvertical_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CSliderHorizonal/csliderhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CSliderHorizonal/csliderhorizontal_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CSliderVertical/cslidervertical_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CSliderVertical/cslidervertical_main.cxx
@@ -93,7 +93,7 @@ static void updateMemoryUsage(unsigned int previous,
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -120,7 +120,7 @@ static void initMemoryUsage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&mmcurrent);
+  mallinfo(&mmcurrent);
 #endif
 
   g_mmInitial  = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CTextBox/ctextboxtest.cxx
+++ b/graphics/nxwidgets/UnitTests/CTextBox/ctextboxtest.cxx
@@ -270,7 +270,7 @@ void CTextBoxTest::injectChars(CTextBox *textbox, int nCh, FAR const uint8_t *st
     {
       // Inject the next character
 
-      (void)nx_kbdchin(handle, string[i]);
+      nx_kbdchin(handle, string[i]);
 
       // Widget events are normally handled in a modal loop.
       // However, for this case we know when there should be keyboard events pending,

--- a/graphics/nxwidgets/src/cbgwindow.cxx
+++ b/graphics/nxwidgets/src/cbgwindow.cxx
@@ -83,7 +83,7 @@ CBgWindow::~CBgWindow(void)
   // instance.  The lifetime of that instance is owned by he-who-
   // constructed-us.
 
-  (void)nx_releasebkgd(m_hWindow);
+  nx_releasebkgd(m_hWindow);
 }
 
 /**
@@ -251,7 +251,7 @@ void CBgWindow::getRectangle(FAR const struct nxgl_rect_s *rect, struct SBitmap 
 {
   // Get a rectangule region from the window
 
-  (void)nx_getrectangle(m_hWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
+  nx_getrectangle(m_hWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
 }
 
 /**

--- a/graphics/nxwidgets/src/cbuttonarray.cxx
+++ b/graphics/nxwidgets/src/cbuttonarray.cxx
@@ -426,7 +426,7 @@ void CButtonArray::drawContents(CGraphicsPort *port)
 
       // Just one.  Get the row/column indices from the last click
 
-      (void)posToButton(m_clickX, m_clickY, column, row);
+      posToButton(m_clickX, m_clickY, column, row);
 
       // And draw that button
 

--- a/graphics/nxwidgets/src/ccallback.cxx
+++ b/graphics/nxwidgets/src/ccallback.cxx
@@ -288,7 +288,7 @@ void CCallback::newKeyboardEvent(NXHANDLE hwnd, uint8_t nCh,
       iocargs.cmd  = NXTERMIOC_NXTERM_KBDIN;
       iocargs.arg  = (uintptr_t)&kbdin;
 
-      (void)boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
+      boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
     }
   else
 #endif

--- a/graphics/nxwidgets/src/cgraphicsport.cxx
+++ b/graphics/nxwidgets/src/cgraphicsport.cxx
@@ -144,7 +144,7 @@ CGraphicsPort::~CGraphicsPort(void)
 const nxgl_coord_t CGraphicsPort::getX(void) const
 {
   struct nxgl_point_s pos;
-  (void)m_pNxWnd->getPosition(&pos);
+  m_pNxWnd->getPosition(&pos);
   return pos.x;
 };
 
@@ -158,7 +158,7 @@ const nxgl_coord_t CGraphicsPort::getX(void) const
 const nxgl_coord_t CGraphicsPort::getY(void) const
 {
   struct nxgl_point_s pos;
-  (void)m_pNxWnd->getPosition(&pos);
+  m_pNxWnd->getPosition(&pos);
   return pos.y;
 };
 
@@ -369,7 +369,7 @@ void CGraphicsPort::drawBitmap(nxgl_coord_t x, nxgl_coord_t y,
 
   // Blit the bitmap
 
-  (void)m_pNxWnd->bitmap(&dest, (FAR const void *)bitmap->data, &origin, bitmap->stride);
+  m_pNxWnd->bitmap(&dest, (FAR const void *)bitmap->data, &origin, bitmap->stride);
 }
 
 /**
@@ -507,7 +507,7 @@ void CGraphicsPort::drawBitmap(nxgl_coord_t x, nxgl_coord_t y,
 
       // Blit the bitmap
 
-      (void)m_pNxWnd->bitmap(&dest, (FAR const void *)runPtr, &origin, bitmap->stride);
+      m_pNxWnd->bitmap(&dest, (FAR const void *)runPtr, &origin, bitmap->stride);
     }
 }
 
@@ -582,7 +582,7 @@ void CGraphicsPort::drawBitmapGreyScale(nxgl_coord_t x, nxgl_coord_t y,
 
       // Now blit the single row
 
-      (void)m_pNxWnd->bitmap(&dest, run, &origin, bitmap->stride);
+      m_pNxWnd->bitmap(&dest, run, &origin, bitmap->stride);
 
        // Setup for the next source row
 
@@ -869,7 +869,7 @@ void CGraphicsPort::copy(nxgl_coord_t sourceX, nxgl_coord_t sourceY,
   offset.x = destX - sourceX;
   offset.y = destY - sourceY;
 
-  (void)m_pNxWnd->move(&rect, &offset);
+  m_pNxWnd->move(&rect, &offset);
 }
 
 /**
@@ -897,7 +897,7 @@ void CGraphicsPort::move(nxgl_coord_t x, nxgl_coord_t y,
   offset.x = deltaX;
   offset.y = deltaY;
 
-  (void)m_pNxWnd->move(&rect, &offset);
+  m_pNxWnd->move(&rect, &offset);
 }
 
 /**

--- a/graphics/nxwidgets/src/ckeypad.cxx
+++ b/graphics/nxwidgets/src/ckeypad.cxx
@@ -179,7 +179,7 @@ void  CKeypad::onClick(nxgl_coord_t x, nxgl_coord_t y)
       // The ultimate recipient will be the widget in the top window
       // that has focus.
 
-      (void)nx_kbdchin(m_hNxServer, (uint8_t)ch);
+      nx_kbdchin(m_hNxServer, (uint8_t)ch);
     }
 }
 

--- a/graphics/nxwidgets/src/cnxfont.cxx
+++ b/graphics/nxwidgets/src/cnxfont.cxx
@@ -127,8 +127,8 @@ void CNxFont::drawChar(FAR SBitmap *bitmap, nxwidget_char_t letter)
 
       // Then render the glyph into the bitmap memory
 
-      (void)FONT_RENDERER((FAR nxgl_mxpixel_t*)bitmap->data, fheight,
-                          fwidth, fstride, fbm, m_fontColor);
+      FONT_RENDERER((FAR nxgl_mxpixel_t*)bitmap->data, fheight,
+                    fwidth, fstride, fbm, m_fontColor);
     }
 }
 

--- a/graphics/nxwidgets/src/cnxserver.cxx
+++ b/graphics/nxwidgets/src/cnxserver.cxx
@@ -177,10 +177,10 @@ bool CNxServer::connect(void)
       // the least efficient way to do this, but it makes this logic flow more
       // smoothly.
 
-      (void)pthread_attr_init(&attr);
+      pthread_attr_init(&attr);
       param.sched_priority = CONFIG_NXWIDGETS_LISTENERPRIO;
-      (void)pthread_attr_setschedparam(&attr, &param);
-      (void)pthread_attr_setstacksize(&attr, CONFIG_NXWIDGETS_LISTENERSTACK);
+      pthread_attr_setschedparam(&attr, &param);
+      pthread_attr_setstacksize(&attr, CONFIG_NXWIDGETS_LISTENERSTACK);
 
       m_stop    = false;
       m_running = true;
@@ -196,7 +196,7 @@ bool CNxServer::connect(void)
 
       // Detach from the thread
 
-      (void)pthread_detach(thread);
+      pthread_detach(thread);
 
       // Don't return until we are connected to the server
 
@@ -205,7 +205,7 @@ bool CNxServer::connect(void)
           // Wait for the listener thread to wake us up when we really
           // are connected.
 
-          (void)sem_wait(&m_connsem);
+          sem_wait(&m_connsem);
         }
 
       // In the successful case, the listener is still running (m_running)
@@ -244,7 +244,7 @@ void CNxServer::disconnect(void)
         {
           // Wait for the listener thread to stop
 
-          (void)sem_wait(&m_connsem);
+          sem_wait(&m_connsem);
         }
     }
 

--- a/graphics/nxwidgets/src/cnxtkwindow.cxx
+++ b/graphics/nxwidgets/src/cnxtkwindow.cxx
@@ -99,7 +99,7 @@ CNxTkWindow::~CNxTkWindow(void)
   // instance.  The lifetime of that instance is owned by he-who-
   // constructed-us.
 
-  (void)nxtk_closewindow(m_hNxTkWindow);
+  nxtk_closewindow(m_hNxTkWindow);
 
   delete m_widgetControl;
 }
@@ -405,7 +405,7 @@ void CNxTkWindow::getRectangle(FAR const struct nxgl_rect_s *rect, struct SBitma
 {
   // Get a rectangule region from the window
 
-  (void)nxtk_getwindow(m_hNxTkWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
+  nxtk_getwindow(m_hNxTkWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
 }
 
 /**

--- a/graphics/nxwidgets/src/cnxtoolbar.cxx
+++ b/graphics/nxwidgets/src/cnxtoolbar.cxx
@@ -100,7 +100,7 @@ CNxToolbar::~CNxToolbar(void)
 
   // Release the toolbar.
 
-  (void)nxtk_closetoolbar(m_hNxTkWindow);
+  nxtk_closetoolbar(m_hNxTkWindow);
 }
 
 /**
@@ -232,7 +232,7 @@ void CNxToolbar::getRectangle(FAR const struct nxgl_rect_s *rect, struct SBitmap
 {
   // Get a rectangule region from the toolbar
 
-  (void)nxtk_gettoolbar(m_hNxTkWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
+  nxtk_gettoolbar(m_hNxTkWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
 }
 
 /**

--- a/graphics/nxwidgets/src/cnxwindow.cxx
+++ b/graphics/nxwidgets/src/cnxwindow.cxx
@@ -83,7 +83,7 @@ CNxWindow::~CNxWindow(void)
 {
   // Release the window.
 
-  (void)nx_closewindow(m_hNxWindow);
+  nx_closewindow(m_hNxWindow);
 
   // Release the widget control instance. Whether its lifetime
   // should be handled by the window, or the owner-of-the-window
@@ -257,7 +257,7 @@ void CNxWindow::getRectangle(FAR const struct nxgl_rect_s *rect, struct SBitmap 
 {
   // Get a rectangule region from the window
 
-  (void)nx_getrectangle(m_hNxWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
+  nx_getrectangle(m_hNxWindow, rect, 0, (FAR uint8_t*)dest->data, dest->stride);
 }
 /**
  * Fill the specified trapezoidal region in the window with the specified

--- a/graphics/nxwidgets/src/cwidgetcontrol.cxx
+++ b/graphics/nxwidgets/src/cwidgetcontrol.cxx
@@ -187,7 +187,7 @@ CWidgetControl::~CWidgetControl(void)
 void CWidgetControl::waitForWindowEvent(void)
 {
   m_waiting = true;
- (void)sem_wait(&m_waitSem);
+  sem_wait(&m_waitSem);
   m_waiting = false;
 }
 #endif
@@ -201,7 +201,7 @@ void CWidgetControl::postWindowEvent(void)
 {
   if (m_waiting)
     {
-      (void)sem_post(&m_waitSem);
+      sem_post(&m_waitSem);
     }
 }
 #endif
@@ -473,7 +473,7 @@ void CWidgetControl::newMouseEvent(FAR const struct nxgl_point_s *pos, uint8_t b
 
           m_xyinput.leftPressed = 1;
 
-          (void)clock_gettime(CLOCK_REALTIME, &m_xyinput.leftPressTime);
+          clock_gettime(CLOCK_REALTIME, &m_xyinput.leftPressTime);
 
           // Check for double click event
 
@@ -494,7 +494,7 @@ void CWidgetControl::newMouseEvent(FAR const struct nxgl_point_s *pos, uint8_t b
           // New left button release
 
           m_xyinput.leftReleased  = 1;
-          (void)clock_gettime(CLOCK_REALTIME, &m_xyinput.leftReleaseTime);
+          clock_gettime(CLOCK_REALTIME, &m_xyinput.leftReleaseTime);
         }
 
       m_xyinput.leftHeld = 0;
@@ -692,7 +692,7 @@ uint32_t CWidgetControl::elapsedTime(FAR const struct timespec *startTime)
 {
   struct timespec endTime;
 
-  (void)clock_gettime(CLOCK_REALTIME, &endTime);
+  clock_gettime(CLOCK_REALTIME, &endTime);
   if (startTime->tv_sec <= endTime.tv_sec)
     {
       // Get the elapsed seconds

--- a/graphics/nxwm/src/ccalibration.cxx
+++ b/graphics/nxwm/src/ccalibration.cxx
@@ -228,12 +228,12 @@ void CCalibration::stop(void)
           // termination request
 
           ginfo("Stopping calibration: m_calthread=%d\n", (int)m_calthread);
-          (void)pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
+          pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
 
           // Wait for the calibration thread to exit
 
           FAR pthread_addr_t value;
-          (void)pthread_join(m_thread, &value);
+          pthread_join(m_thread, &value);
         }
     }
 }
@@ -274,7 +274,7 @@ void CCalibration::hide(void)
       // Ask the calibration thread to hide the display
 
       m_calthread = CALTHREAD_HIDE;
-      (void)pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
+      pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
     }
 }
 
@@ -297,7 +297,7 @@ void CCalibration::redraw(void)
   if (!isStarted())
     {
       ginfo("Starting calibration: m_calthread=%d\n", (int)m_calthread);
-      (void)startCalibration(CALTHREAD_SHOW);
+      startCalibration(CALTHREAD_SHOW);
     }
 
   // Is the calibration thread running? If not, then wait until it is.
@@ -316,7 +316,7 @@ void CCalibration::redraw(void)
       // the display
 
       m_calthread = CALTHREAD_SHOW;
-      (void)pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
+      pthread_kill(m_thread, CONFIG_NXWM_CALIBRATION_SIGNO);
     }
 }
 
@@ -546,13 +546,13 @@ bool CCalibration::startCalibration(enum ECalThreadState initialState)
   // Configure the calibration thread
 
   pthread_attr_t attr;
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
 
   struct sched_param param;
   param.sched_priority = CONFIG_NXWM_CALIBRATION_LISTENERPRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_NXWM_CALIBRATION_LISTENERSTACK);
+  pthread_attr_setstacksize(&attr, CONFIG_NXWM_CALIBRATION_LISTENERSTACK);
 
   // Set the initial state of the thread
 

--- a/graphics/nxwm/src/chexcalculator.cxx
+++ b/graphics/nxwm/src/chexcalculator.cxx
@@ -437,7 +437,7 @@ void CHexCalculator::setGeometry(void)
 
   // Get the size of the window
 
-  (void)window->getSize(&m_windowSize);
+  window->getSize(&m_windowSize);
 
   // Pick a height and width of a button to fill the entire window.
   // For the height, we will assume that the text window is 1.5 times

--- a/graphics/nxwm/src/ckeyboard.cxx
+++ b/graphics/nxwm/src/ckeyboard.cxx
@@ -93,7 +93,7 @@ CKeyboard::~CKeyboard(void)
   // to receive data
   // REVISIT:  Need wait here for the listener thread to terminate
 
-  (void)pthread_kill(m_thread, CONFIG_NXWM_KEYBOARD_SIGNO);
+  pthread_kill(m_thread, CONFIG_NXWM_KEYBOARD_SIGNO);
 
   // Close the keyboard device (or should these be done when the thread exits?)
 
@@ -117,13 +117,13 @@ bool CKeyboard::start(void)
 
   // Start a separate thread to listen for keyboard events
 
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
 
   struct sched_param param;
   param.sched_priority = CONFIG_NXWM_KEYBOARD_LISTENERPRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_NXWM_KEYBOARD_LISTENERSTACK);
+  pthread_attr_setstacksize(&attr, CONFIG_NXWM_KEYBOARD_LISTENERSTACK);
 
   m_state  = LISTENER_STARTED; // The listener thread has been started, but is not yet running
 
@@ -136,7 +136,7 @@ bool CKeyboard::start(void)
 
   // Detach from the thread
 
-  (void)pthread_detach(m_thread);
+  pthread_detach(m_thread);
 
   // Don't return until we are sure that the listener thread is running
   // (or until it reports an error).
@@ -146,7 +146,7 @@ bool CKeyboard::start(void)
       // Wait for the listener thread to wake us up when we really
       // are connected.
 
-      (void)sem_wait(&m_waitSem);
+      sem_wait(&m_waitSem);
     }
 
   // Then return true only if the listener thread reported successful
@@ -381,7 +381,7 @@ FAR void *CKeyboard::listener(FAR void *arg)
 
       // Close the keyboard device
 
-      (void)std::close(This->m_kbdFd);
+      std::close(This->m_kbdFd);
       This->m_kbdFd = -1;
     }
 

--- a/graphics/nxwm/src/cmediaplayer.cxx
+++ b/graphics/nxwm/src/cmediaplayer.cxx
@@ -526,7 +526,7 @@ void CMediaPlayer::setGeometry(void)
 
   // Get the size of the window
 
-  (void)window->getSize(&m_windowSize);
+  window->getSize(&m_windowSize);
 }
 
 /**
@@ -618,7 +618,7 @@ inline bool CMediaPlayer::showMediaFiles(const char *mediaPath)
 
   // Close the directory
 
-  (void)closedir(dirp);
+  closedir(dirp);
 
   // Sort the file names in alphabetical order
 
@@ -814,7 +814,7 @@ bool CMediaPlayer::createPlayer(void)
 
   // Show the media files that are available for playing
 
-  (void)showMediaFiles(CONFIG_NXWM_MEDIAPLAYER_MEDIAPATH);
+  showMediaFiles(CONFIG_NXWM_MEDIAPLAYER_MEDIAPATH);
 
   // Control image widths.
   // Image widths will depend on if the images will be bordered or not
@@ -1536,7 +1536,7 @@ void CMediaPlayer::updateMotionIndicator(void)
       // Set the new speed string
 
       char buffer[8];
-      (void)std::snprintf(buffer, 8, "%dX", g_motionSteps[m_subSample]);
+      std::snprintf(buffer, 8, "%dX", g_motionSteps[m_subSample]);
 
       NXWidgets::CNxString speed(buffer);
       m_speed->setText(speed);

--- a/graphics/nxwm/src/cnxterm.cxx
+++ b/graphics/nxwm/src/cnxterm.cxx
@@ -256,7 +256,7 @@ bool CNxTerm::run(void)
 
   // Get the size of the window
 
-  (void)window->getSize(&g_nxtermvars.wndo.wsize);
+  window->getSize(&g_nxtermvars.wndo.wsize);
 
   // Start the NxTerm task
 
@@ -357,7 +357,7 @@ void CNxTerm::stop(void)
       char devname[32];
       snprintf(devname, 32, "/dev/nxterm%d", m_minor);
 
-      (void)unlink(devname);
+      unlink(devname);
       m_nxterm = 0;
     }
 }
@@ -407,7 +407,7 @@ void CNxTerm::redraw(void)
   // Get the size of the window
 
   struct nxgl_size_s windowSize;
-  (void)window->getSize(&windowSize);
+  window->getSize(&windowSize);
 
   // Redraw the entire NxTerm window
 
@@ -424,7 +424,7 @@ void CNxTerm::redraw(void)
   iocargs.cmd       = NXTERMIOC_NXTERM_REDRAW;
   iocargs.arg       = (uintptr_t)&redraw;
 
-  (void)boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
+  boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
 }
 
 /**
@@ -500,7 +500,7 @@ int CNxTerm::nxterm(int argc, char *argv[])
   if (fd < 0)
     {
       gerr("ERROR: Failed open the console device\n");
-      (void)unlink(devname);
+      unlink(devname);
       goto errout;
     }
 
@@ -509,26 +509,26 @@ int CNxTerm::nxterm(int argc, char *argv[])
   // console).  (2) Don't bother trying to put debug instrumentation in the
   // following becaue it will end up in the NxTerm window.
 
-  (void)std::fflush(stdout);
-  (void)std::fflush(stderr);
+  std::fflush(stdout);
+  std::fflush(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::fclose(stdin);
+  std::fclose(stdin);
 #endif
-  (void)std::fclose(stdout);
-  (void)std::fclose(stderr);
+  std::fclose(stdout);
+  std::fclose(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::dup2(fd, 0);
+  std::dup2(fd, 0);
 #endif
-  (void)std::dup2(fd, 1);
-  (void)std::dup2(fd, 2);
+  std::dup2(fd, 1);
+  std::dup2(fd, 2);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::fdopen(0, "r");
+  std::fdopen(0, "r");
 #endif
-  (void)std::fdopen(1, "w");
-  (void)std::fdopen(2, "w");
+  std::fdopen(1, "w");
+  std::fdopen(2, "w");
 
   // And we can close our original driver file descriptor
 
@@ -545,7 +545,7 @@ int CNxTerm::nxterm(int argc, char *argv[])
   // Run the NSH console
 
 #ifdef CONFIG_NSH_CONSOLE
-  (void)nsh_consolemain(argc, argv);
+  nsh_consolemain(argc, argv);
 #endif
 
   // We get here if the NSH console should exits.  nsh_consolemain() ALWAYS

--- a/graphics/nxwm/src/ctaskbar.cxx
+++ b/graphics/nxwm/src/ctaskbar.cxx
@@ -1164,7 +1164,7 @@ bool CTaskbar::redrawTaskbarWindow(void)
 
           // Set the position of the icon bitmap
 
-          (void)image->moveTo(iconPos.x, iconPos.y);
+          image->moveTo(iconPos.x, iconPos.y);
 
           // Then re-draw the icon at the new position
 
@@ -1427,7 +1427,7 @@ void CTaskbar::handleActionEvent(const NXWidgets::CWidgetEventArgs &e)
               // Maximize the application by moving its window to the top of
               // the hierarchy and re-drawing it.
 
-              (void)maximizeApplication(app);
+              maximizeApplication(app);
             }
 
           // No, it is not minimized.  Is it already the top application?
@@ -1436,7 +1436,7 @@ void CTaskbar::handleActionEvent(const NXWidgets::CWidgetEventArgs &e)
             {
               /* Move window to the top of the hierarchy and re-draw it. */
 
-              (void)topApplication(app);
+              topApplication(app);
             }
 
           // Then break out of the loop

--- a/graphics/nxwm/src/ctouchscreen.cxx
+++ b/graphics/nxwm/src/ctouchscreen.cxx
@@ -130,7 +130,7 @@ CTouchscreen::~CTouchscreen(void)
   // to receive data
   // REVISIT:  Need wait here for the listener thread to terminate
 
-  (void)pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
+  pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
 
   // Close the touchscreen device (or should these be done when the thread exits?)
 
@@ -158,13 +158,13 @@ bool CTouchscreen::start(void)
 
   // Start a separate thread to listen for touchscreen events
 
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
 
   struct sched_param param;
   param.sched_priority = CONFIG_NXWM_TOUCHSCREEN_LISTENERPRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_NXWM_TOUCHSCREEN_LISTENERSTACK);
+  pthread_attr_setstacksize(&attr, CONFIG_NXWM_TOUCHSCREEN_LISTENERSTACK);
 
   m_state  = LISTENER_STARTED; // The listener thread has been started, but is not yet running
 
@@ -177,7 +177,7 @@ bool CTouchscreen::start(void)
 
   // Detach from the thread
 
-  (void)pthread_detach(m_thread);
+  pthread_detach(m_thread);
 
   // Don't return until we are sure that the listener thread is running
   // (or until it reports an error).
@@ -187,7 +187,7 @@ bool CTouchscreen::start(void)
       // Wait for the listener thread to wake us up when we really
       // are connected.
 
-      (void)sem_wait(&m_waitSem);
+      sem_wait(&m_waitSem);
     }
 
   // Then return true only if the listener thread reported successful
@@ -220,7 +220,7 @@ void CTouchscreen::setCalibrationData(const struct SCalibrationData &caldata)
   // Wake up the listener thread so that it will use our buffer
   // to receive data
 
-  (void)pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
+  pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
 }
 
 /**
@@ -246,7 +246,7 @@ bool CTouchscreen::waitRawTouchData(struct touch_sample_s *touch)
   // Wake up the listener thread so that it will use our buffer
   // to receive data
 
-  (void)pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
+  pthread_kill(m_thread, CONFIG_NXWM_TOUCHSCREEN_SIGNO);
 
   // And wait for touch data
 
@@ -583,5 +583,5 @@ void CTouchscreen::handleMouseInput(struct touch_sample_s *sample)
   // Get the server handle and "inject the mouse data
 
   NXHANDLE handle = m_server->getServer();
-  (void)nx_mousein(handle, x, y, buttons);
+  nx_mousein(handle, x, y, buttons);
 }

--- a/graphics/nxwm/src/nxwm_main.cxx
+++ b/graphics/nxwm/src/nxwm_main.cxx
@@ -277,7 +277,7 @@ static bool createTouchScreen(void)
   // Get the physical size of the display in pixels
 
   struct nxgl_size_s displaySize;
-  (void)g_nxwmtest.taskbar->getDisplaySize(displaySize);
+  g_nxwmtest.taskbar->getDisplaySize(displaySize);
 
     // Create the touchscreen device
 
@@ -515,7 +515,7 @@ int main(int argc, char *argv[])
   // 2) here via a call to boardctl() if the interface is enabled
   // (CONFIG_LIB_BOARDCTL=y).
 
-  (void)boardctl(BOARDIOC_INIT, 0);
+  boardctl(BOARDIOC_INIT, 0);
 #endif
 
 #ifdef CONFIG_NXWM_NXTERM

--- a/graphics/tiff/tiff_finalize.c
+++ b/graphics/tiff/tiff_finalize.c
@@ -161,26 +161,26 @@ static void tiff_cleanup(FAR struct tiff_info_s *info)
 
   if (info->outfd >= 0)
     {
-      (void)close(info->outfd);
+      close(info->outfd);
     }
   info->outfd = -1;
 
   if (info->tmp1fd >= 0)
     {
-      (void)close(info->tmp1fd);
+      close(info->tmp1fd);
     }
   info->tmp1fd = -1;
 
   if (info->tmp2fd >= 0)
     {
-      (void)close(info->tmp2fd);
+      close(info->tmp2fd);
     }
   info->tmp2fd = -1;
 
   /* And remove the temporary files */
 
-  (void)unlink(info->tmpfile1);
-  (void)unlink(info->tmpfile2);
+  unlink(info->tmpfile1);
+  unlink(info->tmpfile2);
 }
 
 /****************************************************************************
@@ -434,6 +434,6 @@ void tiff_abort(FAR struct tiff_info_s *info)
 
   /* But then delete the output file as well */
 
-  (void)unlink(info->outfile);
+  unlink(info->outfile);
 }
 

--- a/graphics/tiff/tiff_initialize.c
+++ b/graphics/tiff/tiff_initialize.c
@@ -421,11 +421,11 @@ static int tiff_datetime(FAR char *timbuf, unsigned int buflen)
 
   /* Break the current time up into the format needed by strftime */
 
-  (void)gmtime_r((FAR const time_t*)&ts.tv_sec, &tm);
+  gmtime_r((FAR const time_t*)&ts.tv_sec, &tm);
 
   /* Comvert the current time in the TIFF format */
 
-  (void)strftime(timbuf, buflen, TIFF_DATETIME_FORMAT, &tm);
+  strftime(timbuf, buflen, TIFF_DATETIME_FORMAT, &tm);
   return OK;
 }
 

--- a/graphics/twm4nx/apps/ccalibration.cxx
+++ b/graphics/twm4nx/apps/ccalibration.cxx
@@ -139,9 +139,9 @@ CCalibration::CCalibration(FAR CTwm4Nx *twm4nx)
   // Set up the semaphores that are used to synchronize the calibration
   // thread with Twm4Nx events
 
-  (void)sem_init(&m_exclSem, 0, 1);
-  (void)sem_init(&m_synchSem, 0, 0);
-  (void)sem_setprotocol(&m_synchSem, SEM_PRIO_NONE);
+  sem_init(&m_exclSem, 0, 1);
+  sem_init(&m_synchSem, 0, 0);
+  sem_setprotocol(&m_synchSem, SEM_PRIO_NONE);
 }
 
 /**
@@ -275,13 +275,13 @@ bool CCalibration::run(void)
   // Configure the calibration thread
 
   pthread_attr_t attr;
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
 
   struct sched_param param;
   param.sched_priority = CONFIG_TWM4NX_CALIBRATION_LISTENERPRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_TWM4NX_CALIBRATION_LISTENERSTACK);
+  pthread_attr_setstacksize(&attr, CONFIG_TWM4NX_CALIBRATION_LISTENERSTACK);
 
   // Set the initial state of the thread
 
@@ -1136,12 +1136,12 @@ void CCalibration::stop(void)
           // termination request
 
           twminfo("Stopping calibration: m_calthread=%d\n", (int)m_calthread);
-          (void)pthread_kill(m_thread, CONFIG_TWM4NX_CALIBRATION_SIGNO);
+          pthread_kill(m_thread, CONFIG_TWM4NX_CALIBRATION_SIGNO);
 
           // Wait for the calibration thread to exit
 
           FAR pthread_addr_t value;
-          (void)pthread_join(m_thread, &value);
+          pthread_join(m_thread, &value);
         }
     }
 }

--- a/graphics/twm4nx/apps/cclock.cxx
+++ b/graphics/twm4nx/apps/cclock.cxx
@@ -494,16 +494,16 @@ void CClock::update(void)
   uint8_t codes[CLOCK_NDIGITS];
 
   char ascii = (hour > 9) ? '1' : ' ';
-  (void)m_slcd->convert(ascii, codes[0]);
+  m_slcd->convert(ascii, codes[0]);
 
   ascii = (hour % 10) + '0';
-  (void)m_slcd->convert(ascii, codes[1]);
+  m_slcd->convert(ascii, codes[1]);
 
   ascii = (tm.tm_min / 10) + '0';
-  (void)m_slcd->convert(ascii, codes[2]);
+  m_slcd->convert(ascii, codes[2]);
 
   ascii = (tm.tm_min % 10) + '0';
-  (void)m_slcd->convert(ascii, codes[3]);
+  m_slcd->convert(ascii, codes[3]);
 
   struct nxgl_point_s pos;
   pos.y = CONFIG_TWM4NX_CLOCK_VSPACING;
@@ -534,7 +534,7 @@ void CClock::redraw(void)
   // Get the size of the window
 
   struct nxgl_size_s windowSize;
-  (void)m_window->getWindowSize(&windowSize);
+  m_window->getWindowSize(&windowSize);
 
   // Create a bounding box
 

--- a/graphics/twm4nx/apps/cnxterm.cxx
+++ b/graphics/twm4nx/apps/cnxterm.cxx
@@ -358,7 +358,7 @@ void CNxTerm::stop(void)
       char devname[32];
       snprintf(devname, 32, "/dev/nxterm%d", m_minor);
 
-      (void)unlink(devname);
+      unlink(devname);
       m_NxTerm = 0;
     }
 }
@@ -415,7 +415,7 @@ int CNxTerm::nxterm(int argc, char *argv[])
   if (fd < 0)
     {
       twmerr("ERROR: Failed open the console device\n");
-      (void)unlink(devname);
+      unlink(devname);
       goto errout;
     }
 
@@ -424,26 +424,26 @@ int CNxTerm::nxterm(int argc, char *argv[])
   // console).  (2) Don't bother trying to put debug instrumentation in the
   // following becaue it will end up in the NxTerm window.
 
-  (void)std::fflush(stdout);
-  (void)std::fflush(stderr);
+  std::fflush(stdout);
+  std::fflush(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::fclose(stdin);
+  std::fclose(stdin);
 #endif
-  (void)std::fclose(stdout);
-  (void)std::fclose(stderr);
+  std::fclose(stdout);
+  std::fclose(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::dup2(fd, 0);
+  std::dup2(fd, 0);
 #endif
-  (void)std::dup2(fd, 1);
-  (void)std::dup2(fd, 2);
+  std::dup2(fd, 1);
+  std::dup2(fd, 2);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  (void)std::fdopen(0, "r");
+  std::fdopen(0, "r");
 #endif
-  (void)std::fdopen(1, "w");
-  (void)std::fdopen(2, "w");
+  std::fdopen(1, "w");
+  std::fdopen(2, "w");
 
   // And we can close our original driver file descriptor
 
@@ -460,7 +460,7 @@ int CNxTerm::nxterm(int argc, char *argv[])
   // Run the NSH console
 
 #ifdef CONFIG_NSH_CONSOLE
-  (void)nsh_consolemain(argc, argv);
+  nsh_consolemain(argc, argv);
 #endif
 
   // We get here if the NSH console should exits.  nsh_consolemain() ALWAYS
@@ -521,7 +521,7 @@ void CNxTerm::redraw(void)
   // Get the size of the window
 
   struct nxgl_size_s windowSize;
-  (void)m_nxtermWindow->getWindowSize(&windowSize);
+  m_nxtermWindow->getWindowSize(&windowSize);
 
   // Redraw the entire NxTerm window
 
@@ -538,7 +538,7 @@ void CNxTerm::redraw(void)
   iocargs.cmd       = NXTERMIOC_NXTERM_REDRAW;
   iocargs.arg       = (uintptr_t)&redraw;
 
-  (void)boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
+  boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
 }
 
 /**
@@ -552,7 +552,7 @@ void CNxTerm::resize(void)
   // Get the size of the window
 
   resize.handle     = m_NxTerm;
-  (void)m_nxtermWindow->getWindowSize(&resize.size);
+  m_nxtermWindow->getWindowSize(&resize.size);
 
   // Inform NxTerm of the new size
 
@@ -560,7 +560,7 @@ void CNxTerm::resize(void)
   iocargs.cmd       = NXTERMIOC_NXTERM_RESIZE;
   iocargs.arg       = (uintptr_t)&resize;
 
-  (void)boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
+  boardctl(BOARDIOC_NXTERM_IOCTL, (uintptr_t)&iocargs);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/graphics/twm4nx/src/cbackground.cxx
+++ b/graphics/twm4nx/src/cbackground.cxx
@@ -547,7 +547,7 @@ void CBackground::cleanup(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 

--- a/graphics/twm4nx/src/ciconmgr.cxx
+++ b/graphics/twm4nx/src/ciconmgr.cxx
@@ -111,7 +111,7 @@ CIconMgr::~CIconMgr(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
     }
 
   // Free the icon manager window
@@ -427,7 +427,7 @@ bool CIconMgr::event(FAR struct SEventMsg *eventmsg)
           // button array.  handleActionEvent() will be called in that
           // case.  false is not a failure.
 
-          (void)control->pollEvents();
+          control->pollEvents();
         }
         break;
 

--- a/graphics/twm4nx/src/ciconwidget.cxx
+++ b/graphics/twm4nx/src/ciconwidget.cxx
@@ -126,7 +126,7 @@ CIconWidget::~CIconWidget(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 }

--- a/graphics/twm4nx/src/cinput.cxx
+++ b/graphics/twm4nx/src/cinput.cxx
@@ -135,7 +135,7 @@ CInput::~CInput(void)
   // to receive data
   // REVISIT:  Need wait here for the listener thread to terminate
 
-  (void)pthread_kill(m_thread, CONFIG_TWM4NX_INPUT_SIGNO);
+  pthread_kill(m_thread, CONFIG_TWM4NX_INPUT_SIGNO);
 
 #ifndef CONFIG_TWM4NX_NOKEYBOARD
   // Close the keyboard device
@@ -170,13 +170,13 @@ bool CInput::start(void)
 
   // Start a separate thread to listen for keyboard events
 
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
 
   struct sched_param param;
   param.sched_priority = CONFIG_TWM4NX_INPUT_LISTENERPRIO;
-  (void)pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setschedparam(&attr, &param);
 
-  (void)pthread_attr_setstacksize(&attr, CONFIG_TWM4NX_INPUT_LISTENERSTACK);
+  pthread_attr_setstacksize(&attr, CONFIG_TWM4NX_INPUT_LISTENERSTACK);
 
   m_state  = LISTENER_STARTED; // The listener thread has been started, but is not yet running
 
@@ -189,7 +189,7 @@ bool CInput::start(void)
 
   // Detach from the thread
 
-  (void)pthread_detach(m_thread);
+  pthread_detach(m_thread);
 
   // Don't return until we are sure that the listener thread is running
   // (or until it reports an error).
@@ -199,7 +199,7 @@ bool CInput::start(void)
       // Wait for the listener thread to wake us up when we really
       // are connected.
 
-      (void)sem_wait(&m_waitSem);
+      sem_wait(&m_waitSem);
     }
 
   // Then return true only if the listener thread reported successful
@@ -971,14 +971,14 @@ FAR void *CInput::listener(FAR void *arg)
 #ifndef CONFIG_TWM4NX_NOKEYBOARD
       // Close the keyboard device
 
-      (void)std::close(This->m_kbdFd);
+      std::close(This->m_kbdFd);
       This->m_kbdFd = -1;
 #endif
 
 #ifndef CONFIG_TWM4NX_NOMOUSE
       // Close the mouse device
 
-      (void)std::close(This->m_mouseFd);
+      std::close(This->m_mouseFd);
       This->m_mouseFd = -1;
 #endif
     }

--- a/graphics/twm4nx/src/cmenus.cxx
+++ b/graphics/twm4nx/src/cmenus.cxx
@@ -296,7 +296,7 @@ bool CMenus::event(FAR struct SEventMsg *eventmsg)
           // button array.  handleActionEvent() will be called in that
           // case.  false is not a failure.
 
-          (void)control->pollEvents();
+          control->pollEvents();
         }
         break;
 
@@ -736,7 +736,7 @@ void CMenus::cleanup(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 

--- a/graphics/twm4nx/src/cresize.cxx
+++ b/graphics/twm4nx/src/cresize.cxx
@@ -119,7 +119,7 @@ CResize::~CResize(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 
@@ -438,7 +438,7 @@ void CResize::updateSizeLabel(FAR struct nxgl_size_s &windowSize)
     }
 
   FAR char *str;
-  (void)asprintf(&str, " %4d x %-4d ", windowSize.w, windowSize.h);
+  asprintf(&str, " %4d x %-4d ", windowSize.w, windowSize.h);
   if (str == (FAR char *)0)
     {
       twmerr("ERROR: Failed to get size string\n");

--- a/graphics/twm4nx/src/ctwm4nx.cxx
+++ b/graphics/twm4nx/src/ctwm4nx.cxx
@@ -393,7 +393,7 @@ void CTwm4Nx::genMqName(void)
   unsigned long randvalue =
     (unsigned long)std::random() & 0x00fffffful;
 
-  (void)std::asprintf(&m_queueName, "Twm4Nx%06ul", randvalue);
+  std::asprintf(&m_queueName, "Twm4Nx%06ul", randvalue);
 }
 
 /**
@@ -530,7 +530,7 @@ void CTwm4Nx::cleanup()
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 

--- a/graphics/twm4nx/src/cwindow.cxx
+++ b/graphics/twm4nx/src/cwindow.cxx
@@ -1856,7 +1856,7 @@ void CWindow::cleanup(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 

--- a/graphics/twm4nx/src/cwindowevent.cxx
+++ b/graphics/twm4nx/src/cwindowevent.cxx
@@ -149,7 +149,7 @@ CWindowEvent::~CWindowEvent(void)
 
   if (m_eventq != (mqd_t)-1)
     {
-      (void)mq_close(m_eventq);
+      mq_close(m_eventq);
       m_eventq = (mqd_t)-1;
     }
 

--- a/graphics/twm4nx/src/cwindowfactory.cxx
+++ b/graphics/twm4nx/src/cwindowfactory.cxx
@@ -224,7 +224,7 @@ FAR CWindow *
           iconMgr = m_twm4nx->getIconMgr();
         }
 
-      (void)iconMgr->addWindow(win->cwin);
+      iconMgr->addWindow(win->cwin);
     }
 
   // Return the contained window
@@ -275,7 +275,7 @@ void CWindowFactory::destroyWindow(FAR CWindow *cwin)
   CIconMgr *iconmgr = cwin->getIconMgr();
   DEBUGASSERT(iconmgr != (CIconMgr *)0);
 
-  (void)iconmgr->removeWindow(cwin);
+  iconmgr->removeWindow(cwin);
 
   // Delete the contained CWindow instance
 
@@ -315,7 +315,7 @@ bool CWindowFactory::placeIcon(FAR CWindow *cwin,
       // Get the size of the Icon
 
       struct nxgl_size_s iconSize;
-      (void)cwin->getIconWidgetSize(iconSize);
+      cwin->getIconWidgetSize(iconSize);
 
       // Get the background instance
 
@@ -449,10 +449,10 @@ void CWindowFactory::redrawIcons(FAR const nxgl_rect_s *nxRect)
           // Yes.. Create a bounding box for the icon
 
           struct nxgl_size_s iconSize;
-          (void)cwin->getIconWidgetSize(iconSize);
+          cwin->getIconWidgetSize(iconSize);
 
           struct nxgl_point_s iconPos;
-          (void)cwin->getIconWidgetPosition(iconPos);
+          cwin->getIconWidgetPosition(iconPos);
 
           struct nxgl_rect_s iconBounds;
           iconBounds.pt1.x = iconPos.x;
@@ -506,10 +506,10 @@ bool CWindowFactory::checkCollision(FAR CWindow *cwin,
           // Create a bounding box for the icon
 
           struct nxgl_size_s iconSize;
-          (void)win->cwin->getIconWidgetSize(iconSize);
+          win->cwin->getIconWidgetSize(iconSize);
 
           struct nxgl_point_s iconPos;
-          (void)win->cwin->getIconWidgetPosition(iconPos);
+          win->cwin->getIconWidgetPosition(iconPos);
 
           collision.pt1.x = iconPos.x;
           collision.pt1.y = iconPos.y;

--- a/include/graphics/nxwidgets/cgraphicsport.hxx
+++ b/include/graphics/nxwidgets/cgraphicsport.hxx
@@ -304,7 +304,7 @@ namespace NXWidgets
     inline void drawFilledCircle(struct nxgl_point_s *center, nxgl_coord_t radius,
                                  nxgl_mxpixel_t color)
     {
-      (void)m_pNxWnd->drawFilledCircle(center, radius, color);
+      m_pNxWnd->drawFilledCircle(center, radius, color);
     }
 
     /**

--- a/include/graphics/twm4nx/cwindow.hxx
+++ b/include/graphics/twm4nx/cwindow.hxx
@@ -908,7 +908,7 @@ namespace Twm4Nx
        // pollEvents() returns true if any interesting event occurred.
        // false is not a failure.
 
-        (void)control->pollEvents();
+        control->pollEvents();
         return true;
       }
 

--- a/interpreters/bas/bas.c
+++ b/interpreters/bas/bas.c
@@ -2023,7 +2023,7 @@ static void runline(struct Token *line)
       if (!g_program.runnable && g_pass == COMPILE)
         {
           Value_destroy(&value);
-          (void)compileProgram(&value, 0);
+          compileProgram(&value, 0);
         }
     }
 

--- a/interpreters/bas/bas_token.c
+++ b/interpreters/bas/bas_token.c
@@ -4471,7 +4471,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len)
 
 static void yy_fatal_error (yyconst char* msg)
 {
-      (void) fprintf(stderr, "%s\n", msg);
+  fprintf(stderr, "%s\n", msg);
   exit(YY_EXIT_FAILURE);
 }
 

--- a/modbus/ascii/mbascii.c
+++ b/modbus/ascii/mbascii.c
@@ -181,7 +181,6 @@ eMBErrorCode eMBASCIIInit(uint8_t ucSlaveAddress, uint8_t ucPort,
                           speed_t ulBaudRate, eMBParity eParity)
 {
   eMBErrorCode eStatus = MB_ENOERR;
-  (void)ucSlaveAddress;
 
   ENTER_CRITICAL_SECTION();
   ucMBLFCharacter = MB_ASCII_DEFAULT_LF;
@@ -208,7 +207,7 @@ void eMBASCIIStart(void)
 
   /* No special startup required for ASCII. */
 
-  (void)xMBPortEventPost(EV_READY);
+  xMBPortEventPost(EV_READY);
 }
 
 void eMBASCIIStop(void)
@@ -309,7 +308,7 @@ bool xMBASCIIReceiveFSM(void)
 
   DEBUGASSERT(eSndState == STATE_TX_IDLE);
 
-  (void)xMBPortSerialGetByte((int8_t *) & ucByte);
+  xMBPortSerialGetByte((int8_t *) & ucByte);
   switch (eRcvState)
     {
     /* A new character is received. If the character is a ':' the input

--- a/modbus/functions/mbfunccoils_m.c
+++ b/modbus/functions/mbfunccoils_m.c
@@ -127,7 +127,7 @@ eMBMasterReqErrCode eMBMasterReqReadCoils(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_READ_COILCNT_OFF] = usNCoils >> 8;
       ucMBFrame[MB_PDU_REQ_READ_COILCNT_OFF + 1] = usNCoils;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_READ_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 
@@ -261,7 +261,7 @@ eMBMasterReqErrCode eMBMasterReqWriteCoil(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_WRITE_VALUE_OFF] = usCoilData >> 8;
       ucMBFrame[MB_PDU_REQ_WRITE_VALUE_OFF + 1] = usCoilData;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_WRITE_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 
@@ -395,7 +395,7 @@ eMBMasterReqErrCode eMBMasterReqWriteMultipleCoils(uint8_t ucSndAddr,
 
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_WRITE_MUL_SIZE_MIN +
                                ucByteCount);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 

--- a/modbus/functions/mbfuncdisc_m.c
+++ b/modbus/functions/mbfuncdisc_m.c
@@ -109,7 +109,7 @@ eMBMasterReqErrCode eMBMasterReqReadDiscreteInputs(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_READ_DISCCNT_OFF] = usNDiscreteIn >> 8;
       ucMBFrame[MB_PDU_REQ_READ_DISCCNT_OFF + 1] = usNDiscreteIn;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_READ_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 

--- a/modbus/functions/mbfuncholding_m.c
+++ b/modbus/functions/mbfuncholding_m.c
@@ -138,7 +138,7 @@ eMBMasterReqErrCode eMBMasterReqWriteHoldingRegister(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_WRITE_VALUE_OFF] = usRegData >> 8;
       ucMBFrame[MB_PDU_REQ_WRITE_VALUE_OFF + 1] = usRegData;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_WRITE_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 
@@ -235,7 +235,7 @@ eMBMasterReqErrCode
 
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_WRITE_MUL_SIZE_MIN +
                                2 * usNRegs);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 
@@ -340,7 +340,7 @@ eMBMasterReqErrCode eMBMasterReqReadHoldingRegister(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_READ_REGCNT_OFF] = usNRegs >> 8;
       ucMBFrame[MB_PDU_REQ_READ_REGCNT_OFF + 1] = usNRegs;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_READ_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 
@@ -475,7 +475,7 @@ eMBMasterReqErrCode
 
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_READWRITE_SIZE_MIN +
                                2 * usNWriteRegs);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 

--- a/modbus/functions/mbfuncinput_m.c
+++ b/modbus/functions/mbfuncinput_m.c
@@ -111,7 +111,7 @@ eMBMasterReqErrCode eMBMasterReqReadInputRegister(uint8_t ucSndAddr,
       ucMBFrame[MB_PDU_REQ_READ_REGCNT_OFF] = usNRegs >> 8;
       ucMBFrame[MB_PDU_REQ_READ_REGCNT_OFF + 1] = usNRegs;
       vMBMasterSetPDUSndLength(MB_PDU_SIZE_MIN + MB_PDU_REQ_READ_SIZE);
-      (void)xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
+      xMBMasterPortEventPost(EV_MASTER_FRAME_SENT);
       eErrStatus = eMBMasterWaitRequestFinish();
     }
 

--- a/modbus/mb.c
+++ b/modbus/mb.c
@@ -387,7 +387,7 @@ eMBErrorCode eMBPoll(void)
 
               if ((ucRcvAddress == ucMBAddress) || (ucRcvAddress == MB_ADDRESS_BROADCAST))
                 {
-                  (void)xMBPortEventPost(EV_EXECUTE);
+                  xMBPortEventPost(EV_EXECUTE);
                 }
             }
             break;
@@ -431,7 +431,7 @@ eMBErrorCode eMBPoll(void)
                   vMBPortTimersDelay(CONFIG_MB_ASCII_TIMEOUT_WAIT_BEFORE_SEND_MS);
                 }
 #endif
-              (void)peMBFrameSendCur(ucMBAddress, ucMBFrame, usLength);
+              peMBFrameSendCur(ucMBAddress, ucMBFrame, usLength);
             }
             break;
 

--- a/modbus/mb_m.c
+++ b/modbus/mb_m.c
@@ -312,12 +312,12 @@ eMBErrorCode eMBMasterPoll(void)
           if ((eStatus == MB_ENOERR) &&
               (ucRcvAddress == ucMBMasterGetDestAddress()))
             {
-              (void)xMBMasterPortEventPost(EV_MASTER_EXECUTE);
+              xMBMasterPortEventPost(EV_MASTER_EXECUTE);
             }
           else
             {
               vMBMasterSetErrorType(EV_ERROR_RECEIVE_DATA);
-              (void)xMBMasterPortEventPost(EV_MASTER_ERROR_PROCESS);
+              xMBMasterPortEventPost(EV_MASTER_ERROR_PROCESS);
             }
           break;
 
@@ -383,7 +383,7 @@ eMBErrorCode eMBMasterPoll(void)
           if (eException != MB_EX_NONE)
             {
               vMBMasterSetErrorType(EV_ERROR_EXECUTE_FUNCTION);
-              (void)xMBMasterPortEventPost(EV_MASTER_ERROR_PROCESS);
+              xMBMasterPortEventPost(EV_MASTER_ERROR_PROCESS);
             }
           else
             {

--- a/modbus/nuttx/portevent.c
+++ b/modbus/nuttx/portevent.c
@@ -81,7 +81,7 @@ bool xMBPortEventGet(eMBEventType * eEvent)
        * init functions.
        */
 
-      (void)xMBPortSerialPoll();
+      xMBPortSerialPoll();
 
       /* Check if any of the timers have expired. */
 

--- a/modbus/nuttx/portevent_m.c
+++ b/modbus/nuttx/portevent_m.c
@@ -141,7 +141,7 @@ bool xMBMasterPortEventGet(eMBMasterEventType * eEvent)
        * configured from the timer init functions.
        */
 
-      (void)xMBMasterPortSerialPoll();
+      xMBMasterPortSerialPoll();
 
       /* Check if any of the timers have expired. */
 

--- a/modbus/nuttx/portserial.c
+++ b/modbus/nuttx/portserial.c
@@ -183,7 +183,7 @@ void vMBPortSerialEnable(bool bEnableRx, bool bEnableTx)
   if (bEnableRx)
     {
 #ifdef CONFIG_SERIAL_TERMIOS
-      (void)tcflush(iSerialFd, TCIFLUSH);
+      tcflush(iSerialFd, TCIFLUSH);
 #endif
       uiRxBufferPos = 0;
       bRxEnabled = true;
@@ -322,9 +322,9 @@ void vMBPortClose(void)
   if (iSerialFd != -1)
     {
 #ifdef CONFIG_SERIAL_TERMIOS
-      (void)tcsetattr(iSerialFd, TCSANOW, &xOldTIO);
+      tcsetattr(iSerialFd, TCSANOW, &xOldTIO);
 #endif
-      (void)close(iSerialFd);
+      close(iSerialFd);
       iSerialFd = -1;
     }
 }
@@ -351,7 +351,7 @@ bool xMBPortSerialPoll(void)
                 {
                   /* Call the modbus stack and let him fill the buffers. */
 
-                  (void)pxMBFrameCBByteReceived();
+                  pxMBFrameCBByteReceived();
                 }
 
               uiRxBufferPos = 0;
@@ -369,7 +369,7 @@ bool xMBPortSerialPoll(void)
     {
       while (bTxEnabled)
         {
-          (void)pxMBFrameCBTransmitterEmpty();
+          pxMBFrameCBTransmitterEmpty();
 
           /* Call the modbus stack to let him fill the buffer. */
         }

--- a/modbus/nuttx/portserial_m.c
+++ b/modbus/nuttx/portserial_m.c
@@ -187,7 +187,7 @@ void vMBMasterPortSerialEnable(bool bEnableRx, bool bEnableTx)
   if (bEnableRx)
     {
 #ifdef CONFIG_SERIAL_TERMIOS
-      (void)tcflush(iSerialFd, TCIFLUSH);
+      tcflush(iSerialFd, TCIFLUSH);
 #endif
       uiRxBufferPos = 0;
       bRxEnabled = true;
@@ -331,9 +331,9 @@ void vMBMasterPortClose( void )
   if (iSerialFd != -1)
     {
 #ifdef CONFIG_SERIAL_TERMIOS
-      (void)tcsetattr(iSerialFd, TCSANOW, &xOldTIO);
+      tcsetattr(iSerialFd, TCSANOW, &xOldTIO);
 #endif
-      (void)close(iSerialFd);
+      close(iSerialFd);
       iSerialFd = -1;
     }
 }
@@ -360,7 +360,7 @@ bool xMBMasterPortSerialPoll( void )
                 {
                   /* Call the modbus stack and let him fill the buffers. */
 
-                  (void)pxMBMasterFrameCBByteReceived();
+                  pxMBMasterFrameCBByteReceived();
                 }
 
               uiRxBufferPos = 0;
@@ -379,7 +379,7 @@ bool xMBMasterPortSerialPoll( void )
     {
       while (bTxEnabled)
         {
-          (void)pxMBMasterFrameCBTransmitterEmpty();
+          pxMBMasterFrameCBTransmitterEmpty();
 
           /* Call the modbus stack to let him fill the buffer. */
         }

--- a/modbus/nuttx/porttimer.c
+++ b/modbus/nuttx/porttimer.c
@@ -95,7 +95,7 @@ void vMBPortTimerPoll()
           if (ulDeltaMS > ulTimeOut)
             {
               bTimeoutEnable = false;
-              (void)pxMBPortCBTimerExpired();
+              pxMBPortCBTimerExpired();
             }
         }
     }

--- a/modbus/nuttx/porttimer_m.c
+++ b/modbus/nuttx/porttimer_m.c
@@ -162,7 +162,7 @@ void vMBMasterPortTimerPoll( void )
           if (ulDeltaMS > ulTimeOut)
             {
               bTimeoutEnable = false;
-              (void)pxMBMasterPortCBTimerExpired();
+              pxMBMasterPortCBTimerExpired();
             }
         }
     }

--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -99,7 +99,6 @@ eMBErrorCode eMBRTUInit(uint8_t ucSlaveAddress, uint8_t ucPort,
   eMBErrorCode eStatus = MB_ENOERR;
   uint32_t usTimerT35_50us;
 
-  (void)ucSlaveAddress;
   ENTER_CRITICAL_SECTION();
 
   /* Modbus RTU uses 8 Databits. */
@@ -258,7 +257,7 @@ bool xMBRTUReceiveFSM(void)
 
   /* Always read the character. */
 
-  (void)xMBPortSerialGetByte((int8_t *) & ucByte);
+  xMBPortSerialGetByte((int8_t *) & ucByte);
 
   switch (eRcvState)
     {

--- a/modbus/rtu/mbrtu_m.c
+++ b/modbus/rtu/mbrtu_m.c
@@ -278,7 +278,7 @@ bool xMBMasterRTUReceiveFSM(void)
 
   /* Always read the character. */
 
-  (void)xMBMasterPortSerialGetByte((uint8_t *) & ucByte);
+  xMBMasterPortSerialGetByte((uint8_t *) & ucByte);
 
   switch (eRcvState)
     {

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -514,7 +514,7 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
       /* Set the IP address to INADDR_ANY. */
 
       newaddr.s_addr = INADDR_ANY;
-      (void)netlib_set_ipv4addr(pdhcpc->interface, &newaddr);
+      netlib_set_ipv4addr(pdhcpc->interface, &newaddr);
 
       /* Loop sending DISCOVER until we receive an OFFER from a DHCP
        * server.  We will lock on to the first OFFER and decline any
@@ -555,8 +555,8 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
                    * out of the loop.
                    */
 
-                  (void)netlib_set_ipv4addr(pdhcpc->interface,
-                                            &presult->ipaddr);
+                  netlib_set_ipv4addr(pdhcpc->interface,
+                                      &presult->ipaddr);
                   state = STATE_HAVE_OFFER;
                 }
             }
@@ -632,7 +632,7 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
               else if (msgtype == DHCPOFFER)
                 {
                   ninfo("Received another OFFER, send DECLINE\n");
-                  (void)dhcpc_sendmsg(pdhcpc, presult, DHCPDECLINE);
+                  dhcpc_sendmsg(pdhcpc, presult, DHCPDECLINE);
                 }
 
               /* Otherwise, it is something that we do not recognize */
@@ -653,7 +653,7 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
             {
               /* An error other than a timeout was received */
 
-              (void)netlib_set_ipv4addr(pdhcpc->interface, &oldaddr);
+              netlib_set_ipv4addr(pdhcpc->interface, &oldaddr);
               return ERROR;
             }
         }

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -300,7 +300,7 @@ static inline void dhcpd_arpupdate(FAR uint8_t *ipaddr, FAR uint8_t *hwaddr)
 
   /* Update the ARP table */
 
-  (void)netlib_set_arpmapping(&inaddr, hwaddr);
+  netlib_set_arpmapping(&inaddr, hwaddr);
 }
 #else
 #  define dhcpd_arpupdate(ipaddr,hwaddr)
@@ -1076,7 +1076,7 @@ int dhcpd_sendack(in_addr_t ipaddr)
 
   /* Did the client request a specific lease time? */
 
-  (void)dhcpd_verifyreqleasetime(&leasetime);
+  dhcpd_verifyreqleasetime(&leasetime);
 
   /* Add the lease time to the response */
 
@@ -1174,7 +1174,7 @@ static inline int dhcpd_discover(void)
 
   /* Check if the client has requested a specific lease time */
 
-  (void)dhcpd_verifyreqleasetime(&leasetime);
+  dhcpd_verifyreqleasetime(&leasetime);
 
   /* Send the offer response */
 

--- a/netutils/ftpc/ftpc_chmod.c
+++ b/netutils/ftpc/ftpc_chmod.c
@@ -84,7 +84,7 @@ int ftpc_chmod(SESSION handle, FAR const char *path, FAR const char *mode)
 
   if (FTPC_HAS_CHMOD(session))
     {
-      (void)ftpc_cmd(session, "SITE CHMOD %s %s", path, mode);
+      ftpc_cmd(session, "SITE CHMOD %s %s", path, mode);
 
       /* Check for "502 Command not implemented" */
 

--- a/netutils/ftpc/ftpc_getfile.c
+++ b/netutils/ftpc/ftpc_getfile.c
@@ -193,7 +193,7 @@ static int ftpc_recvbinary(FAR struct ftpc_session_s *session,
             {
               /* errno should already be set by fread */
 
-              (void)ftpc_xfrabort(session, rinstream);
+              ftpc_xfrabort(session, rinstream);
               return ERROR;
             }
 
@@ -207,7 +207,7 @@ static int ftpc_recvbinary(FAR struct ftpc_session_s *session,
       nwritten = fwrite(session->buffer, sizeof(char), nread, loutstream);
       if (nwritten != nread)
         {
-          (void)ftpc_xfrabort(session, loutstream);
+          ftpc_xfrabort(session, loutstream);
 
           /* If nwritten < 0 errno should already be set by fwrite.
            * What would a short write mean?
@@ -397,7 +397,7 @@ int ftpc_recvtext(FAR struct ftpc_session_s *session,
             {
               /* Ooops... */
 
-              (void)ftpc_xfrabort(session, rinstream);
+              ftpc_xfrabort(session, rinstream);
               return ERROR;
             }
 
@@ -414,7 +414,7 @@ int ftpc_recvtext(FAR struct ftpc_session_s *session,
 
     if (fputc(ch, loutstream) == EOF)
       {
-        (void)ftpc_xfrabort(session, loutstream);
+        ftpc_xfrabort(session, loutstream);
         return ERROR;
       }
 

--- a/netutils/ftpc/ftpc_putfile.c
+++ b/netutils/ftpc/ftpc_putfile.c
@@ -98,7 +98,7 @@ static int ftpc_sendbinary(FAR struct ftpc_session_s *session,
 
           if (nread < 0)
             {
-              (void)ftpc_xfrabort(session, linstream);
+              ftpc_xfrabort(session, linstream);
               return ERROR;
             }
 
@@ -112,7 +112,7 @@ static int ftpc_sendbinary(FAR struct ftpc_session_s *session,
       nwritten = fwrite(session->buffer, sizeof(char), nread, routstream);
       if (nwritten != nread)
         {
-          (void)ftpc_xfrabort(session, routstream);
+          ftpc_xfrabort(session, routstream);
 
           /* Return failue */
 
@@ -149,7 +149,7 @@ static int ftpc_sendtext(FAR struct ftpc_session_s *session,
         {
           if (fputc('\r', routstream) == EOF)
             {
-              (void)ftpc_xfrabort(session, routstream);
+              ftpc_xfrabort(session, routstream);
               ret = ERROR;
               break;
             }
@@ -163,7 +163,7 @@ static int ftpc_sendtext(FAR struct ftpc_session_s *session,
 
       if (fputc(ch, routstream) == EOF)
         {
-          (void)ftpc_xfrabort(session, routstream);
+          ftpc_xfrabort(session, routstream);
           ret = ERROR;
           break;
         }

--- a/netutils/ftpc/ftpc_rpwd.c
+++ b/netutils/ftpc/ftpc_rpwd.c
@@ -90,7 +90,7 @@ FAR char *ftpc_rpwd(SESSION handle)
 
   /* Send the PWD command */
 
-  (void)ftpc_cmd(session, "PWD");
+  ftpc_cmd(session, "PWD");
 
   /* Response is like: 257 "/home/gnutt" (from vsftpd).
    *

--- a/netutils/ftpc/ftpc_transfer.c
+++ b/netutils/ftpc/ftpc_transfer.c
@@ -274,7 +274,7 @@ static FAR char *ftpc_abspath(FAR struct ftpc_session_s *session,
 
       else if (relpath[1] == '/')
         {
-          (void)asprintf(&ptr, "%s%s", homedir, &relpath[1]);
+          asprintf(&ptr, "%s%s", homedir, &relpath[1]);
         }
 
       /* Hmmm... this pretty much guaranteed to fail */
@@ -291,7 +291,7 @@ static FAR char *ftpc_abspath(FAR struct ftpc_session_s *session,
 
   else if (strncmp(relpath, "./", 2) == 0)
     {
-      (void)asprintf(&ptr, "%s%s", curdir, relpath+1);
+      asprintf(&ptr, "%s%s", curdir, relpath+1);
     }
 
   /* Check for an absolute path */
@@ -305,7 +305,7 @@ static FAR char *ftpc_abspath(FAR struct ftpc_session_s *session,
 
   else
     {
-      (void)asprintf(&ptr, "%s/%s", curdir, relpath);
+      asprintf(&ptr, "%s/%s", curdir, relpath);
     }
 
   return ptr;

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1021,8 +1021,8 @@ static int ftpd_dataopen(FAR struct ftpd_session_s *session)
         {
           int errval = errno;
           nerr("ERROR: socket() failed: %d\n", errval);
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 451, ' ', "Socket error !");
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 451, ' ', "Socket error !");
           return -errval;
         }
 
@@ -1033,9 +1033,9 @@ static int ftpd_dataopen(FAR struct ftpd_session_s *session)
         {
           int errval = errno;
           nerr("ERROR: connect() failed: %d\n", errval);
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 451, ' ', "Connect error !");
-          (void)ftpd_dataclose(session);
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 451, ' ', "Connect error !");
+          ftpd_dataclose(session);
           return -errval;
         }
 
@@ -1043,10 +1043,10 @@ static int ftpd_dataopen(FAR struct ftpd_session_s *session)
         {
           struct linger ling;
 
-          (void)memset(&ling, 0, sizeof(ling));
+          memset(&ling, 0, sizeof(ling));
           ling.l_onoff = 1;
           ling.l_linger = 4;
-          (void)setsockopt(session->data.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+          setsockopt(session->data.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
         }
 #endif
 
@@ -1061,9 +1061,9 @@ static int ftpd_dataopen(FAR struct ftpd_session_s *session)
   if (sd < 0)
     {
       nerr("ERROR: ftpd_accept() failed: %d\n", sd);
-      (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                          g_respfmt1, 451, ' ', "Accept error !");
-      (void)ftpd_dataclose(session);
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 451, ' ', "Accept error !");
+      ftpd_dataclose(session);
       return sd;
     }
 
@@ -1074,10 +1074,10 @@ static int ftpd_dataopen(FAR struct ftpd_session_s *session)
   {
     struct linger ling;
 
-    (void)memset(&ling, 0, sizeof(ling));
+    memset(&ling, 0, sizeof(ling));
     ling.l_onoff = 1;
     ling.l_linger = 4;
-    (void)setsockopt(session->data.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+    setsockopt(session->data.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
   }
 #endif
 
@@ -1174,7 +1174,7 @@ static FAR struct ftpd_server_s *ftpd_openserver(int port, sa_family_t family)
 #ifdef CONFIG_NET_HAVE_REUSEADDR
   {
     int reuse = 1;
-   (void)setsockopt(server->sd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+   setsockopt(server->sd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
   }
 #endif
 
@@ -1329,7 +1329,7 @@ static FAR struct ftpd_pathnode_s *ftpd_path2node(FAR const char *path)
 
       tail = newnode;
 
-      (void)ftpd_pathignore(newnode);
+      ftpd_pathignore(newnode);
     }
 
   return head;
@@ -1507,7 +1507,7 @@ ftpd_nodeappend(FAR struct ftpd_pathnode_s *head,
   temp = head;
   while (temp)
     {
-      (void)ftpd_pathignore(temp);
+      ftpd_pathignore(temp);
       temp = temp->flink;
     }
 
@@ -1712,7 +1712,7 @@ static off_t ftpd_offsatoi(FAR const char *filename, off_t offset)
       /* ret is binary mode offset */
     }
 
-  (void)fclose(outstream);
+  fclose(outstream);
   return ret;
 }
 
@@ -1806,8 +1806,8 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
   if (session->fd < 0)
     {
       ret = -errno;
-      (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                          g_respfmt1, 550, ' ', "Can not open file !");
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 550, ' ', "Can not open file !");
       goto errout_with_data;
     }
 
@@ -1857,8 +1857,8 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
 
       if (seekoffs < 0)
         {
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 550, ' ', "Can not seek file !");
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 550, ' ', "Can not seek file !");
           ret = -errval;
           goto errout_with_session;
         }
@@ -1922,8 +1922,8 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
       if (rdbytes < 0)
         {
           nerr("ERROR: Read failed: rdbytes=%d errval=%d\n", rdbytes, errval);
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 550, ' ', "Data read error !");
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 550, ' ', "Data read error !");
           ret = -errval;
           break;
         }
@@ -1936,8 +1936,8 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
         {
           /* End-of-file */
 
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 226, ' ', "Transfer complete");
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 226, ' ', "Transfer complete");
 
           /* Return success */
 
@@ -2017,8 +2017,8 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
       if (wrbytes != ((ssize_t)buflen))
         {
           nerr("ERROR: Write failed: wrbytes=%d errval=%d\n", wrbytes, errval);
-          (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                              g_respfmt1, 550, ' ', "Data send error !");
+          ftpd_response(session->cmd.sd, session->txtimeout,
+                        g_respfmt1, 550, ' ', "Data send error !");
            ret = -errval;
            break;
         }
@@ -2034,11 +2034,11 @@ errout_with_session:;
 
     if (isnew && ret < 0)
       {
-        (void)unlink(path);
+        unlink(path);
       }
 
 errout_with_data:;
-    (void)ftpd_dataclose(session);
+    ftpd_dataclose(session);
 
 errout_with_path:
     free(abspath);
@@ -2402,7 +2402,7 @@ static int fptd_listscan(FAR struct ftpd_session_s *session, FAR char *path,
         }
     }
 
-  (void)closedir(dir);
+  closedir(dir);
   return ret;
 }
 
@@ -2631,7 +2631,7 @@ static int ftpd_command_mode(FAR struct ftpd_session_s *session)
 
 static int ftpd_command_abor(FAR struct ftpd_session_s *session)
 {
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
   return ftpd_response(session->cmd.sd, session->txtimeout,
                        g_respfmt1, 426, ' ',
                        "Transfer aborted. Data connection closed.");
@@ -2643,8 +2643,8 @@ static int ftpd_command_abor(FAR struct ftpd_session_s *session)
 
 static int ftpd_command_quit(FAR struct ftpd_session_s *session)
 {
-  (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                      g_respfmt1, 221, ' ', "Good-bye");
+  ftpd_response(session->cmd.sd, session->txtimeout,
+                g_respfmt1, 221, ' ', "Good-bye");
 
   /* Return a negative value to force the server to disconnect */
 
@@ -2721,7 +2721,7 @@ static int ftpd_command_port(FAR struct ftpd_session_s *session)
                            g_respfmt1, 501, ' ', "Illegal PORT command");
     }
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
 
 #if 1 /* Follow param */
 
@@ -2800,9 +2800,9 @@ static int ftpd_command_eprt(FAR struct ftpd_session_s *session)
     {
       /* no message ? */
 
-      (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                          g_respfmt1, 502, ' ',
-                          "EPRT command not implemented !");
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 502, ' ',
+                    "EPRT command not implemented !");
       return -EINVAL;
     }
   right--;
@@ -2821,9 +2821,9 @@ static int ftpd_command_eprt(FAR struct ftpd_session_s *session)
     {
       /* Invalid format */
 
-      (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                          g_respfmt1, 502, ' ',
-                          "EPRT command not implemented !");
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 502, ' ',
+                    "EPRT command not implemented !");
       return -EINVAL;
     }
 
@@ -2858,13 +2858,13 @@ static int ftpd_command_eprt(FAR struct ftpd_session_s *session)
             }
         }
 
-      (void)ftpd_response(session->cmd.sd, session->txtimeout,
-                          g_respfmt1, 502, ' ',
-                          "EPRT command not implemented !");
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 502, ' ',
+                    "EPRT command not implemented !");
         return -EINVAL;
     }
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
 
   memset(&session->data.addr, 0, sizeof(session->data.addr));
   family = atoi(field[0]);
@@ -2874,7 +2874,7 @@ static int ftpd_command_eprt(FAR struct ftpd_session_s *session)
       family = AF_INET;
 
       session->data.addr.in4.sin_family = family;
-      (void)inet_pton(family, field[1], &session->data.addr.in4.sin_addr);
+      inet_pton(family, field[1], &session->data.addr.in4.sin_addr);
       session->data.addr.in4.sin_port = htons((short)atoi(field[2]));
     }
   else
@@ -2885,7 +2885,7 @@ static int ftpd_command_eprt(FAR struct ftpd_session_s *session)
       family = AF_INET6;
 
       session->data.addr.in6.sin6_family = family;
-      (void)inet_pton(family, field[1], &session->data.addr.in6.sin6_addr);
+      inet_pton(family, field[1], &session->data.addr.in6.sin6_addr);
       session->data.addr.in6.sin6_port = htons((short)atoi(field[2]));
     }
   else
@@ -3107,14 +3107,14 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
   unsigned int temp;
   int ret;
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
 
   session->data.addrlen = sizeof(session->data.addr);
 
   session->data.sd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (session->data.sd < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ', "PASV socket create fail !");
     }
@@ -3123,7 +3123,7 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
                     &session->data.addrlen);
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ', "PASV getsockname fail !");
     }
@@ -3154,7 +3154,7 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
              session->data.addrlen);
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ', "PASV bind fail !");
     }
@@ -3163,7 +3163,7 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
                     &session->data.addrlen);
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ', "PASV getsockname fail !");
     }
@@ -3171,14 +3171,14 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
   ret = listen(session->data.sd, 1);
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ', "PASV listen fail !");
     }
 
   if (ntohl(session->data.addr.in4.sin_addr.s_addr) == INADDR_ANY)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 425, ' ',
                            "Can not open passive connection");
@@ -3201,7 +3201,7 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
                       value[3], value[4], value[5]);
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
     }
 
   return ret;
@@ -3220,7 +3220,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
 {
   int ret;
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
 
   session->data.addrlen = sizeof(session->data.addr);
 
@@ -3236,7 +3236,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
 #if defined(IPPROTO_IPV6) && defined(IPV6_V6ONLY)
       int ipv6only = 0;
-      (void)setsockopt(session->data.sd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(ipv6only));
+      setsockopt(session->data.sd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(ipv6only));
 #endif
     }
 #else
@@ -3247,7 +3247,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
                           g_respfmt1, 500, ' ', "EPSV socket create fail !");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3257,7 +3257,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
                           g_respfmt1, 500, ' ', "EPSV getsockname fail !");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3278,7 +3278,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
                           g_respfmt1, 500, ' ', "EPSV family not supported!");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3288,7 +3288,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
                           g_respfmt1, 500, ' ', "EPSV bind fail !");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3298,7 +3298,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
                           g_respfmt1, 500, ' ', "EPSV getsockname fail !");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3307,7 +3307,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
     {
       ret = ftpd_response(session->cmd.sd, session->txtimeout,
             g_respfmt1, 500, ' ', "EPSV listen fail !");
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
@@ -3320,7 +3320,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
                           ntohs(session->data.addr.in6.sin6_port));
       if (ret < 0)
         {
-          (void)ftpd_dataclose(session);
+          ftpd_dataclose(session);
           return ret;
         }
     }
@@ -3334,7 +3334,7 @@ static int ftpd_command_epsv(FAR struct ftpd_session_s *session)
                           ntohs(session->data.addr.in4.sin_port));
       if (ret < 0)
         {
-          (void)ftpd_dataclose(session);
+          ftpd_dataclose(session);
           return ret;
         }
     }
@@ -3369,17 +3369,17 @@ static int ftpd_command_list(FAR struct ftpd_session_s *session)
                       "Opening ASCII mode data connection for file list");
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
   opton |= ftpd_listoption((char **)(&session->param));
-  (void)ftpd_list(session, opton);
+  ftpd_list(session, opton);
 
   ret = ftpd_response(session->cmd.sd, session->txtimeout,
                       g_respfmt1, 226, ' ', "Transfer complete");
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
   return ret;
 }
 
@@ -3403,17 +3403,17 @@ static int ftpd_command_nlst(FAR struct ftpd_session_s *session)
                       "Opening ASCII mode data connection for file list");
   if (ret < 0)
     {
-      (void)ftpd_dataclose(session);
+      ftpd_dataclose(session);
       return ret;
     }
 
   opton |= ftpd_listoption((char **)(&session->param));
-  (void)ftpd_list(session, opton);
+  ftpd_list(session, opton);
 
   ret = ftpd_response(session->cmd.sd, session->txtimeout,
                       g_respfmt1, 226, ' ', "Transfer complete");
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
   return ret;
 }
 
@@ -3530,7 +3530,7 @@ static int ftpd_command_size(FAR struct ftpd_session_s *session)
             offset++;
           }
 
-        (void)fclose(outstream);
+        fclose(outstream);
         ret = ftpd_response(session->cmd.sd, session->txtimeout,
                             "%03u%c%llu\r\n", 213, ' ', (unsigned long long)offset);
       }
@@ -3993,7 +3993,7 @@ static void ftpd_freesession(FAR struct ftpd_session_s *session)
       free(session->data.buffer);
     }
 
-  (void)ftpd_dataclose(session);
+  ftpd_dataclose(session);
 
   if (session->cmd.buffer)
     {
@@ -4023,19 +4023,19 @@ static void ftpd_workersetup(FAR struct ftpd_session_s *session)
 
 #ifdef CONFIG_NET_HAVE_IPTOS
   temp = IPTOS_LOWDELAY;
-  (void)setsockopt(session->cmd.sd, IPPROTO_IP, IP_TOS, &temp, sizeof(temp));
+  setsockopt(session->cmd.sd, IPPROTO_IP, IP_TOS, &temp, sizeof(temp));
 #endif
 
 #ifdef CONFIG_NET_HAVE_OOBINLINE
   temp = 1;
-  (void)setsockopt(session->cmd.sd, SOL_SOCKET, SO_OOBINLINE, &temp, sizeof(temp));
+  setsockopt(session->cmd.sd, SOL_SOCKET, SO_OOBINLINE, &temp, sizeof(temp));
 #endif
 
 #ifdef CONFIG_NET_SOLINGER
-  (void)memset(&ling, 0, sizeof(ling));
+  memset(&ling, 0, sizeof(ling));
   ling.l_onoff = 1;
   ling.l_linger = 4;
-  (void)setsockopt(session->cmd.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+  setsockopt(session->cmd.sd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
 #endif
 }
 
@@ -4108,7 +4108,7 @@ static FAR void *ftpd_worker(FAR void *arg)
                 break;
               }
 
-          (void)ftpd_send(session->cmd.sd, &session->cmd.buffer[offset], 1, session->txtimeout);
+          ftpd_send(session->cmd.sd, &session->cmd.buffer[offset], 1, session->txtimeout);
 
           offset++;
           recvbytes--;

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -324,7 +324,7 @@ static void netinit_set_macaddr(void)
 
   /* Set the 6LoWPAN extended address */
 
-  (void)netlib_seteaddr(NET_DEVNAME, eaddr);
+  netlib_seteaddr(NET_DEVNAME, eaddr);
 #endif /* CONFIG_NET_ETHERNET or HAVE_EADDR */
 }
 #else
@@ -446,7 +446,7 @@ static void netinit_net_bringup(void)
   if (handle != NULL)
     {
       struct dhcpc_state ds;
-      (void)dhcpc_request(handle, &ds);
+      dhcpc_request(handle, &ds);
       netlib_set_ipv4addr(NET_DEVNAME, &ds.ipaddr);
 
       if (ds.netmask.s_addr != 0)
@@ -747,7 +747,7 @@ static int netinit_monitor(void)
           abstime.tv_nsec -= 1000000000;
         }
 
-      (void)sem_timedwait(&g_notify_sem, &abstime);
+      sem_timedwait(&g_notify_sem, &abstime);
       sched_unlock();
     }
 
@@ -756,7 +756,7 @@ static int netinit_monitor(void)
 errout_with_notification:
 #  warning Missing logic
 errout_with_sigaction:
-  (void)sigaction(CONFIG_NETINIT_SIGNO, &oact, NULL);
+  sigaction(CONFIG_NETINIT_SIGNO, &oact, NULL);
 errout_with_socket:
   close(sd);
 errout:
@@ -819,21 +819,21 @@ int netinit_bringup(void)
 
   pthread_attr_init(&attr);
   sparam.sched_priority = CONFIG_NETINIT_THREAD_PRIORITY;
-  (void)pthread_attr_setschedparam(&attr, &sparam);
-  (void)pthread_attr_setstacksize(&attr, CONFIG_NETINIT_THREAD_STACKSIZE);
+  pthread_attr_setschedparam(&attr, &sparam);
+  pthread_attr_setstacksize(&attr, CONFIG_NETINIT_THREAD_STACKSIZE);
 
   ninfo("Starting netinit thread\n");
   ret = pthread_create(&tid, &attr, netinit_thread, NULL);
   if (ret != OK)
     {
       nerr("ERROR: Failed to create netinit thread: %d\n", ret);
-      (void)netinit_thread(NULL);
+      netinit_thread(NULL);
     }
   else
     {
       /* Detach the thread because we will not be joining to it */
 
-      (void)pthread_detach(tid);
+      pthread_detach(tid);
 
       /* Name the thread */
 

--- a/netutils/netlib/netlib_server.c
+++ b/netutils/netlib/netlib_server.c
@@ -136,8 +136,8 @@ void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksiz
        * provided in as the single argument to the new thread.
        */
 
-      (void)pthread_attr_init(&attr);
-      (void)pthread_attr_setstacksize(&attr, stacksize);
+      pthread_attr_init(&attr);
+      pthread_attr_setstacksize(&attr, stacksize);
 
       ret = pthread_create(&child, &attr, handler, (pthread_addr_t)((uintptr_t)acceptsd));
       if (ret != 0)
@@ -166,7 +166,7 @@ void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksiz
        * in order to avoid memory leaks.
        */
 
-      (void)pthread_detach(child);
+      pthread_detach(child);
     }
 
   /* Close the listerner socket */

--- a/netutils/netlib/netlib_setdripv4addr.c
+++ b/netutils/netlib/netlib_setdripv4addr.c
@@ -122,9 +122,9 @@ int netlib_set_dripv4addr(FAR const char *ifname,
               /* Delete the default route first */
               /* This call fails if no default route exists, but it's OK */
 
-              (void)delroute(sockfd,
-                             (FAR struct sockaddr_storage *)&target,
-                             (FAR struct sockaddr_storage *)&netmask);
+              delroute(sockfd,
+                       (FAR struct sockaddr_storage *)&target,
+                       (FAR struct sockaddr_storage *)&netmask);
 
               /* Then add the new default route */
 

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -495,7 +495,7 @@ static int ntpc_daemon(int argc, char **argv)
           sinfo("Waiting for %d seconds\n",
                 CONFIG_NETUTILS_NTPCLIENT_POLLDELAYSEC);
 
-          (void)sleep(CONFIG_NETUTILS_NTPCLIENT_POLLDELAYSEC);
+          sleep(CONFIG_NETUTILS_NTPCLIENT_POLLDELAYSEC);
         }
     }
 
@@ -565,7 +565,7 @@ int ntpc_start(void)
 
       do
         {
-          (void)sem_wait(&g_ntpc_daemon.interlock);
+          sem_wait(&g_ntpc_daemon.interlock);
         }
       while (g_ntpc_daemon.state == NTP_STARTED);
     }
@@ -618,7 +618,7 @@ int ntpc_stop(void)
 
           /* Wait for the NTP client to respond to the stop request */
 
-          (void)sem_wait(&g_ntpc_daemon.interlock);
+          sem_wait(&g_ntpc_daemon.interlock);
         }
       while (g_ntpc_daemon.state == NTP_STOP_REQUESTED);
     }

--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -394,7 +394,7 @@ void icmp_ping(FAR const struct ping_info_s *info)
           rqt.tv_sec  = sec;
           rqt.tv_nsec = frac * NSEC_PER_MSEC;
 
-          (void)nanosleep(&rqt, NULL);
+          nanosleep(&rqt, NULL);
         }
 
       outhdr.seqno = htons(++result.seqno);

--- a/netutils/ping/icmpv6_ping.c
+++ b/netutils/ping/icmpv6_ping.c
@@ -396,7 +396,7 @@ void icmp6_ping(FAR const struct ping6_info_s *info)
           rqt.tv_sec  = sec;
           rqt.tv_nsec = frac * NSEC_PER_MSEC;
 
-          (void)nanosleep(&rqt, NULL);
+          nanosleep(&rqt, NULL);
         }
 
       outhdr.seqno = htons(++result.seqno);

--- a/netutils/smtp/smtp.c
+++ b/netutils/smtp/smtp.c
@@ -362,7 +362,7 @@ void *smtp_open(void)
       /* Initialize the handle */
 
       memset(psmtp, 0, sizeof(struct smtp_state));
-     (void)sem_init(&psmtp->sem, 0, 0);
+     sem_init(&psmtp->sem, 0, 0);
     }
 
   return (void*)psmtp;

--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -346,9 +346,9 @@ static int telnetd_daemon(int argc, char *argv[])
 
       /* Use this driver as stdin, stdout, and stderror */
 
-      (void)dup2(drvrfd, 0);
-      (void)dup2(drvrfd, 1);
-      (void)dup2(drvrfd, 2);
+      dup2(drvrfd, 0);
+      dup2(drvrfd, 1);
+      dup2(drvrfd, 2);
 
       /* And we can close our original driver fd */
 

--- a/netutils/tftpc/tftpc_get.c
+++ b/netutils/tftpc/tftpc_get.c
@@ -87,7 +87,7 @@ static inline int tftp_parsedatapacket(FAR const uint8_t *packet,
 #ifdef CONFIG_DEBUG_NET_WARN
   else if (*opcode == TFTP_ERR)
     {
-      (void)tftp_parseerrpacket(packet);
+      tftp_parseerrpacket(packet);
     }
 #endif
 

--- a/netutils/tftpc/tftpc_put.c
+++ b/netutils/tftpc/tftpc_put.c
@@ -206,7 +206,7 @@ static int tftp_rcvack(int sd, FAR uint8_t *packet,
                   ninfo("Invalid port in DATA\n");
                   packetlen = tftp_mkerrpacket(packet, TFTP_ERR_UNKID,
                                                TFTP_ERRST_UNKID);
-                  (void)tftp_sendto(sd, packet, packetlen, server);
+                  tftp_sendto(sd, packet, packetlen, server);
                   continue;
                 }
 
@@ -226,7 +226,7 @@ static int tftp_rcvack(int sd, FAR uint8_t *packet,
 #ifdef CONFIG_DEBUG_NET_WARN
                   if (opcode == TFTP_ERR)
                     {
-                      (void)tftp_parseerrpacket(packet);
+                      tftp_parseerrpacket(packet);
                     }
                   else
 #endif
@@ -234,7 +234,7 @@ static int tftp_rcvack(int sd, FAR uint8_t *packet,
                     {
                       packetlen = tftp_mkerrpacket(packet, TFTP_ERR_ILLEGALOP,
                                                    TFTP_ERRST_ILLEGALOP);
-                      (void)tftp_sendto(sd, packet, packetlen, server);
+                      tftp_sendto(sd, packet, packetlen, server);
                     }
 
                   /* Break out an bump up the retry count */

--- a/netutils/thttpd/cgi-src/phf.c
+++ b/netutils/thttpd/cgi-src/phf.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 {
   fprintf(stderr, "phf CGI probe from %s\n", getenv("REMOTE_ADDR"));
 
-  (void)printf("\
+  printf("\
 Content-type: text/html\n\
 Status: 404/html\n\
 \n\

--- a/netutils/thttpd/cgi-src/redirect.c
+++ b/netutils/thttpd/cgi-src/redirect.c
@@ -100,7 +100,7 @@ static void internal_error(char *reason)
 {
   char *title = "500 Internal Error";
 
-  (void)printf("\
+  printf("\
 Status: %s\n\
 Content-type: text/html\n\
 \n\
@@ -117,7 +117,7 @@ static void not_found(char *script_name)
 {
   char *title = "404 Not Found";
 
-  (void)printf("\
+  printf("\
 Status: %s\n\
 Content-type: text/html\n\
 \n\
@@ -132,7 +132,7 @@ static void moved(char *script_name, char *url)
 {
   char *title = "Moved";
 
-  (void)printf("\
+  printf("\
 Location: %s\n\
 Content-type: text/html\n\
 \n\
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
           return 2;
         }
 
-      (void)sprintf(cp, "%s%s", script_name, path_info);
+      sprintf(cp, "%s%s", script_name, path_info);
       script_name = cp;
     }
 

--- a/netutils/thttpd/cgi-src/ssi.c
+++ b/netutils/thttpd/cgi-src/ssi.c
@@ -100,7 +100,7 @@ static void internal_error(char *reason)
 {
   char *title = "500 Internal Error";
 
-  (void)printf("\
+  printf("\
 <HTML><HEAD><TITLE>%s</TITLE></HEAD>\n\
 <BODY><H2>%s</H2>\n\
 Something unusual went wrong during a server-side-includes request:\n\
@@ -114,7 +114,7 @@ static void not_found(char *filename)
 {
   char *title = "404 Not Found";
 
-  (void)printf("\
+  printf("\
 <HTML><HEAD><TITLE>%s</TITLE></HEAD>\n\
 <BODY><H2>%s</H2>\n\
 The requested server-side-includes filename, %s,\n\
@@ -126,7 +126,7 @@ static void not_found2(char *directive, char *tag, char *filename)
 {
   char *title = "Not Found";
 
-  (void)printf("\
+  printf("\
 <HR><H2>%s</H2>\n\
 The filename requested in a %s %s directive, %s,\n\
 does not seem to exist.\n\
@@ -137,7 +137,7 @@ static void not_permitted(char *directive, char *tag, char *val)
 {
   char *title = "Not Permitted";
 
-  (void)printf("\
+  printf("\
 <HR><H2>%s</H2>\n\
 The filename requested in the %s %s=%s directive\n\
 may not be fetched.\n\
@@ -148,7 +148,7 @@ static void unknown_directive(char *filename, char *directive)
 {
   char *title = "Unknown Directive";
 
-  (void)printf("\
+  printf("\
 <HR><H2>%s</H2>\n\
 The requested server-side-includes filename, %s,\n\
 tried to use an unknown directive, %s.\n\
@@ -159,7 +159,7 @@ static void unknown_tag(char *filename, char *directive, char *tag)
 {
   char *title = "Unknown Tag";
 
-  (void)printf("\
+  printf("\
 <HR><H2>%s</H2>\n\
 The requested server-side-includes filename, %s,\n\
 tried to use the directive %s with an unknown tag, %s.\n\
@@ -170,7 +170,7 @@ static void unknown_value(char *filename, char *directive, char *tag, char *val)
 {
   char *title = "Unknown Value";
 
-  (void)printf("\
+  printf("\
 <HR><H2>%s</H2>\n\
 The requested server-side-includes filename, %s,\n\
 tried to use the directive %s %s with an unknown value, %s.\n\
@@ -214,8 +214,8 @@ static int get_filename(char *vfilename, char *filename,
           return -1;
         }
 
-      (void)strncpy(fn, filename, fl - vl);
-      (void)strcpy(&fn[fl - vl], val);
+      strncpy(fn, filename, fl - vl);
+      strcpy(&fn[fl - vl], val);
     }
   else if (strcmp(tag, "file") == 0)
     {
@@ -229,14 +229,14 @@ static int get_filename(char *vfilename, char *filename,
           return -1;
         }
 
-      (void)strcpy(fn, filename);
+      strcpy(fn, filename);
       cp = strrchr(fn, '/');
       if (cp == (char *)0)
         {
           cp = &fn[strlen(fn)];
           *cp = '/';
         }
-      (void)strcpy(++cp, val);
+      strcpy(++cp, val);
     }
   else
     {
@@ -309,7 +309,7 @@ static int check_filename(char *filename)
   cp = strrchr(dirname, '/');
   if (cp == (char *)0)
     {
-      (void)strcpy(dirname, ".");
+      strcpy(dirname, ".");
     }
   else
     {
@@ -325,7 +325,7 @@ static int check_filename(char *filename)
       return 0;
     }
 
-  (void)sprintf(authname, "%s/%s", dirname, CONFIG_AUTH_FILE);
+  sprintf(authname, "%s/%s", dirname, CONFIG_AUTH_FILE);
   r = stat(authname, &sb);
 
   free(dirname);
@@ -361,7 +361,7 @@ static void show_time(time_t t, int gmt)
 
   if (strftime(g_iobuffer2, BUFFER_SIZE, g_timeformat, tmP) > 0)
     {
-      (void)puts(g_iobuffer2);
+      puts(g_iobuffer2);
     }
 }
 
@@ -370,25 +370,25 @@ static void show_size(off_t size)
   switch (g_sizefmt)
     {
     case SF_BYTES:
-      (void)printf("%ld", (long)size);  /* spec says should have commas */
+      printf("%ld", (long)size);  /* spec says should have commas */
       break;
 
     case SF_ABBREV:
       if (size < 1024)
         {
-          (void)printf("%ld", (long)size);
+          printf("%ld", (long)size);
         }
       else if (size < 1024 * 1024)
         {
-          (void)printf("%ldK", (long)size / 1024L);
+          printf("%ldK", (long)size / 1024L);
         }
       else if (size < 1024 * 1024 * 1024)
         {
-          (void)printf("%ldM", (long)size / (1024L * 1024L));
+          printf("%ldM", (long)size / (1024L * 1024L));
         }
       else
         {
-          (void)printf("%ldG", (long)size / (1024L * 1024L * 1024L));
+          printf("%ldG", (long)size / (1024L * 1024L * 1024L));
         }
       break;
     }
@@ -409,7 +409,7 @@ static void do_config(FILE *instream, char *vfilename, char *filename,
 
   if (strcmp(tag, "g_timeformat") == 0)
     {
-      (void)strncpy(g_timeformat, val, TIMEFMT_SIZE - 1);
+      strncpy(g_timeformat, val, TIMEFMT_SIZE - 1);
       g_timeformat[TIMEFMT_SIZE - 1] = '\0';
     }
   else if (strcmp(tag, "g_sizefmt") == 0)
@@ -464,11 +464,11 @@ static void do_include(FILE *instream, char *vfilename, char *filename,
     {
       if (strlen(val) <BUFFER_SIZE)
         {
-          (void)strcpy(g_iobuffer2, val);
+          strcpy(g_iobuffer2, val);
         }
       else
         {
-          (void)strcpy(g_iobuffer2, g_iobuffer1);    /* same size, has to fit */
+          strcpy(g_iobuffer2, g_iobuffer1);    /* same size, has to fit */
         }
     }
   else
@@ -476,23 +476,23 @@ static void do_include(FILE *instream, char *vfilename, char *filename,
       if (strlen(vfilename) + 1 + strlen(val) < BUFFER_SIZE)
         {
           char *cp;
-          (void)strcpy(g_iobuffer2, vfilename);
+          strcpy(g_iobuffer2, vfilename);
           cp = strrchr(g_iobuffer2, '/');
           if (cp == (char *)0)
             {
               cp = &g_iobuffer2[strlen(g_iobuffer2)];
               *cp = '/';
             }
-          (void)strcpy(++cp, val);
+          strcpy(++cp, val);
         }
       else
         {
-          (void)strcpy(g_iobuffer2, g_iobuffer1);    /* same size, has to fit */
+          strcpy(g_iobuffer2, g_iobuffer1);    /* same size, has to fit */
         }
     }
 
   read_file(instream2, g_iobuffer2, g_iobuffer1);
-  (void)fclose(instream2);
+  fclose(instream2);
 }
 
 static void do_echo(FILE *instream, char *vfilename, char *filename,
@@ -515,13 +515,13 @@ static void do_echo(FILE *instream, char *vfilename, char *filename,
         {
           /* The current filename. */
 
-          (void)puts(filename);
+          puts(filename);
         }
       else if (strcmp(val, "DOCUMENT_URI") == 0)
         {
           /* The virtual path to this file (such as /~robm/foo.shtml). */
 
-          (void)puts(vfilename);
+          puts(vfilename);
         }
       else if (strcmp(val, "QUERY_STRING_UNESCAPED") == 0)
         {
@@ -530,7 +530,7 @@ static void do_echo(FILE *instream, char *vfilename, char *filename,
           cp = getenv("QUERY_STRING");
           if (cp != (char *)0)
             {
-              (void)puts(cp);
+              puts(cp);
             }
         }
       else if (strcmp(val, "DATE_LOCAL") == 0)
@@ -573,7 +573,7 @@ static void do_echo(FILE *instream, char *vfilename, char *filename,
             }
           else
             {
-              (void)puts(cp);
+              puts(cp);
             }
         }
     }
@@ -838,7 +838,7 @@ static void read_file(FILE *instream, char *vfilename, char *filename)
           else
             {
               state = ST_GROUND;
-              (void)puts("<!");
+              puts("<!");
             }
           break;
 
@@ -851,7 +851,7 @@ static void read_file(FILE *instream, char *vfilename, char *filename)
           else
             {
               state = ST_GROUND;
-              (void)puts("<!-");
+              puts("<!-");
             }
           break;
 
@@ -865,7 +865,7 @@ static void read_file(FILE *instream, char *vfilename, char *filename)
           else
             {
               state = ST_GROUND;
-              (void)puts("<!--");
+              puts("<!--");
             }
           break;
         }
@@ -892,12 +892,12 @@ int main(int argc, char *argv[])
 
   /* Default formats. */
 
-  (void)strcpy(g_timeformat, "%a %b %e %T %Z %Y");
+  strcpy(g_timeformat, "%a %b %e %T %Z %Y");
   g_sizefmt = SF_BYTES;
 
   /* The MIME type has to be text/html. */
 
-  (void)puts("Content-type: text/html\n\n");
+  puts("Content-type: text/html\n\n");
 
   /* Get the name that we were run as. */
 
@@ -922,7 +922,7 @@ int main(int argc, char *argv[])
       internal_error("Out of memory.");
       return 2;
     }
-  (void)sprintf(g_url, "%s%s", script_name, path_info);
+  sprintf(g_url, "%s%s", script_name, path_info);
 
   /* Get the name of the file to parse. */
 
@@ -955,7 +955,7 @@ int main(int argc, char *argv[])
 
   read_file(instream, path_info, path_translated);
 
-  (void)fclose(instream);
+  fclose(instream);
 
 errout_with_g_url:
   free(g_url);

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -252,7 +252,7 @@ static int initialize_listen_socket(httpd_sockaddr *saP)
   if (bind(listen_fd, (struct sockaddr*)saP, sockaddr_len(saP)) < 0)
     {
       nerr("ERROR: bind to %s failed: %d\n", httpd_ntoa(saP), errno);
-      (void)close(listen_fd);
+      close(listen_fd);
       return -1;
     }
 
@@ -262,14 +262,14 @@ static int initialize_listen_socket(httpd_sockaddr *saP)
   if (flags == -1)
     {
       nerr("ERROR: fcntl(F_GETFL) failed: %d\n", errno);
-      (void)close(listen_fd);
+      close(listen_fd);
       return -1;
     }
 
   if (fcntl(listen_fd, F_SETFL, flags | O_NDELAY) < 0)
     {
       nerr("ERROR: fcntl(O_NDELAY) failed: %d\n", errno);
-      (void)close(listen_fd);
+      close(listen_fd);
       return -1;
     }
 
@@ -278,7 +278,7 @@ static int initialize_listen_socket(httpd_sockaddr *saP)
   if (listen(listen_fd, CONFIG_THTTPD_LISTEN_BACKLOG) < 0)
     {
       nerr("ERROR: listen failed: %d\n", errno);
-      (void)close(listen_fd);
+      close(listen_fd);
       return -1;
     }
 
@@ -347,18 +347,18 @@ static void send_mime(httpd_conn *hc, int status, const char *title, const char 
           mod = now.tv_sec;
         }
 
-      (void)snprintf(fixed_type, sizeof(fixed_type), type, CONFIG_THTTPD_CHARSET);
-      (void)snprintf(buf, sizeof(buf), "%.20s %d %s\r\n", hc->protocol, status, title);
+      snprintf(fixed_type, sizeof(fixed_type), type, CONFIG_THTTPD_CHARSET);
+      snprintf(buf, sizeof(buf), "%.20s %d %s\r\n", hc->protocol, status, title);
       add_response(hc, buf);
-      (void)snprintf(buf, sizeof(buf), "Server: %s\r\n", "thttpd");
+      snprintf(buf, sizeof(buf), "Server: %s\r\n", "thttpd");
       add_response(hc, buf);
-      (void)snprintf(buf, sizeof(buf), "Content-Type: %s\r\n", fixed_type);
+      snprintf(buf, sizeof(buf), "Content-Type: %s\r\n", fixed_type);
       add_response(hc, buf);
-      (void)strftime(tmbuf, sizeof(tmbuf), rfc1123fmt, gmtime(&now.tv_sec));
-      (void)snprintf(buf, sizeof(buf), "Date: %s\r\n", tmbuf);
+      strftime(tmbuf, sizeof(tmbuf), rfc1123fmt, gmtime(&now.tv_sec));
+      snprintf(buf, sizeof(buf), "Date: %s\r\n", tmbuf);
       add_response(hc, buf);
-      (void)strftime(tmbuf, sizeof(tmbuf), rfc1123fmt, gmtime(&mod));
-      (void)snprintf(buf, sizeof(buf), "Last-Modified: %s\r\n", tmbuf);
+      strftime(tmbuf, sizeof(tmbuf), rfc1123fmt, gmtime(&mod));
+      snprintf(buf, sizeof(buf), "Last-Modified: %s\r\n", tmbuf);
       add_response(hc, buf);
       add_response(hc, "Accept-Ranges: bytes\r\n");
       add_response(hc, "Connection: close\r\n");
@@ -366,42 +366,42 @@ static void send_mime(httpd_conn *hc, int status, const char *title, const char 
       s100 = status / 100;
       if (s100 != 2 && s100 != 3)
         {
-          (void)snprintf(buf, sizeof(buf), "Cache-Control: no-cache,no-store\r\n");
+          snprintf(buf, sizeof(buf), "Cache-Control: no-cache,no-store\r\n");
           add_response(hc, buf);
         }
 
       if (encodings[0] != '\0')
         {
-          (void)snprintf(buf, sizeof(buf), "Content-Encoding: %s\r\n", encodings);
+          snprintf(buf, sizeof(buf), "Content-Encoding: %s\r\n", encodings);
           add_response(hc, buf);
         }
 
       if (partial_content)
         {
-          (void)snprintf(buf, sizeof(buf),"Content-Range: bytes %ld-%ld/%ld\r\n",
-                         (long)hc->range_start, (long)hc->range_end, (long)length);
+          snprintf(buf, sizeof(buf),"Content-Range: bytes %ld-%ld/%ld\r\n",
+                   (long)hc->range_start, (long)hc->range_end, (long)length);
           add_response(hc, buf);
-          (void)snprintf(buf, sizeof(buf),"Content-Length: %ld\r\n",
-                         (long)(hc->range_end - hc->range_start + 1));
+          snprintf(buf, sizeof(buf),"Content-Length: %ld\r\n",
+                   (long)(hc->range_end - hc->range_start + 1));
           add_response(hc, buf);
         }
       else if (length >= 0)
         {
-          (void)snprintf(buf, sizeof(buf), "Content-Length: %ld\r\n", (long)length);
+          snprintf(buf, sizeof(buf), "Content-Length: %ld\r\n", (long)length);
           add_response(hc, buf);
         }
 
 #ifdef CONFIG_THTTPD_P3P
-      (void)snprintf(buf, sizeof(buf), "P3P: %s\r\n", CONFIG_THTTPD_P3P);
+      snprintf(buf, sizeof(buf), "P3P: %s\r\n", CONFIG_THTTPD_P3P);
       add_response(hc, buf);
 #endif
 
 #ifdef CONFIG_THTTPD_MAXAGE
       expires = now + CONFIG_THTTPD_MAXAGE;
-      (void)strftime(expbuf, sizeof(expbuf), rfc1123fmt, gmtime(&expires));
-      (void)snprintf(buf, sizeof(buf),
-                     "Cache-Control: max-age=%d\r\nExpires: %s\r\n",
-                     CONFIG_THTTPD_MAXAGE, expbuf);
+      strftime(expbuf, sizeof(expbuf), rfc1123fmt, gmtime(&expires));
+      snprintf(buf, sizeof(buf),
+               "Cache-Control: max-age=%d\r\nExpires: %s\r\n",
+               CONFIG_THTTPD_MAXAGE, expbuf);
       add_response(hc, buf);
 #endif
 
@@ -424,7 +424,7 @@ static void send_response(httpd_conn *hc, int status, const char *title, const c
   send_mime(hc, status, title, "", extraheads, "text/html; charset=%s", (off_t)-1, (time_t)0);
   add_response(hc, html_html);
   add_response(hc, html_hdtitle);
-  (void)snprintf(buf, sizeof(buf), "%d %s", status, title);
+  snprintf(buf, sizeof(buf), "%d %s", status, title);
   add_response(hc, buf);
   add_response(hc, html_titlehd);
   add_response(hc, html_body);
@@ -433,7 +433,7 @@ static void send_response(httpd_conn *hc, int status, const char *title, const c
   add_response(hc, html_endhdr2);
 
   defang(arg, defanged, sizeof(defanged));
-  (void)snprintf(buf, sizeof(buf), form, defanged);
+  snprintf(buf, sizeof(buf), form, defanged);
   add_response(hc, buf);
 
   if (match("**MSIE**", hc->useragent))
@@ -514,7 +514,7 @@ static int send_err_file(httpd_conn *hc, int status, char *title, char *extrahea
       buf[nread] = '\0';
       add_response(hc, buf);
     }
-  (void)fclose(fp);
+  fclose(fp);
 
 #ifdef ERR_APPEND_SERVER_INFO
   send_response_tail(hc);
@@ -532,7 +532,7 @@ static void send_authenticate(httpd_conn *hc, char *realm)
   static char headstr[] = "WWW-Authenticate: Basic realm=\"";
 
   httpd_realloc_str(&header, &maxheader, sizeof(headstr) + strlen(realm) + 3);
-  (void)snprintf(header, maxheader, "%s%s\"\r\n", headstr, realm);
+  snprintf(header, maxheader, "%s%s\"\r\n", headstr, realm);
   httpd_send_err(hc, 401, err401title, header, err401form, hc->encodedurl);
 
   /* If the request was a POST then there might still be data to be read, so
@@ -698,7 +698,7 @@ static int auth_check2(httpd_conn *hc, char *dirname)
 
   httpd_realloc_str(&authpath, &maxauthpath,
                     strlen(dirname) + 1 + sizeof(CONFIG_THTTPD_AUTH_FILE));
-  (void)snprintf(authpath, maxauthpath, "%s/%s", dirname, CONFIG_THTTPD_AUTH_FILE);
+  snprintf(authpath, maxauthpath, "%s/%s", dirname, CONFIG_THTTPD_AUTH_FILE);
 
   /* Does this directory have an auth file? */
 
@@ -759,7 +759,7 @@ static int auth_check2(httpd_conn *hc, char *dirname)
 
           httpd_realloc_str(&hc->remoteuser, &hc->maxremoteuser,
                             strlen(authinfo));
-          (void)strcpy(hc->remoteuser, authinfo);
+          strcpy(hc->remoteuser, authinfo);
           return 1;
         }
       else
@@ -816,7 +816,7 @@ static int auth_check2(httpd_conn *hc, char *dirname)
         {
           /* Yes. */
 
-          (void)fclose(fp);
+          fclose(fp);
 
           /* So is the password right? */
 
@@ -825,17 +825,17 @@ static int auth_check2(httpd_conn *hc, char *dirname)
               /* Ok! */
 
               httpd_realloc_str(&hc->remoteuser, &hc->maxremoteuser, strlen(line));
-              (void)strcpy(hc->remoteuser, line);
+              strcpy(hc->remoteuser, line);
 
               /* And cache this user's info for next time. */
 
               httpd_realloc_str(&prevauthpath, &maxprevauthpath, strlen(authpath));
-              (void)strcpy(prevauthpath, authpath);
+              strcpy(prevauthpath, authpath);
               prevmtime = sb.st_mtime;
               httpd_realloc_str(&prevuser, &maxprevuser, strlen(authinfo));
-              (void)strcpy(prevuser, authinfo);
+              strcpy(prevuser, authinfo);
               httpd_realloc_str(&prevcryp, &maxprevcryp, strlen(cryp));
-              (void)strcpy(prevcryp, cryp);
+              strcpy(prevcryp, cryp);
               return 1;
             }
           else
@@ -850,7 +850,7 @@ static int auth_check2(httpd_conn *hc, char *dirname)
 
   /* Didn't find that user.  Access denied. */
 
-  (void)fclose(fp);
+  fclose(fp);
   send_authenticate(hc, dirname);
   return -1;
 }
@@ -873,16 +873,16 @@ static void send_dirredirect(httpd_conn *hc)
         }
 
       httpd_realloc_str(&location, &maxlocation, strlen(hc->encodedurl) + 2 + strlen(hc->query));
-      (void)snprintf(location, maxlocation, "%s/?%s", hc->encodedurl, hc->query);
+      snprintf(location, maxlocation, "%s/?%s", hc->encodedurl, hc->query);
     }
   else
     {
       httpd_realloc_str(&location, &maxlocation, strlen(hc->encodedurl) + 1);
-      (void)snprintf(location, maxlocation, "%s/", hc->encodedurl);
+      snprintf(location, maxlocation, "%s/", hc->encodedurl);
     }
 
   httpd_realloc_str(&header, &maxheader, sizeof(headstr) + strlen(location));
-  (void)snprintf(header, maxheader, "%s%s\r\n", headstr, location);
+  snprintf(header, maxheader, "%s%s\r\n", headstr, location);
   send_response(hc, 302, err302title, header, err302form, location);
 }
 
@@ -898,17 +898,17 @@ static int httpd_tilde_map1(httpd_conn *hc)
 
   len = strlen(hc->expnfilename) - 1;
   httpd_realloc_str(&temp, &maxtemp, len);
-  (void)strcpy(temp, &hc->expnfilename[1]);
+  strcpy(temp, &hc->expnfilename[1]);
 
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename, strlen(prefix) + 1 + len);
-  (void)strcpy(hc->expnfilename, prefix);
+  strcpy(hc->expnfilename, prefix);
 
   if (prefix[0] != '\0')
     {
-      (void)strcat(hc->expnfilename, "/");
+      strcat(hc->expnfilename, "/");
     }
 
-  (void)strcat(hc->expnfilename, temp);
+  strcat(hc->expnfilename, temp);
   return 1;
 }
 #endif /* CONFIG_THTTPD_TILDE_MAP1 */
@@ -929,7 +929,7 @@ static int httpd_tilde_map2(httpd_conn *hc)
   /* Get the username. */
 
   httpd_realloc_str(&temp, &maxtemp, strlen(hc->expnfilename) - 1);
-  (void)strcpy(temp, &hc->expnfilename[1]);
+  strcpy(temp, &hc->expnfilename[1]);
 
   cp = strchr(temp, '/');
   if (cp)
@@ -952,11 +952,11 @@ static int httpd_tilde_map2(httpd_conn *hc)
   /* Set up altdir. */
 
   httpd_realloc_str(&hc->altdir, &hc->maxaltdir, strlen(pw->pw_dir) + 1 + strlen(postfix));
-  (void)strcpy(hc->altdir, pw->pw_dir);
+  strcpy(hc->altdir, pw->pw_dir);
   if (postfix[0] != '\0')
     {
-      (void)strcat(hc->altdir, "/");
-      (void)strcat(hc->altdir, postfix);
+      strcat(hc->altdir, "/");
+      strcat(hc->altdir, postfix);
     }
 
   alt = expand_filename(hc->altdir, &rest, true);
@@ -966,12 +966,12 @@ static int httpd_tilde_map2(httpd_conn *hc)
     }
 
   httpd_realloc_str(&hc->altdir, &hc->maxaltdir, strlen(alt));
-  (void)strcpy(hc->altdir, alt);
+  strcpy(hc->altdir, alt);
 
   /* And the filename becomes altdir plus the post-~ part of the original. */
 
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename, strlen(hc->altdir) + 1 + strlen(cp));
-  (void)snprintf(hc->expnfilename, hc->maxexpnfilename, "%s/%s", hc->altdir, cp);
+  snprintf(hc->expnfilename, hc->maxexpnfilename, "%s/%s", hc->altdir, cp);
 
   /* For this type of tilde mapping, we want to defeat vhost mapping. */
 
@@ -1075,12 +1075,12 @@ static int vhost_map(httpd_conn *hc)
 
       *cp2++ = '/';
     }
-  (void)strcpy(cp2, hc->vhostname);
+  strcpy(cp2, hc->vhostname);
 
 #else /* VHOST_DIRLEVELS */
 
   httpd_realloc_str(&hc->hostdir, &hc->maxhostdir, strlen(hc->vhostname));
-  (void)strcpy(hc->hostdir, hc->vhostname);
+  strcpy(hc->hostdir, hc->vhostname);
 
 #endif /* VHOST_DIRLEVELS */
 
@@ -1088,11 +1088,11 @@ static int vhost_map(httpd_conn *hc)
 
   len = strlen(hc->expnfilename);
   httpd_realloc_str(&tempfilename, &maxtempfilename, len);
-  (void)strcpy(tempfilename, hc->expnfilename);
+  strcpy(tempfilename, hc->expnfilename);
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename, strlen(hc->hostdir) + 1 + len);
-  (void)strcpy(hc->expnfilename, hc->hostdir);
-  (void)strcat(hc->expnfilename, "/");
-  (void)strcat(hc->expnfilename, tempfilename);
+  strcpy(hc->expnfilename, hc->hostdir);
+  strcat(hc->expnfilename, "/");
+  strcat(hc->expnfilename, tempfilename);
   return 1;
 }
 #endif
@@ -1129,7 +1129,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
     {
       checkedlen = strlen(path);
       httpd_realloc_str(&checked, &maxchecked, checkedlen);
-      (void)strcpy(checked, path);
+      strcpy(checked, path);
 
       /* Trim trailing slashes. */
 
@@ -1186,7 +1186,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
 
   restlen = strlen(path);
   httpd_realloc_str(&rest, &maxrest, restlen+1);
-  (void)strcpy(rest, path);
+  strcpy(rest, path);
 
   /* trim trailing slash */
 
@@ -1212,7 +1212,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
               /* Special case for absolute paths. */
 
               httpd_realloc_str(&checked, &maxchecked, checkedlen + 1);
-              (void)strncpy(&checked[checkedlen], r, 1);
+              strncpy(&checked[checkedlen], r, 1);
               checkedlen += 1;
             }
           else if (strncmp(r, "..", MAX(i, 2)) == 0)
@@ -1244,7 +1244,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
                   checked[checkedlen++] = '/';
                 }
 
-              (void)strncpy(&checked[checkedlen], r, i);
+              strncpy(&checked[checkedlen], r, i);
               checkedlen += i;
             }
 
@@ -1287,7 +1287,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
                   checked[checkedlen++] = '/';
                 }
 
-              (void)strcpy(&checked[checkedlen], r);
+              strcpy(&checked[checkedlen], r);
               checkedlen += restlen;
             }
 
@@ -1301,7 +1301,7 @@ static char *expand_filename(char *path, char **restP, bool tildemapped)
   *restP = r;
   if (checked[0] == '\0')
     {
-      (void)strcpy(checked, httpd_root);
+      strcpy(checked, httpd_root);
     }
 
   ninfo("checked: \"%s\"\n", checked);
@@ -1347,19 +1347,19 @@ static void de_dotdot(char *file)
           continue;
         }
 
-      (void)strcpy(cp + 1, cp2);
+      strcpy(cp + 1, cp2);
     }
 
   /* Remove leading ./ and any /./ sequences. */
 
   while (strncmp(file, "./", 2) == 0)
     {
-      (void)strcpy(file, file + 2);
+      strcpy(file, file + 2);
     }
 
   while ((cp = strstr(file, "/./")) != NULL)
     {
-    (void)strcpy(cp, cp + 2);
+    strcpy(cp, cp + 2);
     }
 
   /* Alternate between removing leading ../ and removing xxx/../ */
@@ -1368,7 +1368,7 @@ static void de_dotdot(char *file)
     {
       while (strncmp(file, "../", 3) == 0)
         {
-          (void)strcpy(file, file + 3);
+          strcpy(file, file + 3);
         }
 
       cp = strstr(file, "/../");
@@ -1382,7 +1382,7 @@ static void de_dotdot(char *file)
           continue;
         }
 
-      (void)strcpy(cp2 + 1, cp + 4);
+      strcpy(cp2 + 1, cp + 4);
     }
 
   /* Also elide any xxx/.. at the end. */
@@ -1528,11 +1528,11 @@ done:
                         encodings_len + enc_tab[me_indexes[i]].val_len + 1);
       if (hc->encodings[0] != '\0')
         {
-          (void)strcpy(&hc->encodings[encodings_len], ",");
+          strcpy(&hc->encodings[encodings_len], ",");
           ++encodings_len;
         }
 
-      (void)strcpy(&hc->encodings[encodings_len], enc_tab[me_indexes[i]].val);
+      strcpy(&hc->encodings[encodings_len], enc_tab[me_indexes[i]].val);
       encodings_len += enc_tab[me_indexes[i]].val_len;
     }
 }
@@ -1600,11 +1600,11 @@ static void ls_child(int argc, char **argv)
 
   fputs(html_html, fp);
   fputs(html_hdtitle, fp);
-  (void)fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
+  fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
   fputs(html_titlehd, fp);
   fputs(html_body, fp);
   fputs(html_hdr2, fp);
-  (void)fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
+  fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
   fputs(html_endhdr2, fp);
   fputs(html_crlf, fp);
   fputs("<PRE>\r\nmode  links  bytes  last-changed  name\r\n<HR>", fp);
@@ -1643,7 +1643,7 @@ static void ls_child(int argc, char **argv)
         }
 
       namlen = NAMLEN(de);
-      (void)strncpy(nameptrs[nnames], de->d_name, namlen);
+      strncpy(nameptrs[nnames], de->d_name, namlen);
       nameptrs[nnames][namlen] = '\0';
       ++nnames;
     }
@@ -1667,19 +1667,19 @@ static void ls_child(int argc, char **argv)
 
       if (hc->expnfilename[0] == '\0' || strcmp(hc->expnfilename, ".") == 0)
         {
-          (void)strcpy(name, nameptrs[i]);
-          (void)strcpy(rname, nameptrs[i]);
+          strcpy(name, nameptrs[i]);
+          strcpy(rname, nameptrs[i]);
         }
       else
         {
-          (void)snprintf(name, maxname, "%s/%s", hc->expnfilename, nameptrs[i]);
+          snprintf(name, maxname, "%s/%s", hc->expnfilename, nameptrs[i]);
           if (strcmp(hc->origfilename, ".") == 0)
             {
-              (void)snprintf(rname, maxrname, "%s", nameptrs[i]);
+              snprintf(rname, maxrname, "%s", nameptrs[i]);
             }
           else
             {
-              (void)snprintf(rname, maxrname, "%s%s", hc->origfilename, nameptrs[i]);
+              snprintf(rname, maxrname, "%s%s", hc->origfilename, nameptrs[i]);
             }
         }
 
@@ -1792,17 +1792,17 @@ static void ls_child(int argc, char **argv)
 
       /* And print. */
 
-      (void)fprintf(fp,
-                    "%s %3ld  %10lld  %s  <A HREF=\"/%.500s%s\">%s</A>%s%s%s\n",
-                    modestr, 0, (int16_t)sb.st_size, timestr, encrname,
-                    S_ISDIR(sb.st_mode) ? "/" : "", nameptrs[i], linkprefix,
-                    link, fileclass);
+      fprintf(fp,
+              "%s %3ld  %10lld  %s  <A HREF=\"/%.500s%s\">%s</A>%s%s%s\n",
+              modestr, 0, (int16_t)sb.st_size, timestr, encrname,
+              S_ISDIR(sb.st_mode) ? "/" : "", nameptrs[i], linkprefix,
+              link, fileclass);
     }
 
   fputs("</PRE>", fp);
   fputs(html_endbody, fp);
   fputs(html_endhtml, fp);
-  (void)fclose(fp);
+  fclose(fp);
   exit(0);
 }
 
@@ -2142,7 +2142,7 @@ void httpd_unlisten(httpd_server * hs)
 {
   if (hs->listen_fd != -1)
     {
-      (void)close(hs->listen_fd);
+      close(hs->listen_fd);
       hs->listen_fd = -1;
     }
 }
@@ -2162,7 +2162,7 @@ void httpd_write_response(httpd_conn *hc)
 
   if (hc->buflen > 0)
     {
-      (void)httpd_write(hc->conn_fd, hc->buffer, hc->buflen);
+      httpd_write(hc->conn_fd, hc->buffer, hc->buflen);
       hc->buflen = 0;
     }
 }
@@ -2178,7 +2178,7 @@ void httpd_set_ndelay(int fd)
     {
       newflags = flags | (int)O_NDELAY;
       if (newflags != flags)
-        (void)fcntl(fd, F_SETFL, newflags);
+        fcntl(fd, F_SETFL, newflags);
     }
 }
 
@@ -2194,7 +2194,7 @@ void httpd_clear_ndelay(int fd)
       newflags = flags & ~(int)O_NDELAY;
       if (newflags != flags)
         {
-          (void)fcntl(fd, F_SETFL, newflags);
+          fcntl(fd, F_SETFL, newflags);
         }
     }
 }
@@ -2212,8 +2212,8 @@ void httpd_send_err(httpd_conn *hc, int status, const char *title, const char *e
 #ifdef CONFIG_THTTPD_VHOST
   if (hc->hostdir[0] != '\0')
     {
-      (void)snprintf(filename, sizeof(filename),
-                     "%s/%s/err%d.html", hc->hostdir, CONFIG_THTTPD_ERROR_DIRECTORY, status);
+      snprintf(filename, sizeof(filename),
+               "%s/%s/err%d.html", hc->hostdir, CONFIG_THTTPD_ERROR_DIRECTORY, status);
       if (send_err_file(hc, status, title, extraheads, filename))
         {
           ninfo("Sent VHOST error file\n");
@@ -2224,7 +2224,7 @@ void httpd_send_err(httpd_conn *hc, int status, const char *title, const char *e
 
   /* Try server-wide error page. */
 
-  (void)snprintf(filename, sizeof(filename), "%s/err%d.html", CONFIG_THTTPD_ERROR_DIRECTORY, status);
+  snprintf(filename, sizeof(filename), "%s/err%d.html", CONFIG_THTTPD_ERROR_DIRECTORY, status);
   if (send_err_file(hc, status, title, extraheads, filename))
     {
       ninfo("Sent server-wide error page\n");
@@ -2321,8 +2321,8 @@ int httpd_get_conn(httpd_server *hs, int listen_fd, httpd_conn *hc)
 #endif
 
   hc->hs = hs;
-  (void)memset(&hc->client_addr, 0, sizeof(hc->client_addr));
-  (void)memmove(&hc->client_addr, &sa, sockaddr_len(&sa));
+  memset(&hc->client_addr, 0, sizeof(hc->client_addr));
+  memmove(&hc->client_addr, &sa, sockaddr_len(&sa));
   hc->read_idx          = 0;
   hc->checked_idx       = 0;
   hc->checked_state     = CHST_FIRSTWORD;
@@ -2671,7 +2671,7 @@ int httpd_parse_request(httpd_conn *hc)
         }
 
       httpd_realloc_str(&hc->reqhost, &hc->maxreqhost, strlen(reqhost));
-      (void)strcpy(hc->reqhost, reqhost);
+      strcpy(hc->reqhost, reqhost);
       *url = '/';
     }
 
@@ -2706,13 +2706,13 @@ int httpd_parse_request(httpd_conn *hc)
   httpd_strdecode(hc->decodedurl, hc->encodedurl);
 
   httpd_realloc_str(&hc->origfilename, &hc->maxorigfilename, strlen(hc->decodedurl));
-  (void)strcpy(hc->origfilename, &hc->decodedurl[1]);
+  strcpy(hc->origfilename, &hc->decodedurl[1]);
 
   /* Special case for top-level URL. */
 
   if (hc->origfilename[0] == '\0')
     {
-      (void)strcpy(hc->origfilename, ".");
+      strcpy(hc->origfilename, ".");
     }
 
   /* Extract query string from encoded URL. */
@@ -2722,7 +2722,7 @@ int httpd_parse_request(httpd_conn *hc)
     {
       ++cp;
       httpd_realloc_str(&hc->query, &hc->maxquery, strlen(cp));
-      (void)strcpy(hc->query, cp);
+      strcpy(hc->query, cp);
 
       /* Remove query from (decoded) origfilename. */
 
@@ -2796,13 +2796,13 @@ int httpd_parse_request(httpd_conn *hc)
                       continue;
                     }
                   httpd_realloc_str(&hc->accept, &hc->maxaccept, strlen(hc->accept) + 2 + strlen(cp));
-                  (void)strcat(hc->accept, ", ");
+                  strcat(hc->accept, ", ");
                 }
               else
                 {
                   httpd_realloc_str(&hc->accept, &hc->maxaccept, strlen(cp));
                 }
-              (void)strcat(hc->accept, cp);
+              strcat(hc->accept, cp);
             }
           else if (strncasecmp(buf, "Accept-Encoding:", 16) == 0)
             {
@@ -2817,13 +2817,13 @@ int httpd_parse_request(httpd_conn *hc)
                       continue;
                     }
                   httpd_realloc_str(&hc->accepte, &hc->maxaccepte, strlen(hc->accepte) + 2 + strlen(cp));
-                  (void)strcat(hc->accepte, ", ");
+                  strcat(hc->accepte, ", ");
                 }
               else
                 {
                   httpd_realloc_str(&hc->accepte, &hc->maxaccepte, strlen(cp));
                 }
-             (void)strcpy(hc->accepte, cp);
+             strcpy(hc->accepte, cp);
             }
           else if (strncasecmp(buf, "Accept-Language:", 16) == 0)
             {
@@ -2983,7 +2983,7 @@ int httpd_parse_request(httpd_conn *hc)
 
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename,
                     strlen(hc->origfilename));
-  (void)strcpy(hc->expnfilename, hc->origfilename);
+  strcpy(hc->expnfilename, hc->origfilename);
 
   /* Tilde mapping. */
 
@@ -3027,9 +3027,9 @@ int httpd_parse_request(httpd_conn *hc)
     }
 
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename, strlen(cp));
-  (void)strcpy(hc->expnfilename, cp);
+  strcpy(hc->expnfilename, cp);
   httpd_realloc_str(&hc->pathinfo, &hc->maxpathinfo, strlen(pi));
-  (void)strcpy(hc->pathinfo, pi);
+  strcpy(hc->pathinfo, pi);
   ninfo("expnfilename: \"%s\" pathinfo: \"%s\"\n", hc->expnfilename, hc->pathinfo);
 
   /* Remove pathinfo stuff from the original filename too. */
@@ -3080,13 +3080,13 @@ void httpd_close_conn(httpd_conn *hc)
 {
   if (hc->file_fd >= 0)
     {
-      (void)close(hc->file_fd);
+      close(hc->file_fd);
       hc->file_fd = -1;
     }
 
   if (hc->conn_fd >= 0)
     {
-      (void)close(hc->conn_fd);
+      close(hc->conn_fd);
       hc->conn_fd = -1;
     }
 }
@@ -3197,11 +3197,11 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowP)
         {
           httpd_realloc_str(&indexname, &maxindexname,
                             expnlen + 1 + strlen(index_names[i]));
-          (void)strcpy(indexname, hc->expnfilename);
+          strcpy(indexname, hc->expnfilename);
           indxlen = strlen(indexname);
           if (indxlen == 0 || indexname[indxlen - 1] != '/')
             {
-              (void)strcat(indexname, "/");
+              strcat(indexname, "/");
             }
 
           if (strcmp(indexname, "./") == 0)
@@ -3209,7 +3209,7 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowP)
               indexname[0] = '\0';
             }
 
-          (void)strcat(indexname, index_names[i]);
+          strcat(indexname, index_names[i]);
           if (stat(indexname, &hc->sb) >= 0)
             {
               goto got_one;
@@ -3278,7 +3278,7 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowP)
 
       expnlen = strlen(cp);
       httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename, expnlen);
-      (void)strcpy(hc->expnfilename, cp);
+      strcpy(hc->expnfilename, cp);
 
       /* Now, is the index version world-readable or world-executable? */
 
@@ -3298,11 +3298,11 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowP)
 
 #ifdef CONFIG_THTTPD_AUTH_FILE
   httpd_realloc_str(&dirname, &maxdirname, expnlen);
-  (void)strcpy(dirname, hc->expnfilename);
+  strcpy(dirname, hc->expnfilename);
   cp = strrchr(dirname, '/');
   if (!cp)
     {
-      (void)strcpy(dirname, httpd_root);
+      strcpy(dirname, httpd_root);
     }
   else
     {
@@ -3439,7 +3439,7 @@ char *httpd_ntoa(httpd_sockaddr *saP)
     {
       /* Elide IPv6ish prefix for IPv4 addresses. */
 
-      (void)strcpy(str, &str[7]);
+      strcpy(str, &str[7]);
     }
 
   return str;

--- a/netutils/thttpd/tdate_parse.c
+++ b/netutils/thttpd/tdate_parse.c
@@ -139,8 +139,8 @@ static int scan_wday(char *str_wday, long *tm_wdayP)
 
   if (!sorted)
     {
-      (void)qsort(wday_tab, sizeof(wday_tab) / sizeof(struct strlong),
-                  sizeof(struct strlong), strlong_compare);
+      qsort(wday_tab, sizeof(wday_tab) / sizeof(struct strlong),
+            sizeof(struct strlong), strlong_compare);
       sorted = 1;
     }
   pound_case(str_wday);
@@ -170,8 +170,8 @@ static int scan_mon(char *str_mon, long *tm_monP)
 
   if (!sorted)
     {
-      (void)qsort(mon_tab, sizeof(mon_tab) / sizeof(struct strlong),
-                  sizeof(struct strlong), strlong_compare);
+      qsort(mon_tab, sizeof(mon_tab) / sizeof(struct strlong),
+            sizeof(struct strlong), strlong_compare);
       sorted = 1;
     }
   pound_case(str_mon);
@@ -204,7 +204,7 @@ time_t tdate_parse(char *str)
 
   /* Initialize. */
 
-  (void)memset((char *)&tm, 0, sizeof(struct tm));
+  memset((char *)&tm, 0, sizeof(struct tm));
 
   /* Skip initial whitespace ourselves - sscanf is clumsy at this. */
 

--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -759,7 +759,7 @@ int thttpd_main(int argc, char **argv)
   /* Main loop */
 
   ninfo("Entering the main loop\n");
-  (void)gettimeofday(&tv, NULL);
+  gettimeofday(&tv, NULL);
   for (;;)
     {
       /* Do the fd watch */
@@ -778,7 +778,7 @@ int thttpd_main(int argc, char **argv)
           exit(1);
         }
 
-      (void)gettimeofday(&tv, NULL);
+      gettimeofday(&tv, NULL);
 
       if (num_ready == 0)
         {

--- a/netutils/thttpd/thttpd_alloc.c
+++ b/netutils/thttpd/thttpd_alloc.c
@@ -90,7 +90,7 @@ void httpd_memstats(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   mm = mallinfo();
 #else
-  (void)mallinfo(&mm);
+  mallinfo(&mm);
 #endif
   ninfo("arena: %08x ordblks: %08x mxordblk: %08x uordblks: %08x fordblks: %08x\n",
        mm.arena, mm.ordblks, mm.mxordblk, mm.uordblks, mm.fordblks);

--- a/netutils/thttpd/thttpd_cgi.c
+++ b/netutils/thttpd/thttpd_cgi.c
@@ -199,7 +199,7 @@ static void create_environment(httpd_conn *hc)
   setenv("GATEWAY_INTERFACE", "CGI/1.1", TRUE);
   setenv("SERVER_PROTOCOL", hc->protocol, TRUE);
 
-  (void)snprintf(buf, sizeof(buf), "%d", (int)CONFIG_THTTPD_PORT);
+  snprintf(buf, sizeof(buf), "%d", (int)CONFIG_THTTPD_PORT);
   setenv("SERVER_PORT", buf, TRUE);
 
   setenv("REQUEST_METHOD", httpd_method_str(hc->method), TRUE);
@@ -209,19 +209,19 @@ static void create_environment(httpd_conn *hc)
       char *cp2;
       size_t l;
 
-      (void)snprintf(buf, sizeof(buf), "/%s", hc->pathinfo);
+      snprintf(buf, sizeof(buf), "/%s", hc->pathinfo);
       setenv("PATH_INFO", buf, TRUE);
 
       l = strlen(httpd_root) + strlen(hc->pathinfo) + 1;
       cp2 = NEW(char, l);
       if (cp2)
         {
-          (void)snprintf(cp2, l, "%s%s", httpd_root, hc->pathinfo);
+          snprintf(cp2, l, "%s%s", httpd_root, hc->pathinfo);
           setenv("PATH_TRANSLATED", cp2, TRUE);
         }
     }
 
-  (void)snprintf(buf, sizeof(buf), "/%s",strcmp(hc->origfilename, ".") == 0 ? "" : hc->origfilename);
+  snprintf(buf, sizeof(buf), "/%s",strcmp(hc->origfilename, ".") == 0 ? "" : hc->origfilename);
   setenv("SCRIPT_NAME", buf, TRUE);
 
   if (hc->query[0] != '\0')
@@ -272,7 +272,7 @@ static void create_environment(httpd_conn *hc)
 
   if (hc->contentlength != -1)
     {
-      (void)snprintf(buf, sizeof(buf), "%lu", (unsigned long)hc->contentlength);
+      snprintf(buf, sizeof(buf), "%lu", (unsigned long)hc->contentlength);
       setenv("CONTENT_LENGTH", buf, TRUE);
     }
 
@@ -417,7 +417,7 @@ static inline int cgi_interpose_input(struct cgi_conn_s *cc)
 
       /* And read up to 2 bytes. */
 
-      (void)read(cc->connfd, cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE);
+      read(cc->connfd, cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE);
       return 1;
     }
   return 0;
@@ -494,7 +494,7 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
               /* Accumulate more header data */
 
               httpd_realloc_str(&cc->outbuf.buffer, &cc->outbuf.size, cc->outbuf.len + nbytes_read);
-              (void)memcpy(&(cc->outbuf.buffer[cc->outbuf.len]), cc->inbuf.buffer, nbytes_read);
+              memcpy(&(cc->outbuf.buffer[cc->outbuf.len]), cc->inbuf.buffer, nbytes_read);
               cc->outbuf.len                   += nbytes_read;
               cc->outbuf.buffer[cc->outbuf.len] = '\0';
               ninfo("Header bytes accumulated: %d\n", cc->outbuf.len);
@@ -616,12 +616,12 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
               break;
             }
 
-          (void)snprintf(cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE, "HTTP/1.0 %d %s\r\n", status, title);
-          (void)httpd_write(cc->connfd, cc->inbuf.buffer, strlen(cc->inbuf.buffer));
+          snprintf(cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE, "HTTP/1.0 %d %s\r\n", status, title);
+          httpd_write(cc->connfd, cc->inbuf.buffer, strlen(cc->inbuf.buffer));
 
           /* Write the saved cc->outbuf.buffer to the client. */
 
-          (void)httpd_write(cc->connfd, cc->outbuf.buffer, cc->outbuf.len);
+          httpd_write(cc->connfd, cc->outbuf.buffer, cc->outbuf.len);
         }
 
         /* Then set up to read the data following the header from the CGI program and
@@ -675,7 +675,7 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
             {
                /* Forward the data from the CGI program to the client */
 
-             (void)httpd_write(cc->connfd, cc->inbuf.buffer, nbytes_read);
+             httpd_write(cc->connfd, cc->inbuf.buffer, nbytes_read);
             }
         }
         break;
@@ -831,7 +831,7 @@ static int cgi_child(int argc, char **argv)
       directory = dirname(dupname);
       if (directory)
         {
-          (void)chdir(directory); /* ignore errors */
+          chdir(directory); /* ignore errors */
         }
 
       httpd_free(dupname);
@@ -913,7 +913,7 @@ static int cgi_child(int argc, char **argv)
   cgi_semgive();  /* Not safe to reference hc after this point */
   do
     {
-      (void)fdwatch(fw, 1000);
+      fdwatch(fw, 1000);
 
       /* Check for incoming data from the remote client to the CGI task */
 

--- a/netutils/thttpd/thttpd_strings.c
+++ b/netutils/thttpd/thttpd_strings.c
@@ -168,7 +168,7 @@ void httpd_strencode(char *to, int tosize, char *from)
         }
       else
         {
-          (void)sprintf(to, "%%%02x", (int)*from & 0xff);
+          sprintf(to, "%%%02x", (int)*from & 0xff);
           to += 3;
           tolen += 3;
         }

--- a/netutils/thttpd/timers.c
+++ b/netutils/thttpd/timers.c
@@ -217,7 +217,7 @@ Timer *tmr_create(struct timeval *now, TimerProc *timer_proc,
     }
   else
     {
-      (void)gettimeofday(&tmr->time, NULL);
+      gettimeofday(&tmr->time, NULL);
     }
 
   tmr->time.tv_sec  += msecs / 1000L;

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -347,9 +347,9 @@ static inline int wget_parseheaders(struct wget_s *ws)
                    * retain the current location.
                    */
 
-                  (void)netlib_parsehttpurl(ws->line + strlen(g_httplocation), &ws->port,
-                                         ws->hostname, CONFIG_WEBCLIENT_MAXHOSTNAME,
-                                         ws->filename, CONFIG_WEBCLIENT_MAXFILENAME);
+                  netlib_parsehttpurl(ws->line + strlen(g_httplocation), &ws->port,
+                                      ws->hostname, CONFIG_WEBCLIENT_MAXHOSTNAME,
+                                      ws->filename, CONFIG_WEBCLIENT_MAXFILENAME);
                   ninfo("New hostname='%s' filename='%s'\n", ws->hostname, ws->filename);
                 }
             }
@@ -503,10 +503,10 @@ static int wget_base(FAR const char *url, FAR char *buffer, int buflen,
       tv.tv_sec  = CONFIG_WEBCLIENT_TIMEOUT;
       tv.tv_usec = 0;
 
-      (void)setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv,
-                       sizeof(struct timeval));
-      (void)setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (FAR const void *)&tv,
-                       sizeof(struct timeval));
+      setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv,
+                 sizeof(struct timeval));
+      setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (FAR const void *)&tv,
+                 sizeof(struct timeval));
 
       /* Get the server address from the host name */
 

--- a/netutils/webserver/httpd.c
+++ b/netutils/webserver/httpd.c
@@ -167,9 +167,9 @@ static int httpd_openindex(struct httpd_state *pstate)
 #  if defined(CONFIG_NETUTILS_HTTPD_INDEX)
   if (ret == ERROR && errno == EISDIR)
     {
-      (void) snprintf(pstate->ht_filename + z,
-                      sizeof pstate->ht_filename - z, "/%s",
-                      CONFIG_NETUTILS_HTTPD_INDEX);
+      snprintf(pstate->ht_filename + z,
+               sizeof pstate->ht_filename - z, "/%s",
+               CONFIG_NETUTILS_HTTPD_INDEX);
 
       ret = httpd_open(pstate->ht_filename, &pstate->ht_file);
     }
@@ -341,7 +341,7 @@ static int handle_script(struct httpd_state *pstate)
               DEBUGASSERT(status >= 0);
               UNUSED(status);
 
-              (void)httpd_close(&pstate->ht_file);
+              httpd_close(&pstate->ht_file);
             }
           else
             {
@@ -521,8 +521,8 @@ static int send_headers(struct httpd_state *pstate, int status, int len)
 
   if (len >= 0)
     {
-      (void)snprintf(contentlen, HTTPD_MAX_CONTENTLEN,
-                     "Content-Length: %d\r\n", len);
+      snprintf(contentlen, HTTPD_MAX_CONTENTLEN,
+               "Content-Length: %d\r\n", len);
     }
   else
     {
@@ -534,8 +534,8 @@ static int send_headers(struct httpd_state *pstate, int status, int len)
 #if defined(CONFIG_NETUTILS_HTTPD_ENABLE_CHUNKED_ENCODING)
       /* Turn on chunked encoding */
 
-      (void)snprintf(contentlen, HTTPD_MAX_CONTENTLEN,
-                     "Transfer-Encoding: chunked\r\n");
+      snprintf(contentlen, HTTPD_MAX_CONTENTLEN,
+               "Transfer-Encoding: chunked\r\n");
       pstate->ht_chunked = true;
 #endif
     }
@@ -593,9 +593,8 @@ static int httpd_senderror(struct httpd_state *pstate, int status)
     }
 #endif
 
-  (void) snprintf(pstate->ht_filename, sizeof pstate->ht_filename,
-    "%s/%d.html",
-    CONFIG_NETUTILS_HTTPD_ERRPATH, status);
+  snprintf(pstate->ht_filename, sizeof pstate->ht_filename,
+           "%s/%d.html", CONFIG_NETUTILS_HTTPD_ERRPATH, status);
 
   ret = httpd_openindex(pstate);
 
@@ -607,7 +606,7 @@ static int httpd_senderror(struct httpd_state *pstate, int status)
 
   if (ret != OK)
     {
-      (void) snprintf(msg, sizeof msg, "Error %d\n", status);
+      snprintf(msg, sizeof msg, "Error %d\n", status);
 
       ret = send_chunk(pstate, msg, sizeof msg - 1);
     }
@@ -621,7 +620,7 @@ static int httpd_senderror(struct httpd_state *pstate, int status)
 #endif
 #endif
 
-      (void)httpd_close(&pstate->ht_file);
+      httpd_close(&pstate->ht_file);
     }
 
   return ret;
@@ -702,7 +701,7 @@ static int httpd_sendfile(struct httpd_state *pstate)
 #endif
 
 done:
-  (void)httpd_close(&pstate->ht_file);
+  httpd_close(&pstate->ht_file);
   return ret;
 }
 
@@ -812,7 +811,7 @@ static inline int httpd_parse(struct httpd_state *pstate)
               }
 
             *v = '\0';
-            (void) strcpy(pstate->ht_filename, start);
+            strcpy(pstate->ht_filename, start);
             state = STATE_HEADER;
             break;
 
@@ -919,11 +918,11 @@ static void *httpd_handler(void *arg)
           status = httpd_parse(pstate);
           if (status >= 400)
             {
-              (void)httpd_senderror(pstate, status);
+              httpd_senderror(pstate, status);
             }
           else
             {
-              (void) httpd_sendfile(pstate);
+              httpd_sendfile(pstate);
             }
 
 #ifndef CONFIG_NETUTILS_HTTPD_KEEPALIVE_DISABLE
@@ -1009,7 +1008,7 @@ static void single_server(uint16_t portno, pthread_startroutine_t handler,
 
       /* Handle the request. This blocks until complete. */
 
-      (void)httpd_handler((FAR void *)acceptsd);
+      httpd_handler((FAR void *)acceptsd);
     }
 
   /* Close the sockets */

--- a/netutils/webserver/httpd_mmap.c
+++ b/netutils/webserver/httpd_mmap.c
@@ -125,7 +125,7 @@ int httpd_mmap_open(const char *name, struct httpd_fs_file *file)
   file->data = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED | MAP_FILE, file->fd, 0);
   if (file->data == MAP_FAILED)
     {
-       (void) close(file->fd);
+       close(file->fd);
        return ERROR;
     }
 

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -78,11 +78,11 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
 
   /* Close stderr: note we only close stderr if we opened the alternative one */
 
-  (void)fclose(stderr);
+  fclose(stderr);
 
   /* Associate the new opened file descriptor to stderr */
 
-  (void)dup2(fd, 2);
+  dup2(fd, 2);
 
   /* Close the console device that we just opened */
 
@@ -101,11 +101,11 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
 
   /* Close stdout: note we only close stdout if we opened the alternative one */
 
-  (void)fclose(stdout);
+  fclose(stdout);
 
   /* Associate the new opened file descriptor to stdout */
 
-  (void)dup2(fd, 1);
+  dup2(fd, 1);
 
   /* Close the console device that we just opened */
 
@@ -202,7 +202,7 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
 
   /* Close stdin: note we only closed stdin if we opened the alternative one */
 
-  (void)fclose(stdin);
+  fclose(stdin);
 
   /* Okay.. we have successfully opened the input device.  Did
    * we just re-open fd 0?
@@ -212,7 +212,7 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
     {
        /* No..  Dup the fd to create standard fd 0.  stdin should not know. */
 
-      (void)dup2(fd, 0);
+      dup2(fd, 0);
 
       /* Setup the input console */
 
@@ -281,13 +281,13 @@ int nsh_consolemain(int argc, char *argv[])
   /* Execute the one-time start-up script.  Any output will go to /dev/console. */
 
 #ifdef CONFIG_NSH_ROMFSETC
-  (void)nsh_initscript(&pstate->cn_vtbl);
+  nsh_initscript(&pstate->cn_vtbl);
 #endif
 
 #if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
   /* First map stderr and stdout to alternative devices */
@@ -315,7 +315,7 @@ int nsh_consolemain(int argc, char *argv[])
 
       /* Execute the session */
 
-      (void)nsh_session(pstate);
+      nsh_session(pstate);
 
       /* We lost the connection.  Wait for the keyboard to
        * be re-connected.

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -140,7 +140,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
            * SIGINT.
            */
 
-          (void)ioctl(stdout->fs_fd, TIOCSCTTY, ret);
+          ioctl(stdout->fs_fd, TIOCSCTTY, ret);
 
           /* Wait for the application to exit.  We did lock the scheduler
            * above, but that does not guarantee that the application did not
@@ -201,7 +201,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
               */
             }
 
-          (void)ioctl(stdout->fs_fd, TIOCSCTTY, -1);
+          ioctl(stdout->fs_fd, TIOCSCTTY, -1);
         }
 #  ifndef CONFIG_NSH_DISABLEBG
       else

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -313,7 +313,7 @@ static void nsh_consolerelease(FAR struct nsh_vtbl_s *vtbl)
   /* Close the console stream */
 
 #ifdef CONFIG_NSH_ALTCONDEV
-  (void)fclose(pstate->cn_constream);
+  fclose(pstate->cn_constream);
 #endif
 
 #ifdef CONFIG_NSH_VARS

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -87,7 +87,7 @@ int nsh_consolemain(int argc, char *argv[])
 #ifdef CONFIG_NSH_ROMFSETC
   /* Execute the start-up script */
 
-  (void)nsh_initscript(&pstate->cn_vtbl);
+  nsh_initscript(&pstate->cn_vtbl);
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
   /* Reset the option flags */
@@ -105,7 +105,7 @@ int nsh_consolemain(int argc, char *argv[])
 #if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
   /* Execute the session */

--- a/nshlib/nsh_dbgcmds.c
+++ b/nshlib/nsh_dbgcmds.c
@@ -392,7 +392,7 @@ int cmd_hexdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   buffer = (FAR uint8_t *)malloc(IOBUFFERSIZE);
   if(buffer == NULL)
     {
-      (void)close(fd);
+      close(fd);
       nsh_error(vtbl, g_fmtcmdfailed, "hexdump", "malloc", NSH_ERRNO);
       return ERROR;
     }
@@ -491,7 +491,7 @@ int cmd_hexdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
     }
 
-  (void)close(fd);
+  close(fd);
   free(buffer);
   return ret;
 }

--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -314,9 +314,9 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef CONFIG_NSH_CMDOPT_DD_STATS
 #ifdef CONFIG_CLOCK_MONOTONIC
-  (void)clock_gettime(CLOCK_MONOTONIC, &ts0);
+  clock_gettime(CLOCK_MONOTONIC, &ts0);
 #else
-  (void)clock_gettime(CLOCK_REALTIME, &ts0);
+  clock_gettime(CLOCK_REALTIME, &ts0);
 #endif
 #endif
 
@@ -367,9 +367,9 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef CONFIG_NSH_CMDOPT_DD_STATS
 #ifdef CONFIG_CLOCK_MONOTONIC
-  (void)clock_gettime(CLOCK_MONOTONIC, &ts1);
+  clock_gettime(CLOCK_MONOTONIC, &ts1);
 #else
-  (void)clock_gettime(CLOCK_REALTIME, &ts1);
+  clock_gettime(CLOCK_REALTIME, &ts1);
 #endif
 
   elapsed  = (((uint64_t)ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec);
@@ -385,10 +385,10 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #endif
 
 errout_with_outf:
-  (void)close(dd.outfd);
+  close(dd.outfd);
 
 errout_with_inf:
-  (void)close(dd.infd);
+  close(dd.infd);
   free(dd.buffer);
 
 errout_with_paths:

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -175,7 +175,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
            * SIGINT.
            */
 
-          (void)ioctl(stdout->fs_fd, TIOCSCTTY, pid);
+          ioctl(stdout->fs_fd, TIOCSCTTY, pid);
 
           /* Wait for the application to exit.  We did lock the scheduler
            * above, but that does not guarantee that the application did not
@@ -228,7 +228,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                */
             }
 
-          (void)ioctl(stdout->fs_fd, TIOCSCTTY, -1);
+          ioctl(stdout->fs_fd, TIOCSCTTY, -1);
         }
 #  ifndef CONFIG_NSH_DISABLEBG
       else
@@ -270,10 +270,10 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
    */
 
 errout_with_actions:
-  (void)posix_spawn_file_actions_destroy(&file_actions);
+  posix_spawn_file_actions_destroy(&file_actions);
 
 errout_with_attrs:
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawnattr_destroy(&attr);
 
 errout:
   /* Most posix_spawn interfaces return a positive errno value on failure

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -819,7 +819,7 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   /* Free resources */
 
 errout_with_fd:
-  (void)close(fd);
+  close(fd);
 
 errout_with_paths:
   if (loopdev)
@@ -986,7 +986,7 @@ int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   /* Free resources */
 
 errout_with_fd:
-  (void)close(fd);
+  close(fd);
 
 errout_with_paths:
   if (loopdev)

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -91,7 +91,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
   buffer = (FAR char *)malloc(IOBUFFERSIZE);
   if(buffer == NULL)
     {
-      (void)close(fd);
+      close(fd);
       nsh_error(vtbl, g_fmtcmdfailed, cmd, "malloc", NSH_ERRNO);
       return ERROR;
     }
@@ -175,7 +175,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
    /* Close the input file and return the result */
 
-   (void)close(fd);
+   close(fd);
    free(buffer);
    return ret;
 }

--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -85,12 +85,12 @@ void nsh_initialize(void)
 #if defined(CONFIG_NSH_READLINE) && defined(CONFIG_READLINE_TABCOMPLETION)
   /* Configure the NSH prompt */
 
-  (void)readline_prompt(g_nshprompt);
+  readline_prompt(g_nshprompt);
 
 #ifdef CONFIG_READLINE_HAVE_EXTMATCH
   /* Set up for tab completion on NSH commands */
 
-  (void)readline_extmatch(&g_nsh_extmatch);
+  readline_extmatch(&g_nsh_extmatch);
 #endif
 #endif
 
@@ -101,12 +101,12 @@ void nsh_initialize(void)
 #ifdef CONFIG_NSH_ARCHINIT
   /* Perform architecture-specific initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_INIT, 0);
+  boardctl(BOARDIOC_INIT, 0);
 #endif
 
 #ifdef CONFIG_NSH_NETINIT
   /* Bring up the network */
 
-  (void)netinit_bringup();
+  netinit_bringup();
 #endif
 }

--- a/nshlib/nsh_modcmds.c
+++ b/nshlib/nsh_modcmds.c
@@ -181,7 +181,7 @@ int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
                  datasize      ? datasize      : "");
     }
 
-  (void)fclose(stream);
+  fclose(stream);
   return OK;
 }
 #endif /* CONFIG_FS_PROCFS && !CONFIG_FS_PROCFS_EXCLUDE_MODULE */

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -187,7 +187,7 @@ typedef int (*nsh_netdev_callback_t)(FAR struct nsh_vtbl_s *vtbl,
    !defined(CONFIG_NSH_DISABLE_IFCONFIG)
 static inline void net_statistics(FAR struct nsh_vtbl_s *vtbl)
 {
-  (void)nsh_catfile(vtbl, "ifconfig", CONFIG_NSH_PROC_MOUNTPOINT "/net/stat");
+  nsh_catfile(vtbl, "ifconfig", CONFIG_NSH_PROC_MOUNTPOINT "/net/stat");
 }
 #else
 # define net_statistics(vtbl)
@@ -207,7 +207,7 @@ static int ifconfig_callback(FAR struct nsh_vtbl_s *vtbl, FAR char *devname)
   /* Construct the full path to the /proc/net entry for this device */
 
   snprintf(buffer, IFNAMSIZ + 12, CONFIG_NSH_PROC_MOUNTPOINT "/net/%s", devname);
-  (void)nsh_catfile(vtbl, "ifconfig", buffer);
+  nsh_catfile(vtbl, "ifconfig", buffer);
 
   return OK;
 }
@@ -359,7 +359,7 @@ errout:
 static void wget_callback(FAR char **buffer, int offset, int datend,
                           FAR int *buflen, FAR void *arg)
 {
-  (void)write((int)((intptr_t)arg), &((*buffer)[offset]), datend - offset);
+  write((int)((intptr_t)arg), &((*buffer)[offset]), datend - offset);
 }
 #endif
 #endif
@@ -411,7 +411,7 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
 
   /* Close the directory */
 
-  (void)closedir(dir);
+  closedir(dir);
   return ret;
 }
 #endif
@@ -925,7 +925,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
         {
           struct dhcpc_state ds;
 
-          (void)dhcpc_request(handle, &ds);
+          dhcpc_request(handle, &ds);
           netlib_set_ipv4addr("eth0", &ds.ipaddr);
 
           if (ds.netmask.s_addr != 0)

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -357,7 +357,7 @@ static void nsh_releaseargs(struct cmdarg_s *arg)
 
   if (vtbl->np.np_redirect)
     {
-      (void)close(arg->fd);
+      close(arg->fd);
     }
 #endif
 
@@ -639,7 +639,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
       if (vtbl->np.np_redirect)
         {
-          (void)nsh_redirect(bkgvtbl, fd, NULL);
+          nsh_redirect(bkgvtbl, fd, NULL);
         }
 #endif
 
@@ -681,9 +681,9 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
       /* Set up the thread attributes */
 
-      (void)pthread_attr_init(&attr);
-      (void)pthread_attr_setschedpolicy(&attr, SCHED_NSH);
-      (void)pthread_attr_setschedparam(&attr, &param);
+      pthread_attr_init(&attr);
+      pthread_attr_setschedpolicy(&attr, SCHED_NSH);
+      pthread_attr_setschedparam(&attr, &param);
 
       /* Execute the command as a separate thread at the appropriate priority */
 
@@ -700,7 +700,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
        * Otherwise, we would have a memory leak.
        */
 
-      (void)pthread_detach(thread);
+      pthread_detach(thread);
 
       nsh_output(vtbl, "%s [%d:%d]\n", argv[0], thread, param.sched_priority);
     }

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -120,7 +120,7 @@ int nsh_session(FAR struct console_stdio_s *pstate)
   /* Execute the login script */
 
 #ifdef CONFIG_NSH_ROMFSRC
-  (void)nsh_loginscript(vtbl);
+  nsh_loginscript(vtbl);
 #endif
 
   /* Then enter the command line parsing loop */
@@ -178,7 +178,7 @@ int nsh_session(FAR struct console_stdio_s *pstate)
 
       /* Parse process the command */
 
-      (void)nsh_parse(vtbl, pstate->cn_line);
+      nsh_parse(vtbl, pstate->cn_line);
       fflush(pstate->cn_outstream);
     }
 

--- a/nshlib/nsh_stdsession.c
+++ b/nshlib/nsh_stdsession.c
@@ -162,7 +162,7 @@ int nsh_session(FAR struct console_stdio_s *pstate)
 
       /* Parse process the command */
 
-      (void)nsh_parse(vtbl, pstate->cn_line);
+      nsh_parse(vtbl, pstate->cn_line);
     }
 
   /* We do not get here, but this is necessary to keep some compilers happy.

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -127,7 +127,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
        * reset the board due to some constraints.
        */
 
-      (void)boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+      boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
     }
   else
     {
@@ -136,7 +136,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
        * to power-off the* board due to some constraints.
        */
 
-      (void)boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
+      boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
     }
 
 #elif defined(CONFIG_BOARDCTL_RESET)
@@ -157,7 +157,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
    * reset the board due to some constraints.
    */
 
-  (void)boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+  boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
 
 #else
   /* Only the reset behavior is supported and we already know that there is
@@ -169,7 +169,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
    * off the board due to some constraints.
    */
 
-  (void)boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
+  boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
 #endif
 
   /* boarctl() will not return in any case.  It if does, it means that
@@ -288,11 +288,11 @@ int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   if (argc > 1)
     {
-      (void)boardctl(BOARDIOC_POWEROFF, atoi(argv[1]));
+      boardctl(BOARDIOC_POWEROFF, atoi(argv[1]));
     }
   else
     {
-      (void)boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
+      boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
     }
 
   /* boarctl() will not return in any case.  It if does, it means that
@@ -318,11 +318,11 @@ int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   if (argc > 1)
     {
-      (void)boardctl(BOARDIOC_RESET, atoi(argv[1]));
+      boardctl(BOARDIOC_RESET, atoi(argv[1]));
     }
   else
     {
-      (void)boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+      boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
     }
 
   /* boarctl() will not return in this case.  It if does, it means that

--- a/nshlib/nsh_system.c
+++ b/nshlib/nsh_system.c
@@ -83,7 +83,7 @@ int nsh_system(int argc, char *argv[])
 
       /* Parse process the command */
 
-      (void)nsh_parse(vtbl, argv[1]);
+      nsh_parse(vtbl, argv[1]);
 #if CONFIG_NFILE_STREAMS > 0
       fflush(pstate->cn_outstream);
 #endif

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -133,13 +133,13 @@ static int nsh_telnetmain(int argc, char *argv[])
    */
 
 #if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
-  (void)nsh_initscript(vtbl);
+  nsh_initscript(vtbl);
 #endif
 
   /* Execute the login script */
 
 #ifdef CONFIG_NSH_ROMFSRC
-  (void)nsh_loginscript(vtbl);
+  nsh_loginscript(vtbl);
 #endif
 
   /* Then enter the command line parsing loop */
@@ -202,7 +202,7 @@ static int nsh_telnetmain(int argc, char *argv[])
 
       /* Parse process the received Telnet command */
 
-      (void)nsh_parse(vtbl, pstate->cn_line);
+      nsh_parse(vtbl, pstate->cn_line);
       fflush(pstate->cn_outstream);
     }
 

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -77,15 +77,15 @@ static void nsh_configstdio(int fd)
 {
   /* Make sure the stdin, stdout, and stderr are closed */
 
-  (void)fclose(stdin);
-  (void)fclose(stdout);
-  (void)fclose(stderr);
+  fclose(stdin);
+  fclose(stdout);
+  fclose(stderr);
 
   /* Dup the fd to create standard fd 0-2 */
 
-  (void)dup2(fd, 0);
-  (void)dup2(fd, 1);
-  (void)dup2(fd, 2);
+  dup2(fd, 0);
+  dup2(fd, 1);
+  dup2(fd, 2);
 
   /* fdopen to get the stdin, stdout and stderr streams. The following logic depends
    * on the fact that the library layer will allocate FILEs in order.  And since
@@ -96,9 +96,9 @@ static void nsh_configstdio(int fd)
    * fd = 2 is stderr (write-only, append)
    */
 
-  (void)fdopen(0, "r");
-  (void)fdopen(1, "a");
-  (void)fdopen(2, "a");
+  fdopen(0, "r");
+  fdopen(1, "a");
+  fdopen(2, "a");
 }
 
 /****************************************************************************
@@ -217,7 +217,7 @@ restart:
 
           if (nbytes <= 0)
             {
-              (void)close(fd);
+              close(fd);
               goto restart;
             }
         }
@@ -308,19 +308,19 @@ int nsh_consolemain(int argc, char *argv[])
   /* Configure to use /dev/null if we do not have a valid console. */
 
 #ifndef CONFIG_DEV_CONSOLE
-  (void)nsh_nullstdio();
+  nsh_nullstdio();
 #endif
 
   /* Execute the one-time start-up script (output may go to /dev/null) */
 
 #ifdef CONFIG_NSH_ROMFSETC
-  (void)nsh_initscript(&pstate->cn_vtbl);
+  nsh_initscript(&pstate->cn_vtbl);
 #endif
 
 #if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
   /* Perform architecture-specific final-initialization (if configured) */
 
-  (void)boardctl(BOARDIOC_FINALINIT, 0);
+  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
   /* Now loop, executing creating a session for each USB connection */
@@ -332,19 +332,18 @@ int nsh_consolemain(int argc, char *argv[])
        */
 
       ret = nsh_waitusbready();
-
-      (void)ret; /* Eliminate warning if not used */
+      UNUSED(ret); /* Eliminate warning if not used */
       DEBUGASSERT(ret == OK);
 
       /* Execute the session */
 
-      (void)nsh_session(pstate);
+      nsh_session(pstate);
 
       /* Switch to /dev/null because we probably no longer have a
        * valid console device.
        */
 
-      (void)nsh_nullstdio();
+      nsh_nullstdio();
     }
 }
 

--- a/nshlib/nsh_usbtrace.c
+++ b/nshlib/nsh_usbtrace.c
@@ -129,7 +129,7 @@ static int nsh_tracecallback(struct usbtrace_s *trace, void *arg)
 
 void nsh_usbtrace(void)
 {
-  (void)usbtrace_enumerate(nsh_tracecallback, NULL);
+  usbtrace_enumerate(nsh_tracecallback, NULL);
 }
 
 #endif /* CONFIG_NSH_USBDEV_TRACE */

--- a/nshlib/nsh_vars.c
+++ b/nshlib/nsh_vars.c
@@ -255,7 +255,7 @@ int nsh_setvar(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
        * will be added again below.
        */
 
-      (void)nsh_removevar(pstate, pair);
+      nsh_removevar(pstate, pair);
     }
 
   /* Get the size of the new name=value string.  The +2 is for the '=' and for
@@ -322,7 +322,7 @@ int nsh_unsetvar(FAR struct nsh_vtbl_s *vtbl, FAR const char *name)
     {
       /* It does!  Remove the name=value pair from the NSH variables. */
 
-      (void)nsh_removevar(pstate, pair);
+      nsh_removevar(pstate, pair);
 
       /* Reallocate the new NSH variable buffer */
 

--- a/system/cdcacm/cdcacm_main.c
+++ b/system/cdcacm/cdcacm_main.c
@@ -146,7 +146,7 @@ int serdis_main(int argc, char *argv[])
   ctrl.instance = CONFIG_SYSTEM_CDCACM_DEVMINOR;
   ctrl.handle   = &g_cdcacm.handle;
 
-  (void)boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
   g_cdcacm.handle = NULL;
   printf("serdis: Disconnected\n");
   return EXIT_SUCCESS;

--- a/system/cfgdata/cfgdata_main.c
+++ b/system/cfgdata/cfgdata_main.c
@@ -248,7 +248,6 @@ static void cfgdatacmd_parse_byte_array(struct config_data_s *cfg,
 
 static void cfgdatacmd_set(int argc, char *argv[])
 {
-  int                   x;
   int                   ret;
   int                   fd;
   struct config_data_s  cfg;
@@ -259,9 +258,10 @@ static void cfgdatacmd_set(int argc, char *argv[])
   /* Copy the name to the cfg struct */
 
   strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
-  (void) x;
 
 #else
+  int                   x;
+
   /* Parse the id and instance */
 
   cfg.id = atoi(argv[2]);
@@ -380,7 +380,6 @@ static void cfgdatacmd_set(int argc, char *argv[])
 
 static void cfgdatacmd_unset(int argc, char *argv[])
 {
-  int                   x;
   int                   ret;
   int                   fd;
   struct config_data_s  cfg;
@@ -389,9 +388,10 @@ static void cfgdatacmd_unset(int argc, char *argv[])
   /* Copy the name to the cfg struct */
 
   strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
-  (void) x;
 
 #else
+  int                   x;
+
   /* Parse the id and instance */
 
   cfg.id = atoi(argv[2]);
@@ -444,7 +444,7 @@ static void cfgdatacmd_unset(int argc, char *argv[])
 static void cfgdatacmd_print(int argc, char *argv[])
 {
   struct config_data_s  cfg;
-  int                   x, ret;
+  int                   ret;
   int                   fd;
   bool                  isstring;
 
@@ -453,9 +453,10 @@ static void cfgdatacmd_print(int argc, char *argv[])
   /* Copy the name to the cfg struct */
 
   strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
-  (void)x;
 
 #else
+  int                   x;
+
   /* Parse the id and instance */
 
   cfg.id = atoi(argv[2]);

--- a/system/composite/composite_main.c
+++ b/system/composite/composite_main.c
@@ -127,7 +127,7 @@ static void check_test_memory_usage(FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&g_composite.mmcurrent);
+  mallinfo(&g_composite.mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -159,7 +159,7 @@ static void final_memory_usage(FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&g_composite.mmcurrent);
+  mallinfo(&g_composite.mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -447,7 +447,7 @@ int main(int argc, FAR char *argv[])
   g_composite.mmstart    = mallinfo();
   g_composite.mmprevious = g_composite.mmstart;
 #  else
-  (void)mallinfo(&g_composite.mmstart);
+  mallinfo(&g_composite.mmstart);
   memcpy(&g_composite.mmprevious, &g_composite.mmstart, sizeof(struct mallinfo));
 #  endif
 #endif
@@ -566,7 +566,7 @@ int disconn_main(int argc, char *argv[])
   ctrl.config   = config;
   ctrl.handle   = &g_composite.cmphandle;
 
-  (void)boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
 
   g_composite.cmphandle = NULL;
   printf("disconn_main: Disconnected\n");

--- a/system/dhcpc/renew_main.c
+++ b/system/dhcpc/renew_main.c
@@ -105,7 +105,7 @@ int main(int argc, FAR char *argv[])
   ret = dhcpc_request(handle, &ds);
   if (ret < 0)
     {
-      (void)dhcpc_close(handle);
+      dhcpc_close(handle);
       fprintf(stderr, "ERROR: dhcpc_request() failed\n");
       return EXIT_FAILURE;
     }

--- a/system/i2c/i2c_dev.c
+++ b/system/i2c/i2c_dev.c
@@ -182,7 +182,7 @@ int i2ccmd_dev(FAR struct i2ctool_s *i2ctool, int argc, char **argv)
       i2ctool_flush(i2ctool);
     }
 
-  (void)close(fd);
+  close(fd);
 
 errout:
 

--- a/system/i2c/i2c_dump.c
+++ b/system/i2c/i2c_dump.c
@@ -227,7 +227,7 @@ int i2ccmd_dump(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   free(buf);
 
 errout_with_fildes:
-  (void)close(fd);
+  close(fd);
   return ret;
 }
 

--- a/system/i2c/i2c_get.c
+++ b/system/i2c/i2c_get.c
@@ -161,7 +161,7 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
         }
     }
 
-  (void)close(fd);
+  close(fd);
   return ret;
 }
 

--- a/system/i2c/i2c_main.c
+++ b/system/i2c/i2c_main.c
@@ -388,7 +388,7 @@ int main(int argc, FAR char *argv[])
   /* Parse and process the command line */
 
   i2c_setup(&g_i2ctool);
-  (void)i2c_parse(&g_i2ctool, argc, argv);
+  i2c_parse(&g_i2ctool, argc, argv);
 
   i2ctool_flush(&g_i2ctool);
   i2c_teardown(&g_i2ctool);

--- a/system/i2c/i2c_set.c
+++ b/system/i2c/i2c_set.c
@@ -188,7 +188,7 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
         }
     }
 
-  (void)close(fd);
+  close(fd);
   return ret;
 }
 

--- a/system/i2c/i2c_verf.c
+++ b/system/i2c/i2c_verf.c
@@ -215,6 +215,6 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
         }
     }
 
-  (void)close(fd);
+  close(fd);
   return ret;
 }

--- a/system/lzf/lzf_main.c
+++ b/system/lzf/lzf_main.c
@@ -82,7 +82,7 @@ static uint8_t g_buf2[MAX_BLOCKSIZE + LZF_MAX_HDR_SIZE + 16];
 static void lzf_exit(int exitcode) noreturn_function;
 static void lzf_exit(int exitcode)
 {
-  (void)sem_post(&g_exclsem);
+  sem_post(&g_exclsem);
   exit(exitcode);
 }
 #else

--- a/system/mdio/mdio_main.c
+++ b/system/mdio/mdio_main.c
@@ -218,7 +218,7 @@ int main(int argc, FAR char *argv[])
 
       for (i = 0; i < 32; i++)
         {
-          (void)get_phy_reg(phy_id, i, &val_out);
+          get_phy_reg(phy_id, i, &val_out);
           printf("phy[%d][%d] = 0x%4x\n", phy_id, i, val_out);
         }
     }

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -158,7 +158,7 @@ static int nsh_task(void)
   symdesc.symtab   = (FAR struct symtab_s *)CONFIG_SYSTEM_NSH_SYMTAB_ARRAYNAME; /* Discard 'const' */
   symdesc.nsymbols = CONFIG_SYSTEM_NSH_SYMTAB_COUNTNAME;
 
-  (void)boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
+  boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
 #endif
 
   /* Initialize the NSH library */
@@ -215,13 +215,13 @@ int main(int argc, FAR char *argv[])
 
   /* Check the task priority that we were started with */
 
-  (void)sched_getparam(0, &param);
+  sched_getparam(0, &param);
   if (param.sched_priority != CONFIG_SYSTEM_NSH_PRIORITY)
     {
       /* If not then set the priority to the configured priority */
 
       param.sched_priority = CONFIG_SYSTEM_NSH_PRIORITY;
-      (void)sched_setparam(0, &param);
+      sched_setparam(0, &param);
     }
 
   /* There are two modes that NSH can be executed in:

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -208,10 +208,10 @@ static int _open_with_http(const char *fullurl)
   tv.tv_sec  = 10; /* TODO */
   tv.tv_usec = 0;
 
-  (void)setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv,
-                   sizeof(struct timeval));
-  (void)setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (FAR const void *)&tv,
-                   sizeof(struct timeval));
+  setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv,
+             sizeof(struct timeval));
+  setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (FAR const void *)&tv,
+             sizeof(struct timeval));
 
   struct sockaddr_in server;
   server.sin_family = AF_INET;
@@ -975,7 +975,7 @@ static void *nxplayer_playthread(pthread_addr_t pvarg)
        */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-      (void)nxplayer_setvolume(pplayer, pplayer->volume);
+      nxplayer_setvolume(pplayer, pplayer->volume);
 #ifndef CONFIG_AUDIO_EXCLUDE_BALANCE
       nxplayer_setbalance(pplayer, pplayer->balance);
 #endif
@@ -1998,9 +1998,9 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
 
   pthread_attr_init(&tattr);
   sparam.sched_priority = sched_get_priority_max(SCHED_FIFO) - 9;
-  (void)pthread_attr_setschedparam(&tattr, &sparam);
-  (void)pthread_attr_setstacksize(&tattr,
-                                  CONFIG_NXPLAYER_PLAYTHREAD_STACKSIZE);
+  pthread_attr_setschedparam(&tattr, &sparam);
+  pthread_attr_setstacksize(&tattr,
+                            CONFIG_NXPLAYER_PLAYTHREAD_STACKSIZE);
 
   /* Add a reference count to the player for the thread and start the
    * thread.  We increment for the thread to avoid thread start-up

--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -928,9 +928,9 @@ int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
 
   pthread_attr_init(&tattr);
   sparam.sched_priority = sched_get_priority_max(SCHED_FIFO) - 9;
-  (void)pthread_attr_setschedparam(&tattr, &sparam);
-  (void)pthread_attr_setstacksize(&tattr,
-                                  CONFIG_NXRECORDER_RECORDTHREAD_STACKSIZE);
+  pthread_attr_setschedparam(&tattr, &sparam);
+  pthread_attr_setstacksize(&tattr,
+                            CONFIG_NXRECORDER_RECORDTHREAD_STACKSIZE);
 
   /* Add a reference count to the recorder for the thread and start the
    * thread.  We increment for the thread to avoid thread start-up

--- a/system/popen/popen.c
+++ b/system/popen/popen.c
@@ -280,14 +280,14 @@ FILE *popen(FAR const char *command, FAR const char *mode)
    * the interface.
    */
 
-  (void)close(newfd);
+  close(newfd);
 
   /* Free attributes and file actions.  Ignoring return values in the case
    * of an error.
    */
 
-  (void)posix_spawn_file_actions_destroy(&file_actions);
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawn_file_actions_destroy(&file_actions);
+  posix_spawnattr_destroy(&attr);
 
   /* Finale and return input input/output stream */
 
@@ -295,17 +295,17 @@ FILE *popen(FAR const char *command, FAR const char *mode)
   return &container->copy;
 
 errout_with_actions:
-  (void)posix_spawn_file_actions_destroy(&file_actions);
+  posix_spawn_file_actions_destroy(&file_actions);
 
 errout_with_attrs:
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawnattr_destroy(&attr);
 
 errout_with_stream:
-  (void)fclose(container->original);
+  fclose(container->original);
 
 errout_with_pipe:
-  (void)close(fd[0]);
-  (void)close(fd[1]);
+  close(fd[0]);
+  close(fd[1]);
 
 errout_with_container:
   free(container);
@@ -380,7 +380,7 @@ int pclose(FILE *stream)
    * process)
    */
 
-  (void)fclose(original);
+  fclose(original);
 
   shell = container->shell;
   free(container);

--- a/system/readline/readline.c
+++ b/system/readline/readline.c
@@ -181,7 +181,7 @@ static void readline_write(FAR struct rl_common_s *vtbl,
   FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
   DEBUGASSERT(priv && buffer && buflen > 0);
 
-  (void)write(priv->outfd, buffer, buflen);
+  write(priv->outfd, buffer, buflen);
 }
 #endif
 

--- a/system/sched_note/note_main.c
+++ b/system/sched_note/note_main.c
@@ -624,7 +624,7 @@ static int note_daemon(int argc, char *argv[])
       usleep(CONFIG_SYSTEM_NOTE_DELAY * 1000L);
     }
 
-  (void)close(fd);
+  close(fd);
 
 errout:
   g_note_daemon_started = false;

--- a/system/spi/spi_exch.c
+++ b/system/spi/spi_exch.c
@@ -161,7 +161,7 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
 
   ret = spidev_transfer(fd, &seq);
 
-  (void)close(fd);
+  close(fd);
 
   if (ret)
     {

--- a/system/spi/spi_main.c
+++ b/system/spi/spi_main.c
@@ -403,7 +403,7 @@ int main(int argc, FAR char *argv[])
   /* Parse and process the command line */
 
   spi_setup(&g_spitool);
-  (void)spi_parse(&g_spitool, argc, argv);
+  spi_parse(&g_spitool, argc, argv);
 
   spitool_flush(&g_spitool);
   spi_teardown(&g_spitool);

--- a/system/system/system.c
+++ b/system/system/system.c
@@ -170,11 +170,11 @@ int system(FAR const char *cmd)
       rc = ERROR;
     }
 
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawnattr_destroy(&attr);
   return rc;
 
 errout_with_attrs:
-  (void)posix_spawnattr_destroy(&attr);
+  posix_spawnattr_destroy(&attr);
 
 errout:
   set_errno(errcode);

--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -186,7 +186,7 @@ int main(int argc, FAR char *argv[])
                             CONFIG_SYSTEM_TASKSET_STACKSIZE, nsh_system,
                             (FAR char * const *)nshargv);
 
-          (void)waitpid(pid, &rc, 0);
+          waitpid(pid, &rc, 0);
         }
     }
 

--- a/system/tee/tee.c
+++ b/system/tee/tee.c
@@ -228,7 +228,7 @@ errout_with_list:
   for (curr = head; curr; curr = next)
     {
       next = curr->next;
-      (void)close(curr->fd);
+      close(curr->fd);
       free(curr);
     }
 

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -152,7 +152,7 @@ static void check_test_memory_usage(FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&g_usbmsc.mmcurrent);
+  mallinfo(&g_usbmsc.mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -184,7 +184,7 @@ static void final_memory_usage(FAR const char *msg)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmcurrent = mallinfo();
 #else
-  (void)mallinfo(&g_usbmsc.mmcurrent);
+  mallinfo(&g_usbmsc.mmcurrent);
 #endif
 
   /* Show the change from the previous time */
@@ -414,7 +414,7 @@ static void usbmsc_disconnect(FAR void *handle)
   ctrl.instance = 0;
   ctrl.handle   = &handle;
 
-  (void)boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
 }
 
 /****************************************************************************
@@ -458,7 +458,7 @@ int main(int argc, FAR char *argv[])
   g_usbmsc.mmstart    = mallinfo();
   g_usbmsc.mmprevious = g_usbmsc.mmstart;
 #  else
-  (void)mallinfo(&g_usbmsc.mmstart);
+  mallinfo(&g_usbmsc.mmstart);
   memcpy(&g_usbmsc.mmprevious, &g_usbmsc.mmstart, sizeof(struct mallinfo));
 #  endif
 #endif

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -1338,7 +1338,7 @@ static bool vi_insertfile(FAR struct vi_s *vi, off_t pos,
     }
 
   vi->fullredraw = true;
-  (void)fclose(stream);
+  fclose(stream);
   return ret;
 }
 
@@ -1379,11 +1379,11 @@ static bool vi_savetext(FAR struct vi_s *vi, FAR const char *filename,
       /* Report the error (or partial write).  EINTR is not handled. */
 
       vi_error(vi, g_fmtcmdfail, "fwrite", errno);
-      (void)fclose(stream);
+      fclose(stream);
       return false;
     }
 
-  (void)fclose(stream);
+  fclose(stream);
 
   len = sprintf(vi->scratch, "%dC written", nwritten);
   vi_write(vi, vi->scratch, len);
@@ -3703,7 +3703,7 @@ static void vi_cmd_mode(FAR struct vi_s *vi)
 
         case KEY_CMDMODE_BOTTOM:  /* Move to bottom of screen */
           {
-            (void)vi_gotoscreenbottom(vi, 0);
+            vi_gotoscreenbottom(vi, 0);
           }
           break;
 
@@ -4927,11 +4927,11 @@ static void vi_parsefind(FAR struct vi_s *vi, bool revfind)
   vi->revfind = revfind;
   if (revfind)
     {
-      (void)vi_revfindstring(vi);
+      vi_revfindstring(vi);
     }
   else
     {
-      (void)vi_findstring(vi);
+      vi_findstring(vi);
     }
 
   /* Exit the sub-mode and revert to command mode */
@@ -5879,7 +5879,7 @@ int main(int argc, FAR char *argv[])
 
       /* Load the file into memory */
 
-      (void)vi_insertfile(vi, 0, vi->filename);
+      vi_insertfile(vi, 0, vi->filename);
       vi->modified = false;
 
       /* Skip over the filename argument.  There should nothing after this */

--- a/system/zmodem/rz_main.c
+++ b/system/zmodem/rz_main.c
@@ -172,7 +172,7 @@ int main(int argc, FAR char *argv[])
   exitcode = EXIT_SUCCESS;
 
 errout_with_zmodem:
-  (void)zmr_release(handle);
+  zmr_release(handle);
 
 errout_with_device:
 #ifdef CONFIG_SERIAL_TERMIOS
@@ -187,7 +187,7 @@ errout_with_device:
   tcsetattr(fd, TCSANOW, &saveterm);
 #endif
 
-  (void)close(fd);
+  close(fd);
 
 errout:
   return exitcode;

--- a/system/zmodem/sz_main.c
+++ b/system/zmodem/sz_main.c
@@ -271,7 +271,7 @@ int main(int argc, FAR char *argv[])
   exitcode = EXIT_SUCCESS;
 
 errout_with_zmodem:
-  (void)zms_release(handle);
+  zms_release(handle);
 
 errout_with_device:
 #ifdef CONFIG_SERIAL_TERMIOS
@@ -286,7 +286,7 @@ errout_with_device:
   tcsetattr(fd, TCSANOW, &saveterm);
 #endif
 
-  (void)close(fd);
+  close(fd);
 
 errout:
   return exitcode;

--- a/system/zmodem/zm_receive.c
+++ b/system/zmodem/zm_receive.c
@@ -738,7 +738,7 @@ static int zmr_filedata(FAR struct zm_state_s *pzm)
 
           /* Send the cancel string */
 
-          (void)zm_remwrite(pzm->remfd, g_canistr, CANISTR_SIZE);
+          zm_remwrite(pzm->remfd, g_canistr, CANISTR_SIZE);
 
           /* Enter PSTATE_DATA */
 
@@ -782,7 +782,7 @@ static int zmr_filedata(FAR struct zm_state_s *pzm)
       pzm->state     = ZMR_FINISH;
       pzm->pstate    = PSTATE_IDLE;
       pzm->psubstate = PIDLE_ZPAD;
-      (void)zmr_fileerror(pzmr, ZFERR, (uint32_t)errorcode);
+      zmr_fileerror(pzmr, ZFERR, (uint32_t)errorcode);
       return -errorcode;
     }
 
@@ -1697,7 +1697,7 @@ int zmr_release(ZMRHANDLE handle)
 
   /* Release the timer resources */
 
-  (void)zm_timerrelease(&pzmr->cmn);
+  zm_timerrelease(&pzmr->cmn);
 
   /* Clean up any resouces that may be held from the last file transfer */
 

--- a/system/zmodem/zm_send.c
+++ b/system/zmodem/zm_send.c
@@ -1622,7 +1622,7 @@ ZMSHANDLE zms_initialize(int remfd)
   return (ZMSHANDLE)pzms;
 
 errout_with_timer:
-  (void)zm_timerrelease(&pzms->cmn);
+  zm_timerrelease(&pzms->cmn);
 errout:
   free(pzms);
   return (ZMSHANDLE)NULL;
@@ -1714,7 +1714,7 @@ int zms_release(ZMSHANDLE handle)
 
   /* Release the timer resources */
 
-  (void)zm_timerrelease(&pzms->cmn);
+  zm_timerrelease(&pzms->cmn);
 
   /* Make sure that the file is closed */
 

--- a/system/zmodem/zm_state.c
+++ b/system/zmodem/zm_state.c
@@ -890,7 +890,7 @@ int zm_datapump(FAR struct zm_state_s *pzm)
 
       /* Stop the timer */
 
-      (void)zm_timerstop(pzm);
+      zm_timerstop(pzm);
       sched_unlock();
 
       /* EOF from the remote peer can only mean that we lost the connection

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -153,7 +153,7 @@ static void fstest_loopmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous loop */
@@ -179,7 +179,7 @@ static void fstest_endmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
   printf("\nFinal memory usage:\n");
   fstest_showmemusage(&g_mmbefore, &g_mmafter);
@@ -967,7 +967,7 @@ int main(int argc, FAR char *argv[])
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
   memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
 #endif
 
@@ -988,7 +988,7 @@ int main(int argc, FAR char *argv[])
        */
 
       printf("\n=== FILLING %u =============================\n", i);
-      (void)fstest_fillfs();
+      fstest_fillfs();
       printf("Filled file system\n");
       printf("  Number of files: %d\n", g_nfiles);
       printf("  Number deleted:  %d\n", g_ndeleted);
@@ -1084,7 +1084,7 @@ int main(int argc, FAR char *argv[])
 
       /* Perform garbage collection, integrity checks */
 
-      (void)fstest_gc(buf.f_bfree);
+      fstest_gc(buf.f_bfree);
 
       /* Show memory usage */
 

--- a/testing/nxffs/nxffs_main.c
+++ b/testing/nxffs/nxffs_main.c
@@ -184,7 +184,7 @@ static void nxffs_loopmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous loop */
@@ -210,7 +210,7 @@ static void nxffs_endmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
       g_mmafter = mallinfo();
 #else
-      (void)mallinfo(&g_mmafter);
+      mallinfo(&g_mmafter);
 #endif
       printf("\nFinal memory usage:\n");
       nxffs_showmemusage(&g_mmbefore, &g_mmafter);
@@ -833,7 +833,7 @@ int main(int argc, FAR char *argv[])
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
   memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
 #endif
 
@@ -854,7 +854,7 @@ int main(int argc, FAR char *argv[])
        */
 
       printf("\n=== FILLING %u =============================\n", i);
-      (void)nxffs_fillfs();
+      nxffs_fillfs();
       printf("Filled file system\n");
       printf("  Number of files: %d\n", g_nfiles);
       printf("  Number deleted:  %d\n", g_ndeleted);

--- a/testing/ostest/aio.c
+++ b/testing/ostest/aio.c
@@ -304,7 +304,7 @@ void aio_test(void)
   sigfillset(&set);
   sigdelset(&set, SIGUSR1);
   sigdelset(&set, SIGALRM);
-  (void)sigprocmask(SIG_SETMASK, &set, &oset);
+  sigprocmask(SIG_SETMASK, &set, &oset);
 
   /* Case 1: Poll for transfer complete */
 
@@ -627,7 +627,7 @@ void aio_test(void)
     }
   while (ret < 0);
 
-  (void)sigprocmask(SIG_SETMASK, &oset, NULL);
+  sigprocmask(SIG_SETMASK, &oset, NULL);
   printf("aio_test: Test completed successfully\n");
   return;
 
@@ -635,7 +635,7 @@ errout_with_fildes:
   close(g_fildes);
   g_fildes = -1;
 errout_with_procmask:
-  (void)sigprocmask(SIG_SETMASK, &oset, NULL);
+  sigprocmask(SIG_SETMASK, &oset, NULL);
   printf("aio_test: ERROR: Test aborted\n");
 }
 

--- a/testing/ostest/barrier.c
+++ b/testing/ostest/barrier.c
@@ -138,7 +138,7 @@ void barrier_test(void)
 
   /* Create the barrier */
 
-  (void)pthread_barrierattr_init(&barrierattr);
+  pthread_barrierattr_init(&barrierattr);
 
   /* Start CONFIG_TESTING_OSTEST_NBARRIER_THREADS thread instances */
 

--- a/testing/ostest/fpu.c
+++ b/testing/ostest/fpu.c
@@ -336,8 +336,8 @@ void fpu_test(void)
   /* Wait for each task to complete */
 
   fflush(stdout);
-  (void)waitpid(task1, &statloc, 0);
-  (void)waitpid(task2, &statloc, 0);
+  waitpid(task1, &statloc, 0);
+  waitpid(task2, &statloc, 0);
 
 #else
   printf("fpu_test: ERROR: The FPU test is not properly configured\n");

--- a/testing/ostest/mutex.c
+++ b/testing/ostest/mutex.c
@@ -130,7 +130,7 @@ void mutex_test(void)
 
   printf("Starting thread 1\n");
 #ifdef SDCC
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
   status = pthread_create(&thread1, &attr, thread_func, (pthread_addr_t)1);
 #else
   status = pthread_create(&thread1, NULL, thread_func, (pthread_addr_t)1);

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -142,7 +142,7 @@ static void check_test_memory_usage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous time */
@@ -228,7 +228,7 @@ static int user_main(int argc, char *argv[])
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
   memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
 #endif
 
@@ -556,7 +556,7 @@ static int user_main(int argc, char *argv[])
 #ifdef CONFIG_CAN_PASS_STRUCTS
       g_mmafter = mallinfo();
 #else
-      (void)mallinfo(&g_mmafter);
+      mallinfo(&g_mmafter);
 #endif
 
       printf("\nFinal memory usage:\n");

--- a/testing/ostest/posixtimer.c
+++ b/testing/ostest/posixtimer.c
@@ -118,7 +118,7 @@ static void timer_expiration(int signo, siginfo_t *info, void *ucontext)
 
   /* Check sigprocmask */
 
-  (void)sigfillset(&allsigs);
+  sigfillset(&allsigs);
   status = sigprocmask(SIG_SETMASK, NULL, &oldset);
   if (status != OK)
     {
@@ -156,8 +156,8 @@ void timer_test(void)
 
   printf("timer_test: Unmasking signal %d\n" , MY_TIMER_SIGNAL);
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, MY_TIMER_SIGNAL);
+  sigemptyset(&set);
+  sigaddset(&set, MY_TIMER_SIGNAL);
   status = sigprocmask(SIG_UNBLOCK, &set, NULL);
   if (status != OK)
     {
@@ -169,8 +169,8 @@ void timer_test(void)
   act.sa_sigaction = timer_expiration;
   act.sa_flags  = SA_SIGINFO;
 
-  (void)sigfillset(&act.sa_mask);
-  (void)sigdelset(&act.sa_mask, MY_TIMER_SIGNAL);
+  sigfillset(&act.sa_mask);
+  sigdelset(&act.sa_mask, MY_TIMER_SIGNAL);
 
   status = sigaction(MY_TIMER_SIGNAL, &act, &oact);
   if (status != OK)

--- a/testing/ostest/prioinherit.c
+++ b/testing/ostest/prioinherit.c
@@ -552,20 +552,20 @@ void priority_inheritance(void)
     {
       printf("priority_inheritance: Waiting for highpri_thread-%d to complete\n", i+1);
       FFLUSH();
-      (void)pthread_join(highpri[i], &result);
+      pthread_join(highpri[i], &result);
       dump_nfreeholders("priority_inheritance:");
     }
 
   printf("priority_inheritance: Waiting for medpri_thread to complete\n");
   FFLUSH();
-  (void)pthread_join(medpri, &result);
+  pthread_join(medpri, &result);
   dump_nfreeholders("priority_inheritance:");
 
   for (i = 0; i < NLOWPRI_THREADS; i++)
     {
       printf("priority_inheritance: Waiting for lowpri_thread-%d to complete\n", i+1);
       FFLUSH();
-      (void)pthread_join(lowpri[i], &result);
+      pthread_join(lowpri[i], &result);
       dump_nfreeholders("priority_inheritance:");
     }
 

--- a/testing/ostest/pthread_rwlock.c
+++ b/testing/ostest/pthread_rwlock.c
@@ -268,8 +268,8 @@ static void test_two_threads(void)
   g_race_cond_thread_pos = 0;
   status = pthread_create(&thread1, NULL, race_cond_thread1, &rc);
   status = pthread_create(&thread2, NULL, race_cond_thread2, &rc);
-  (void) pthread_join(thread1, NULL);
-  (void) pthread_join(thread2, NULL);
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
 }
 
 static void * timeout_thread1(FAR void * data)
@@ -373,8 +373,8 @@ static void test_timeout(void)
   status = pthread_create(&thread1, NULL, timeout_thread1, &rc);
   status = pthread_create(&thread2, NULL, timeout_thread2, &rc);
 
-  (void) pthread_join(thread1, NULL);
-  (void) pthread_join(thread2, NULL);
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
 }
 
 /****************************************************************************

--- a/testing/ostest/pthread_rwlock_cancel.c
+++ b/testing/ostest/pthread_rwlock_cancel.c
@@ -63,7 +63,7 @@ static void * timeout_thread1(FAR void * data)
 
   while(1)
     {
-      (void)clock_gettime(CLOCK_REALTIME, &time);
+      clock_gettime(CLOCK_REALTIME, &time);
       time.tv_sec += 1;
 
       status = pthread_rwlock_timedrdlock(sync->write_lock, &time);
@@ -84,7 +84,7 @@ static void * timeout_thread2(FAR void * data)
 
   while (1)
     {
-      (void)clock_gettime(CLOCK_REALTIME, &time);
+      clock_gettime(CLOCK_REALTIME, &time);
       time.tv_sec += 1;
 
       status = pthread_rwlock_timedrdlock(sync->read_lock, &time);
@@ -104,7 +104,7 @@ static void * timeout_thread2(FAR void * data)
             }
         }
 
-      (void)clock_gettime(CLOCK_REALTIME, &time);
+      clock_gettime(CLOCK_REALTIME, &time);
       time.tv_sec += 1;
 
       status = pthread_rwlock_timedwrlock(sync->read_lock, &time);
@@ -186,8 +186,8 @@ static void test_timeout(void)
       printf("pthread_rwlock_cancel: ERROR pthread_cancel, status=%d\n", status);
     }
 
-  (void) pthread_join(thread1, NULL);
-  (void) pthread_join(thread2, NULL);
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
 
   /* Do some operations on locks in order to check if they are still in
    * usable state after deferred cancellation. */

--- a/testing/ostest/rmutex.c
+++ b/testing/ostest/rmutex.c
@@ -161,7 +161,7 @@ void recursive_mutex_test(void)
     {
       printf("recursive_mutex_test: Starting thread %d\n", i+1);
 #ifdef SDCC
-      (void)pthread_attr_init(&attr);
+      pthread_attr_init(&attr);
       status = pthread_create(&thread[i], &attr, thread_outer, (pthread_addr_t)((uintptr_t)i+1));
 #else
       status = pthread_create(&thread[i], NULL, thread_outer, (pthread_addr_t)((uintptr_t)i+1));

--- a/testing/ostest/sighand.c
+++ b/testing/ostest/sighand.c
@@ -136,7 +136,7 @@ static void wakeup_action(int signo, siginfo_t *info, void *ucontext)
 
   /* Check sigprocmask */
 
-  (void)sigfillset(&allsigs);
+  sigfillset(&allsigs);
   status = sigprocmask(SIG_SETMASK, NULL, &oldset);
   if (status != OK)
     {
@@ -161,8 +161,8 @@ static int waiter_main(int argc, char *argv[])
   printf("waiter_main: Waiter started\n" );
 
   printf("waiter_main: Unmasking signal %d\n" , WAKEUP_SIGNAL);
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, WAKEUP_SIGNAL);
+  sigemptyset(&set);
+  sigaddset(&set, WAKEUP_SIGNAL);
   status = sigprocmask(SIG_UNBLOCK, &set, NULL);
   if (status != OK)
     {
@@ -174,8 +174,8 @@ static int waiter_main(int argc, char *argv[])
   act.sa_sigaction = wakeup_action;
   act.sa_flags  = SA_SIGINFO;
 
-  (void)sigfillset(&act.sa_mask);
-  (void)sigdelset(&act.sa_mask, WAKEUP_SIGNAL);
+  sigfillset(&act.sa_mask);
+  sigdelset(&act.sa_mask, WAKEUP_SIGNAL);
 
   status = sigaction(WAKEUP_SIGNAL, &act, &oact);
   if (status != OK)
@@ -214,7 +214,7 @@ static int waiter_main(int argc, char *argv[])
   /* Detach the signal handler */
 
   act.sa_handler = SIG_DFL;
-  (void)sigaction(WAKEUP_SIGNAL, &act, &oact);
+  sigaction(WAKEUP_SIGNAL, &act, &oact);
 
   printf("waiter_main: done\n" );
   FFLUSH();
@@ -245,8 +245,8 @@ void sighand_test(void)
 #ifdef CONFIG_SCHED_HAVE_PARENT
   printf("sighand_test: Unmasking SIGCHLD\n");
 
-  (void)sigemptyset(&set);
-  (void)sigaddset(&set, SIGCHLD);
+  sigemptyset(&set);
+  sigaddset(&set, SIGCHLD);
   status = sigprocmask(SIG_UNBLOCK, &set, NULL);
   if (status != OK)
     {
@@ -258,8 +258,8 @@ void sighand_test(void)
   act.sa_sigaction = death_of_child;
   act.sa_flags  = SA_SIGINFO;
 
-  (void)sigfillset(&act.sa_mask);
-  (void)sigdelset(&act.sa_mask, SIGCHLD);
+  sigfillset(&act.sa_mask);
+  sigdelset(&act.sa_mask, SIGCHLD);
 
   status = sigaction(SIGCHLD, &act, &oact);
   if (status != OK)
@@ -332,7 +332,7 @@ void sighand_test(void)
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
   act.sa_handler = SIG_DFL;
-  (void)sigaction(SIGCHLD, &act, &oact);
+  sigaction(SIGCHLD, &act, &oact);
 #endif
 
   printf("sighand_test: done\n" );

--- a/testing/ostest/signest.c
+++ b/testing/ostest/signest.c
@@ -134,7 +134,7 @@ static int waiter_main(int argc, char *argv[])
   printf("waiter_main: Waiter started\n" );
   printf("waiter_main: Setting signal mask\n" );
 
-  (void)sigemptyset(&set);
+  sigemptyset(&set);
   ret = sigprocmask(SIG_SETMASK, &set, NULL);
   if (ret < 0)
     {
@@ -147,12 +147,12 @@ static int waiter_main(int argc, char *argv[])
   act.sa_handler = waiter_action;
   act.sa_flags   = 0;
 
-  (void)sigemptyset(&act.sa_mask);
+  sigemptyset(&act.sa_mask);
   for (i = 1; i < MAX_SIGNO; i += 2)
     {
       if (signest_catchable(i))
         {
-          (void)sigaddset(&act.sa_mask, i);
+          sigaddset(&act.sa_mask, i);
         }
     }
 
@@ -196,7 +196,7 @@ static int interfere_main(int argc, char *argv[])
   g_interferer_running = true;
   while (!g_done)
     {
-      (void)sem_wait(&g_interferer_sem);
+      sem_wait(&g_interferer_sem);
     }
 
   /* Just exit, the system should clean up the signal handlers */

--- a/testing/ostest/specific.c
+++ b/testing/ostest/specific.c
@@ -129,7 +129,7 @@ void specific_test(void)
 
   printf("Starting thread\n");
 #ifdef SDCC
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
   ret = pthread_create(&thread, &attr, thread_func, (pthread_addr_t)0);
 #else
   ret = pthread_create(&thread, NULL, thread_func, (pthread_addr_t)0);

--- a/testing/ostest/timedmutex.c
+++ b/testing/ostest/timedmutex.c
@@ -119,7 +119,7 @@ static void *thread_func(FAR void *parameter)
 
       /* Release the lock and wait a bit in case the main thread wants it. */
 
-      (void)pthread_mutex_unlock(&g_mutex);
+      pthread_mutex_unlock(&g_mutex);
       usleep(500*1000);
     }
 
@@ -157,7 +157,7 @@ void timedmutex_test(void)
 
   printf("mutex_test: Starting thread\n");
 #ifdef SDCC
-  (void)pthread_attr_init(&attr);
+  pthread_attr_init(&attr);
   status = pthread_create(&thread, &attr, thread_func, (pthread_addr_t)0);
 #else
   status = pthread_create(&thread, NULL, thread_func, (pthread_addr_t)0);
@@ -175,7 +175,7 @@ void timedmutex_test(void)
   /* Then unlock the mutex.  This should wake up the pthread. */
 
   printf("mutex_test: Unlocking\n");
-  (void)pthread_mutex_unlock(&g_mutex);
+  pthread_mutex_unlock(&g_mutex);
 
   /* Wait a bit to assure that the thread gets a chance to lock the mutex at
    * least once (it may probably loop and retake the mutex several times)
@@ -227,7 +227,7 @@ void timedmutex_test(void)
 #endif
 
 errout_with_lock:
-  (void)pthread_mutex_unlock(&g_mutex);
+  pthread_mutex_unlock(&g_mutex);
 errout_with_mutex:
-  (void)pthread_mutex_destroy(&g_mutex);
+  pthread_mutex_destroy(&g_mutex);
 }

--- a/testing/smart/smart_main.c
+++ b/testing/smart/smart_main.c
@@ -187,7 +187,7 @@ static void smart_loopmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
 
   /* Show the change from the previous loop */
@@ -213,7 +213,7 @@ static void smart_endmemusage(void)
 #ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
 #else
-  (void)mallinfo(&g_mmafter);
+  mallinfo(&g_mmafter);
 #endif
   printf("\nFinal memory usage:\n");
   smart_showmemusage(&g_mmbefore, &g_mmafter);
@@ -829,9 +829,9 @@ int main(int argc, FAR char *argv[])
   /* Create a SMARTFS filesystem */
 
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
-  (void)mksmartfs("/dev/smart1", 1024, 1);
+  mksmartfs("/dev/smart1", 1024, 1);
 #else
-  (void)mksmartfs("/dev/smart1", 1024);
+  mksmartfs("/dev/smart1", 1024);
 #endif
 
   /* Mount the file system */
@@ -850,7 +850,7 @@ int main(int argc, FAR char *argv[])
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
 #else
-  (void)mallinfo(&g_mmbefore);
+  mallinfo(&g_mmbefore);
   memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
 #endif
 
@@ -871,7 +871,7 @@ int main(int argc, FAR char *argv[])
        */
 
       printf("\n=== FILLING %u =============================\n", i);
-      (void)smart_fillfs();
+      smart_fillfs();
       printf("Filled file system\n");
       printf("  Number of files: %d\n", g_nfiles);
       printf("  Number deleted:  %d\n", g_ndeleted);

--- a/testing/smp/smp_main.c
+++ b/testing/smp/smp_main.c
@@ -148,7 +148,7 @@ static void hog_time(FAR const char *caller, int threadno)
 
       /* Let other threads run */
 
-      (void)pthread_yield();
+      pthread_yield();
       show_cpu_conditional(caller, threadno);
     }
 }
@@ -265,7 +265,7 @@ int main(int argc, FAR char *argv[])
 
   /* Create the barrier */
 
-  (void)pthread_barrierattr_init(&barrierattr);
+  pthread_barrierattr_init(&barrierattr);
 
   /* Start CONFIG_TESTING_SMP_NBARRIER_THREADS thread instances */
 

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -508,8 +508,8 @@ static int socket_request(int fd, FAR struct gs2200m_s *priv,
        */
 
       usock = gs2200m_socket_get(priv, usockid);
-      (void)usock_send_event(fd, priv, usock,
-                             USRSOCK_EVENT_SENDTO_READY);
+      usock_send_event(fd, priv, usock,
+                       USRSOCK_EVENT_SENDTO_READY);
     }
 
   gs2200m_printf("%s: end \n", __func__);
@@ -553,7 +553,7 @@ static int close_request(int fd, FAR struct gs2200m_s *priv,
 
   memset(&clmsg, 0, sizeof(clmsg));
   clmsg.cid = cid;
-  (void)ioctl(priv->gsfd, GS2200M_IOC_CLOSE, (unsigned long)&clmsg);
+  ioctl(priv->gsfd, GS2200M_IOC_CLOSE, (unsigned long)&clmsg);
 
 errout:
 
@@ -1281,7 +1281,7 @@ static int ioctl_request(int fd, FAR struct gs2200m_s *priv,
       case SIOCSIFDSTADDR:
       case SIOCSIFNETMASK:
 
-        (void)read(fd, &imsg.ifr, sizeof(imsg.ifr));
+        read(fd, &imsg.ifr, sizeof(imsg.ifr));
         break;
 
       default:
@@ -1314,7 +1314,7 @@ static int ioctl_request(int fd, FAR struct gs2200m_s *priv,
       resp2.valuelen_nontrunc = sizeof(imsg.ifr);
       resp2.valuelen = sizeof(imsg.ifr);
 
-      (void)_write_to_usock(fd, &resp2, sizeof(resp2));
+      _write_to_usock(fd, &resp2, sizeof(resp2));
 
       /* Return struct ifreq address */
 

--- a/wireless/ieee802154/i8sak/i8sak_assoc.c
+++ b/wireless/ieee802154/i8sak/i8sak_assoc.c
@@ -311,7 +311,7 @@ void i8sak_assoc_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
   /* Clean up and return */
 
-  (void)i8sak_eventlistener_removereceiver(i8sak, assoc_eventcb);
+  i8sak_eventlistener_removereceiver(i8sak, assoc_eventcb);
   i8sak_releasedaemon(i8sak);
   close(fd);
 }


### PR DESCRIPTION
1.Remove void cast for function because many place ignore the returned value witout cast
2.Replace void cast for variable with UNUSED macro

Change-Id: Ie644129a563244a6397036789c4c3ea83c4e9b09
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>