### PR TITLE
Fix error about netlib and gs2200m

### DIFF
--- a/netutils/netlib/netlib_listenon.c
+++ b/netutils/netlib/netlib_listenon.c
@@ -94,8 +94,7 @@ int netlib_listenon(uint16_t portno)
   optval = 1;
   if (setsockopt(listensd, SOL_SOCKET, SO_REUSEADDR, (void*)&optval, sizeof(int)) < 0)
     {
-      nerr("ERROR: setsockopt SO_REUSEADDR failure: %d\n", errno);
-      goto errout_with_socket;
+      nwarn("WARNING: setsockopt SO_REUSEADDR failure: %d\n", errno);
     }
 
   /* Bind the socket to a local address */

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1221,8 +1221,8 @@ err_out:
 static int setsockopt_request(int fd, FAR struct gs2200m_s *priv,
                               FAR void *hdrbuf)
 {
-  ASSERT(false);
-  return -EINVAL;
+  DEBUGASSERT(false);
+  return -ENOSYS;
 }
 
 /****************************************************************************
@@ -1232,8 +1232,8 @@ static int setsockopt_request(int fd, FAR struct gs2200m_s *priv,
 static int getsockopt_request(int fd, FAR struct gs2200m_s *priv,
                               FAR void *hdrbuf)
 {
-  ASSERT(false);
-  return -EINVAL;
+  DEBUGASSERT(false);
+  return -ENOSYS;
 }
 
 /****************************************************************************
@@ -1243,8 +1243,8 @@ static int getsockopt_request(int fd, FAR struct gs2200m_s *priv,
 static int getsockname_request(int fd, FAR struct gs2200m_s *priv,
                                FAR void *hdrbuf)
 {
-  ASSERT(false);
-  return -EINVAL;
+  DEBUGASSERT(false);
+  return -ENOSYS;
 }
 
 /****************************************************************************
@@ -1254,8 +1254,8 @@ static int getsockname_request(int fd, FAR struct gs2200m_s *priv,
 static int getpeername_request(int fd, FAR struct gs2200m_s *priv,
                                FAR void *hdrbuf)
 {
-  ASSERT(false);
-  return -EINVAL;
+  DEBUGASSERT(false);
+  return -ENOSYS;
 }
 
 /****************************************************************************


### PR DESCRIPTION
As commented [1] all the code guarded by `CONFIG_NET_HAVE_REUSEADDR` was dead code.

The pull request [2] made some of it back to life to "undead" code, that raises an error always in `netlib_listenon()`

This fix that by lowering it as a warning in netlib and `DEBUGASSERT` in `gs2200m` command.

[1] https://github.com/apache/incubator-nuttx-apps/pull/45#discussion_r374093618
[2] https://github.com/apache/incubator-nuttx-apps/pull/47/files
