### PR TITLE
apps: elf: Fix stack corruption in task test

### DIFF
--- a/examples/elf/tests/task/task.c
+++ b/examples/elf/tests/task/task.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 
   child_argv[0] = child_arg;
   child_argv[1] = 0;
-  child_pid = task_create(child_name, 50, 512, child_task, (FAR char * const *)child_argv);
+  child_pid = task_create(child_name, 50, 2048, child_task, (FAR char * const *)child_argv);
   if (child_pid < 0)
     {
       printf("Parent: task_create failed: %d\n", errno);


### PR DESCRIPTION
### Summary

-  Increase stack size for task test from 512B to 2KB to avoid stack corruption

### Impact

-  This PR only affects a task test in apps/examples/elf

### Testing

- Test program passed on Sony Spresense board
