### PR TITLE
Add install dependency on chardev BIN to fix parallel build break

### DIFF
--- a/examples/module/drivers/chardev/Makefile
+++ b/examples/module/drivers/chardev/Makefile
@@ -92,6 +92,6 @@ clean:
 	$(call DELFILE, $(BIN))
 	$(call CLEAN)
 
-install:
+install: $(BIN)
 	$(Q) mkdir -p $(FSROOT_DIR)
 	$(Q) install $(BIN) $(FSROOT_DIR)/$(BIN)


### PR DESCRIPTION
chardev bin may not availabe before make install in parallel build,
so add install dependency on chardev BIN here.

Change-Id: If28451ceeeed0a6463544d8c342871cecda5a057
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>