### PR TITLE
graphics/littlevgl/Makefile: update lvgl.h dependency to fix parallel…

### DIFF
--- a/graphics/littlevgl/Makefile
+++ b/graphics/littlevgl/Makefile
@@ -82,7 +82,9 @@ $(LVGL_UNPACKNAME)/.patched: $(LVGL_UNPACKNAME) $(PATCH_FILES)
 	$(Q) cat $(PATCH_FILES) | $(PATCH)
 	$(Q) touch $(LVGL_UNPACKNAME)/.patched
 
-$(APPDIR)/include/graphics/lvgl.h: $(LVGL_UNPACKNAME) $(LVGL_UNPACKNAME)/.patched lvgl/lvgl.h
+lvgl/lvgl.h: $(LVGL_UNPACKNAME)
+
+$(APPDIR)/include/graphics/lvgl.h: $(LVGL_UNPACKNAME)/.patched lvgl/lvgl.h
 	@echo "CP: lvgl/lvgl.h"
 	$(Q) cp lvgl/lvgl.h $(APPDIR)/include/graphics/lvgl.h
 


### PR DESCRIPTION
… build break

Parallel build imxrt1060-evk:lvgl with the below error:
make[3]: *** No rule to make target 'lvgl/lvgl.h', needed by '/home/jenkins/jenkins-slave/
workspace/NuttX-Nightly-Build/apps/include/graphics/lvgl.h'.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>