### PR TITLE
Remove unselectable CONFIG_NET_TCP_READHEAD dependencies.

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -895,7 +895,6 @@ examples/netloop
     CONFIG_NET_LOOPBACK           - Requires local loopback supprt
     CONFIG_NET_TCP                - Requires TCP support with the following:
     CONFIG_NET_TCPBACKLOG
-    CONFIG_NET_TCP_READAHEAD
     CONFIG_NET_TCP_WRITE_BUFFERS
     CONFIG_NET_IPv4               - Currently supports only IPv4
 
@@ -1229,7 +1228,6 @@ examples/poll
 
   CONFIG_NET                        - Defined for general network support
   CONFIG_NET_TCP                    - Defined for TCP/IP support
-  CONFIG_NET_TCP_READAHEAD          - Defined
   CONFIG_NET_NTCP_READAHEAD_BUFFERS - Defined to be greater than zero
 
   CONFIG_EXAMPLES_POLL_NOMAC         - (May be defined to use software assigned MAC)

--- a/examples/netloop/Kconfig
+++ b/examples/netloop/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_NETLOOP
 	tristate "Local loopback example"
 	default n
-	depends on NET_LOOPBACK && NET_TCP && NET_TCPBACKLOG && NET_TCP_READAHEAD && NET_TCP_WRITE_BUFFERS && NET_IPv4
+	depends on NET_LOOPBACK && NET_TCP && NET_TCPBACKLOG && NET_TCP_WRITE_BUFFERS && NET_IPv4
 	---help---
 		Enable the local loopback example
 

--- a/examples/netloop/netloop.h
+++ b/examples/netloop/netloop.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * examples/netloop/netloop.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2015, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,6 @@
  * CONFIG_NET                  - Network support must be enabled
  * CONFIG_NET_TCP              - Only support on TCP (because read-ahead
  *                               buffering s not yet support for UDP)
- * CONFIG_NET_TCP_READAHEAD    - TCP/IP read-ahead buffering must be enabled
  */
 
 
@@ -64,8 +63,8 @@
 #  error Network socket support not enabled
 #endif
 
-#if !defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_READAHEAD) || \
-    !defined(CONFIG_NET_TCPBACKLOG) || !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+#if !defined(CONFIG_NET_TCP) || !defined(CONFIG_NET_TCPBACKLOG) || \
+    !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
 #  error TCP not configured correctly
 #endif
 

--- a/examples/poll/poll_internal.h
+++ b/examples/poll/poll_internal.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * examples/poll/poll_internal.h
  *
- *   Copyright (C) 2008, 2009, 2014 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2008, 2009, 2014, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,11 +56,9 @@
  * CONFIG_NET                  - Network support must be enabled
  * CONFIG_NET_TCP              - Only support on TCP (because read-ahead
  *                               buffering s not yet support for UDP)
- * CONFIG_NET_TCP_READAHEAD    - TCP/IP read-ahead buffering must be enabled
  */
 
-#if defined(CONFIG_NET) && defined(CONFIG_NET_TCP) && \
-    defined(CONFIG_NET_TCP_READAHEAD)
+#if defined(CONFIG_NET) && defined(CONFIG_NET_TCP)
 #  define HAVE_NETPOLL 1
 #else
 #  undef HAVE_NETPOLL

--- a/netutils/thttpd/config.h
+++ b/netutils/thttpd/config.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * netutils/thttpd/config.h
  *
- *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@
 #undef CONFIG_THTTPD
 #if defined(CONFIG_NET) && defined(CONFIG_NET_TCP) && \
     defined(CONFIG_NET_TCPBACKLOG) && !defined(CONFIG_DISABLE_ENVIRON) && \
-    !defined(CONFIG_SDCLONE_DISABLE) && defined(CONFIG_NET_TCP_READAHEAD)
+    !defined(CONFIG_SDCLONE_DISABLE)
 
 #  define CONFIG_THTTPD 1
 


### PR DESCRIPTION
NuttX commit 346336bb9e5c9199b82e34d08bf23dd1bc389460 make CONFIG_NET_TCP_READADHEAD unselectable and removed all references to CONFIG_NET_TCP_READHEAD from the the NuttX repositories.  However, there was no corresponding removal of CONFIG_NET_TCP_READHEAD from the apps/ repository.  As a result, there was logic that depended on the selection of CONFIG_NET_TCP_READHEAD that could never be enabled.

This was found during build testing using the configuration olimex-lpc1766stk/thttpd-binfs.  THTTPD was not being built fully because it had dependencies on CONFIG_NET_TCP_READHEAD.  There resulted int numerous new warnings and, finally, the error:

    (.../apps.examples.thttpd.o): in function `thttp_main':
    thttpd_main.c:(.text+0x104): undefined reference to `thttpd_main'