### PR TITLE
examples: elf: Fix warnings when compiled for RISC-V 64bit

### DIFF
--- a/examples/elf/tests/mutex/mutex.c
+++ b/examples/elf/tests/mutex/mutex.c
@@ -64,7 +64,7 @@ static volatile bool bendoftest;
 
 void thread_func(void *parameter)
 {
-  int my_id  = (int)parameter;
+  intptr_t my_id  = (intptr_t)parameter;
   int my_ndx = my_id - 1;
   int i;
 

--- a/examples/elf/tests/pthread/pthread.c
+++ b/examples/elf/tests/pthread/pthread.c
@@ -82,16 +82,16 @@ enum exit_values_e
 
 void *child_start_routine(void *arg)
 {
-  printf("CHILD: started with arg=%d\n", (int)arg);
+  printf("CHILD: started with arg=%d\n", (intptr_t)arg);
 
   if (arg != CHILD_ARG)
     {
-      printf("CHILD: expected arg=%d\n", (int)CHILD_ARG);
+      printf("CHILD: expected arg=%d\n", (intptr_t)CHILD_ARG);
       return (void*)TESTRESULT_CHILD_ARG_FAIL;
     }
   sleep(2);
 
-  printf("CHILD: returning %d\n", (int)CHILD_RET);
+  printf("CHILD: returning %d\n", (intptr_t)CHILD_RET);
   pthread_exit(CHILD_RET);
 }
 
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
       exit(TESTRESULT_PTHREAD_ATTR_INIT_FAIL);
     }
 
-  printf("PARENT: calling pthread_start with arg=%d\n", (int)CHILD_ARG);
+  printf("PARENT: calling pthread_start with arg=%d\n", (intptr_t)CHILD_ARG);
   status = pthread_create(&thread, &attr, child_start_routine, CHILD_ARG);
   if (status != 0)
     {
@@ -131,10 +131,10 @@ int main(int argc, char **argv)
       exit(TESTRESULT_PTHREAD_JOIN_FAIL);
     }
 
-  printf("PARENT child exitted with %d\n", (int)retval);
+  printf("PARENT child exitted with %d\n", (intptr_t)retval);
   if (retval != CHILD_RET)
     {
-      printf("PARENT child thread did not exit with %d\n", (int)CHILD_RET);
+      printf("PARENT child thread did not exit with %d\n", (intptr_t)CHILD_RET);
       exit(TESTRESULT_CHILD_RETVAL_FAIL);
     }
 


### PR DESCRIPTION
### Summary

- Fix warnings such as "warning: cast from pointer to integer of different size"

### Impact

- This PR only affects apps/examples/elf.

### Testing

- Tested with Sony Spresense (armv7-m 32bit) and K210 (RISC-V RV64GC)

