### PR TITLE
mksymtab.sh: Avoid using find -executable

### DIFF
--- a/examples/elf/tests/mksymtab.sh
+++ b/examples/elf/tests/mksymtab.sh
@@ -22,7 +22,7 @@ fi
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
 
-varlist=`find ${dir} -executable -type f | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+varlist=`find ${dir} -type f -perm -a=x | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
 
 # Now output the symbol table as a structure in a C source file.  All
 # undefined symbols are declared as void* types.  If the toolchain does

--- a/examples/module/drivers/mksymtab.sh
+++ b/examples/module/drivers/mksymtab.sh
@@ -22,7 +22,7 @@ fi
 # Extract all of the undefined symbols from the MODULE files and create a
 # list of sorted, unique undefined variable names.
 
-varlist=`find ${dir} -executable -type f | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+varlist=`find ${dir} -type f -perm -a=x | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
 
 # Now output the symbol table as a structure in a C source file.  All
 # undefined symbols are declared as void* types.  If the toolchain does

--- a/examples/posix_spawn/filesystem/mksymtab.sh
+++ b/examples/posix_spawn/filesystem/mksymtab.sh
@@ -22,7 +22,7 @@ fi
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
 
-varlist=`find ${dir} -executable -type f | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+varlist=`find ${dir} -type f -perm -a=x | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
 
 # Now output the symbol table as a structure in a C source file.  All
 # undefined symbols are declared as void* types.  If the toolchain does

--- a/examples/sotest/lib/mksymtab.sh
+++ b/examples/sotest/lib/mksymtab.sh
@@ -23,7 +23,7 @@ fi
 # Extract all of the undefined symbols from the SOTEST files and create a
 # list of sorted, unique undefined variable names.
 
-tmplist=`find ${dir} -executable -type f | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+tmplist=`find ${dir} -type f -perm -a=x | xargs nm | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
 
 # Remove the special symbol 'modprint'.  It it is not exported by the
 # base firmware, but rather in this test from one shared library to another.


### PR DESCRIPTION
As it seems GNU-find only.  macOS doesn't have it.

-perm is in POSIX and should be more widely available.