### PR TITLE
apps/wireless/gs2200m/gs2200m_main.c:  Eliminate a warning

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1413,7 +1413,6 @@ static int gs2200m_loop(FAR struct gs2200m_s *priv)
         }
     }
 
-errout:
   close(fd[1]);
   close(fd[0]);
 


### PR DESCRIPTION
Eliminate warning:

    gs2200m_main.c:  In function 'gs2200m_loop':
    gs2200m_main.c:1416:1:  warning: label 'errout' defined but not used [-Wunused-label]