### PR TITLE
wireless: gs2200m: Fix sendto_request() in gs2200m_main.c

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -802,7 +802,9 @@ static int sendto_request(int fd, FAR struct gs2200m_s *priv,
           goto prepare;
         }
 
-      ret = req->buflen;
+      /* return length which gs2200m sent */
+
+      ret = smsg.len;
     }
 
 prepare:


### PR DESCRIPTION
### Summary

- This is an additional PR (please see https://github.com/apache/incubator-nuttx/pull/171)

### Impact

- This PR only affects the gs2200m daemon and typically for congested network or receiver window size is zero cases.

### Testing

- To test this PR, https://github.com/apache/incubator-nuttx/pull/171 must be used.
