### PR TITLE
apps: gs2200m: Remove unnecessary usleep() to improve throughput

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1404,8 +1404,6 @@ static int gs2200m_loop(FAR struct gs2200m_s *priv)
                                USRSOCK_EVENT_RECVFROM_AVAIL);
             }
         }
-
-      usleep(1);
     }
 
 errout:


### PR DESCRIPTION
### Summary

- Removed unnecessary usleep() in gs2200m_main.c to improve throughput.

### Impact

- All network use-cases whch use gs2200m Wi-Fi module.

### Testing

- I tested webserver and telnetd use-cases with Spresense.
