### PR TITLE
Add configuration settings for apps/examples/sendmail.

### DIFF
--- a/examples/sendmail/Kconfig
+++ b/examples/sendmail/Kconfig
@@ -6,8 +6,53 @@
 config EXAMPLES_SENDMAIL
 	tristate "Sendmail example"
 	default n
+	depends on NET_IPv4
+	depends on NET_TCP
+	select NETUTILS_SMTP
 	---help---
 		Enable the sendmail example
 
 if EXAMPLES_SENDMAIL
+
+config EXAMPLES_SENDMAIL_NOMAC
+	bool "Use Canned MAC Address"
+	default n
+	---help---
+		If the hardware has no MAC address of its own, define this =y to
+		provide a bogus address for testing.
+
+config EXAMPLES_SENDMAIL_IPADDR
+	hex "Target IP address"
+	default 0x0a000002
+	---help---
+		The target IP address.  Default 10.0.0.2 (0x0a000002)
+
+config EXAMPLES_SENDMAIL_DRIPADDR
+	hex "Default Router IP address (Gateway)"
+	default 0x0a000001
+	---help---
+		The default router address. Default 10.0.0.1 (0x0a000001)
+
+config EXAMPLES_SENDMAIL_NETMASK
+	hex "Network Mask"
+	default 0xffffff00
+	---help---
+		The network mask.  Default: 255.255.255.0 (0xffffff00)
+
+config EXAMPLES_SENDMAIL_RECIPIENT
+	string "Recipient email"
+	default "Jane Doe <jane.doe@janedoemail.com>"
+
+config EXAMPLES_SENDMAIL_SENDER
+	string "Sender email"
+	default "John Doe <john.doe@johndoemail.com>"
+
+config EXAMPLES_SENDMAIL_SUBJECT
+	string "Subject"
+	default "Test"
+
+config EXAMPLES_SENDMAIL_BODY
+	string "Mail Body"
+	default "This is a test"
+
 endif

--- a/examples/sendmail/sendmail_main.c
+++ b/examples/sendmail/sendmail_main.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * examples/sendmail/sendmail_maini.c
  *
- *   Copyright (C) 2009, 2011 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009, 2011, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,19 +57,19 @@
  ****************************************************************************/
 
 #ifndef CONFIG_EXAMPLES_SENDMAIL_RECIPIENT
-#  error "You must provice CONFIG_EXAMPLES_SENDMAIL_RECIPIENT"
+#  error "You must provide CONFIG_EXAMPLES_SENDMAIL_RECIPIENT"
 #endif
 
 #ifndef CONFIG_EXAMPLES_SENDMAIL_IPADDR
-#  error "You must provice CONFIG_EXAMPLES_SENDMAIL_IPADDR"
+#  error "You must provide CONFIG_EXAMPLES_SENDMAIL_IPADDR"
 #endif
 
 #ifndef CONFIG_EXAMPLES_SENDMAIL_DRIPADDR
-#  error "You must provice CONFIG_EXAMPLES_SENDMAIL_DRIPADDR"
+#  error "You must provide CONFIG_EXAMPLES_SENDMAIL_DRIPADDR"
 #endif
 
 #ifndef CONFIG_EXAMPLES_SENDMAIL_NETMASK
-#  error "You must provice CONFIG_EXAMPLES_SENDMAIL_NETMASK"
+#  error "You must provide CONFIG_EXAMPLES_SENDMAIL_NETMASK"
 #endif
 
 #ifndef CONFIG_EXAMPLES_SENDMAIL_SENDER
@@ -95,10 +95,6 @@ static const char g_subject[]   = CONFIG_EXAMPLES_SENDMAIL_SUBJECT;
 static const char g_msg_body[]  = CONFIG_EXAMPLES_SENDMAIL_BODY "\r\n";
 
 /****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -119,7 +115,7 @@ int main(int argc, FAR char *argv[])
   printf("sendmail: Subject: %s\n", g_subject);
   printf("sendmail: Body: %s\n", g_msg_body);
 
-/* Many embedded network interfaces must have a software assigned MAC */
+  /* Many embedded network interfaces must have a software assigned MAC */
 
 #ifdef CONFIG_EXAMPLES_SENDMAIL_NOMAC
   mac[0] = 0x00;

--- a/netutils/smtp/Kconfig
+++ b/netutils/smtp/Kconfig
@@ -6,6 +6,8 @@
 config NETUTILS_SMTP
 	bool "SMTP"
 	default n
+	depends on NET_IPv4
+	depends on NET_TCP
 	---help---
 		Enable support for SMTP.
 

--- a/netutils/smtp/smtp.c
+++ b/netutils/smtp/smtp.c
@@ -2,7 +2,8 @@
  * apps/netutitls/smtp/smtp.c
  * smtp SMTP E-mail sender
  *
- *   Copyright (C) 2007, 2009, 2011, 2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007, 2009, 2011, 2015, 2020 Gregory Nutt. All rights
+ *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Heavily leveraged from uIP 1.0 which also has a BSD-like license:
@@ -134,7 +135,8 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
       return ERROR;
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtphelo, psmtp->localhostname);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtphelo, psmtp->localhostname);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
@@ -150,7 +152,8 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
       return ERROR;
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtpmailfrom, psmtp->from);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtpmailfrom, psmtp->from);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
@@ -166,7 +169,8 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
       return ERROR;
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtprcptto, psmtp->to);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtprcptto, psmtp->to);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
@@ -184,7 +188,8 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
 
   if (psmtp->cc != 0)
     {
-      snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtprcptto, psmtp->cc);
+      snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+               g_smtprcptto, psmtp->cc);
       if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
         {
           return ERROR;
@@ -216,7 +221,8 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
       return ERROR;
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtpto, psmtp->to);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtpto, psmtp->to);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
@@ -224,20 +230,23 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
 
   if (psmtp->cc != 0)
     {
-      snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtpto, psmtp->cc);
+      snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+               g_smtpto, psmtp->cc);
       if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
         {
           return ERROR;
         }
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtpfrom, psmtp->from);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtpfrom, psmtp->from);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
     }
 
-  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n", g_smtpsubject, psmtp->subject);
+  snprintf(psmtp->buffer, SMTP_INPUT_BUFFER_SIZE, "%s%s\r\n",
+           g_smtpsubject, psmtp->subject);
   if (send(sockfd, psmtp->buffer, strlen(psmtp->buffer), 0) < 0)
     {
       return ERROR;
@@ -267,6 +276,7 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
     {
       return ERROR;
     }
+
   return OK;
 }
 
@@ -274,7 +284,7 @@ static inline int smtp_send_message(int sockfd, struct smtp_state *psmtp)
  * Public Functions
  ****************************************************************************/
 
-/* Specificy an SMTP server and hostname.
+/* Specify an SMTP server and hostname.
  *
  * This function is used to configure the SMTP module with an SMTP server and
  * the hostname of the host.
@@ -362,10 +372,10 @@ void *smtp_open(void)
       /* Initialize the handle */
 
       memset(psmtp, 0, sizeof(struct smtp_state));
-     sem_init(&psmtp->sem, 0, 0);
+      sem_init(&psmtp->sem, 0, 0);
     }
 
-  return (void*)psmtp;
+  return (FAR void *)psmtp;
 }
 
 void smtp_close(void *handle)

--- a/system/zmodem/zm_state.c
+++ b/system/zmodem/zm_state.c
@@ -647,7 +647,7 @@ static int zm_data(FAR struct zm_state_s *pzm, uint8_t ch)
   if (pzm->pktlen >= ZM_PKTBUFSIZE)
     {
       zmdbg("ERROR:  The packet buffer is full\n");
-      zmdbg("        ch=%c[%02x] pktlen=%d ptktype=%02x ncrc=%d\n",
+      zmdbg("        ch=%c[%02x] pktlen=%d pkttype=%02x ncrc=%d\n",
             isprint(ch) ? ch : '.', ch, pzm->pktlen, pzm->pkttype, pzm->ncrc);
       zmdbg("        rcvlen=%d rcvndx=%d\n",
             pzm->rcvlen, pzm->rcvndx);


### PR DESCRIPTION
The sendmail example hasn't been used in years.  I am not sure it was ever debugged.  It is so old that it still expects hand editted .config files.  As a result, all of the configuration settings were missing from the Kconfig file.

This commit adds the missing apps/examples/sendmail configuration settings so that the example at least builds.  I cannot test it because I have no smtp server that I am willing to spam.

This configuration also adds missing configuration dependencies and runs the C files in apps/examples/sendmail and apps/netutils/smtp through nxstyle.

This commit resolves an issue reported by surya prakash rased in the Google group:  https://groups.google.com/forum/#!topic/nuttx/idr-M164Y24