### PR TITLE
Set NXGLYPHS_BACKGROUNDCOLOR default value

### DIFF
--- a/graphics/nxglyphs/Kconfig
+++ b/graphics/nxglyphs/Kconfig
@@ -11,6 +11,9 @@ config NXGLYPHS_LARGE_ICONS
 
 config NXGLYPHS_BACKGROUNDCOLOR
 	hex "Background Color"
+	default 0x97 if NXWIDGETS_BPP = 8
+	default 0x95fa if NXWIDGETS_BPP = 16
+	default 0x94bdd7 if NXWIDGETS_BPP = 24 || NXWIDGETS_BPP = 32
 	---help---
 		Normal background color.  Default: RGB(148,189,215)
 


### PR DESCRIPTION
to avoid warning: symbol value '' invalid for NXGLYPHS_BACKGROUNDCOLOR

Change-Id: I56e83a88b41d26a6833131a8dc89afe0dcf25d96
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>