### PR TITLE
examples/posix_spawn: update dependency to fix parallel build break

### DIFF
--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -77,7 +77,7 @@ $(ROMFS_HDR) : $(ROMFS_IMG)
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): $(ROMFS_DIR)/hello $(ROMFS_DIR)/redirect $(ROMFS_DIR)/testdata.txt
+$(SYMTAB_SRC): $(ROMFS_IMG)
 	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@
 
 # Clean each subdirectory

--- a/examples/posix_spawn/filesystem/hello/Makefile
+++ b/examples/posix_spawn/filesystem/hello/Makefile
@@ -56,7 +56,6 @@ clean:
 	$(call DELFILE, *.dSYM)
 	$(call CLEAN)
 
-install:
-
+install: $(BIN)
 	$(Q) mkdir -p $(ROMFS_DIR)
 	$(Q) install $(BIN) $(ROMFS_DIR)/$(BIN)

--- a/examples/posix_spawn/filesystem/redirect/Makefile
+++ b/examples/posix_spawn/filesystem/redirect/Makefile
@@ -56,7 +56,6 @@ clean:
 	$(call DELFILE, *.dSYM)
 	$(call CLEAN)
 
-install:
-
+install: $(BIN)
 	$(Q) mkdir -p $(ROMFS_DIR)
 	$(Q) install -m 0755 $(BIN) $(ROMFS_DIR)/$(BIN)


### PR DESCRIPTION
In stm32f4discovery:posix_spawn and lc823450-xgevk:posix_spawn parallel build,
it failed since apps/examples/posix_spawn/filesystem/romfs/hello is not available
which is needed by examples/posix_spawn/filesystem/symtab.c.

Change-Id: I588317396f8e3ca4d69d4ec8db8ccad219207048
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>