### PR TITLE
changes NSH command line editing so ctrl-K deletes from char pos to EOL like GNU readline

### DIFF
--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -1076,7 +1076,7 @@ static int cle_editloop(FAR struct cle_s *priv)
 
         case KEY_DELEOL:  /* Delete to the end of the line */
           {
-            priv->nchars = (priv->nchars > 0 ? priv->curpos + 1 : 0);
+            priv->nchars = (priv->nchars > 0 ? priv->curpos : 0);
           }
           break;
 


### PR DESCRIPTION
### Summary

- changes NSH command line editing so ctrl-K deletes from char pos to EOL like GNU readline
- now you can delete entire line with `ctrl-A` `ctrl-K`

### Impact

- None if `CONFIG_NSH_CLE` is not set
- if `CONFIG_NSH_CLE=y` is set, `ctrl-K` deletes from cursor position to end of line, instead of the old behavior, cursor position + 1 to end of line. 
- The new behavior is more like GNU Readline

### Testing

- Manual, on the SAMA5D36-Xplained board.

### How To Verify (beyond provided automated tests)

- `CONFIG_NSH_CLE=y`in `.config`
- make clean; make
- connect to the NSH via a serial console
- You should see the new command line editing behavior

