### PR TITLE
examples: hello: Show CPU index when running in SMP mode

### DIFF
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -40,6 +40,10 @@
 #include <nuttx/config.h>
 #include <stdio.h>
 
+#ifdef CONFIG_SMP
+#  include <nuttx/arch.h>
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -50,6 +54,12 @@
 
 int main(int argc, FAR char *argv[])
 {
+#ifdef CONFIG_SMP
+  uint32_t cpu = up_cpu_index();
+
+  printf("Hello, World from CPU%d !!\n", cpu);
+#else
   printf("Hello, World!!\n");
+#endif
   return 0;
 }


### PR DESCRIPTION
### Summary

- The hello app now shows cpu index when running in SMP mode.

### Impact

- This PR only affects the hello app.

### Testing

- I only tested the app with Sony Spresense in SMP/non-SMP modes.
