### PR TITLE
Remove all CONFIG_NET_HAVE_REUSEADDR guard

### DIFF
--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1174,12 +1174,10 @@ static FAR struct ftpd_server_s *ftpd_openserver(int port, sa_family_t family)
       return NULL;
     }
 
-#ifdef CONFIG_NET_HAVE_REUSEADDR
   {
     int reuse = 1;
     setsockopt(server->sd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
   }
-#endif
 
   /* Bind the socket to the address */
 

--- a/netutils/netlib/netlib_listenon.c
+++ b/netutils/netlib/netlib_listenon.c
@@ -78,9 +78,7 @@ int netlib_listenon(uint16_t portno)
 {
   struct sockaddr_in myaddr;
   int listensd;
-#ifdef CONFIG_NET_HAVE_REUSEADDR
   int optval;
-#endif
 
   /* Create a new TCP socket to use to listen for connections */
 
@@ -93,14 +91,12 @@ int netlib_listenon(uint16_t portno)
 
   /* Set socket to reuse address */
 
-#ifdef CONFIG_NET_HAVE_REUSEADDR
   optval = 1;
   if (setsockopt(listensd, SOL_SOCKET, SO_REUSEADDR, (void*)&optval, sizeof(int)) < 0)
     {
       nerr("ERROR: setsockopt SO_REUSEADDR failure: %d\n", errno);
       goto errout_with_socket;
     }
-#endif
 
   /* Bind the socket to a local address */
 


### PR DESCRIPTION
Change-Id: I24990bbec8cc4d6d0f06899bec45c575dd35b77f
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>