### PR TITLE
gs2200m: Retry indefinately on GS2200M_IOC_ASSOC failure

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1350,12 +1350,15 @@ static int gs2200m_loop(FAR struct gs2200m_s *priv)
   amsg.key  = priv->key;
   amsg.mode = priv->mode;
   amsg.ch   = priv->ch;
-  ret = ioctl(priv->gsfd, GS2200M_IOC_ASSOC, (unsigned long)&amsg);
-
-  if (0 != ret)
+  while (true)
     {
-      fprintf(stderr, "association failed : invalid ssid or key \n");
-      goto errout;
+      ret = ioctl(priv->gsfd, GS2200M_IOC_ASSOC, (unsigned long)&amsg);
+
+      if (0 == ret)
+        {
+          break;
+        }
+      fprintf(stderr, "association failed : retrying\n");
     }
 
   while (true)


### PR DESCRIPTION
The ioctl doesn't return why it failed.
It might or might not be a transient failure.

In my environment, gs2200m often returns the following for AT+WA.
It usually works after a few retries.

[   12.110000] _parse_pkt_in_s1: +++++ 0:(msize=19, msg=WLAN CONNECT ERROR|)
[   12.110000] _parse_pkt_in_s1: +++++ 1:(msize=6, msg=ERROR|)