### PR TITLE
netutils/ftpd/ftpd.c:  Fix an error introduced in PR10.

### DIFF
--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1617,8 +1617,6 @@ static int ftpd_changedir(FAR struct ftpd_session_s *session,
                      (FAR char **)(&workpath));
   if (ret < 0)
     {
-      free(workpath);
-      free(abspath);
       ftpd_response(session->cmd.sd, session->txtimeout,
                     g_respfmt1, 550, ' ',
                     "Can not change directory !");


### PR DESCRIPTION
In error clean-up, it was trying to free memory on an error where we failed allocated memory.  Not good.