### PR TITLE
apps/examples/elf:  Correct mount point configuration error.

### DIFF
--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -107,13 +107,13 @@
 
 #  define MOUNTPT      "/mnt/cromfs"
 
-#elif defined(CONFIG_EXAMPLES_ELF_EXTERN)
+#elif defined(CONFIG_EXAMPLES_ELF_EXTERN) && defined(CONFIG_EXAMPLES_ELF_FSMOUNT)
 /* Describe the external file system */
 
 #  define MOUNTPT      "/mnt/" CONFIG_EXAMPLES_ELF_FSTYPE
 
 #else
-#  error "No file system selected"
+#  undef MOUNTPT
 #endif
 
 /* If CONFIG_DEBUG_FEATURES is enabled, use info/err instead of printf so that the
@@ -356,7 +356,7 @@ int main(int argc, FAR char *argv[])
 
   mm_update(&g_mmstep, "after mount");
 
-#if defined(CONFIG_LIB_ENVPATH)
+#if defined(CONFIG_LIB_ENVPATH) && defined(MOUNTPT)
   /* Does the system support the PATH variable?
    * If YES, then set the PATH variable to the ROMFS mountpoint.
    */


### PR DESCRIPTION
If an external file system is used but is not mounted by the the ELF example, then a compilation error will occur.  This configuration problem has existed for a long time but was unmasked by a recent PR.  In the failure mode, CONFIG_EXAMPLES_ELF_FSTYPE would not be defined because it depends on CONFIG_EXAMPLES_ELF_FSMOUNT which is not defined.  The resulting mountpoint, MOUNTPT, would therefore be left in an invalid state.  Previous changes to conditional logic now allowed setenv() to run and to attempt to set the PATH variable to MOUNTPT, causing a compile time failure like this:

    CC:  elf_main.c
    elf_main.c: In function 'elf_main':
    elf_main.c:113:32: error: expected ')' before 'CONFIG_EXAMPLES_ELF_FSTYPE'
     #  define MOUNTPT      "/mnt/" CONFIG_EXAMPLES_ELF_FSTYPE
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~
    elf_main.c:364:18: note: in expansion of macro 'MOUNTPT'
       setenv("PATH", MOUNTPT, 1);
                       ^~~~~~~
    elf_main.c:364:3: error: too few arguments to function 'setenv'
       setenv("PATH", MOUNTPT, 1);
       ^~~~~~
    In file included from elf_main.c:47:
    D:\Spuda\Documents\projects\nuttx\master\nuttx-fork\include/stdlib.h:158:11: note: declared here
     int       setenv(FAR const char *name, FAR const char *value, int overwrite);
               ^~~~~~

This problem was found during manual build testing using configuration lx_cpu:nsh.