### PR TITLE
testing/fstest/fstest_main.c: Eliminate a warning found during the build

### DIFF
--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -1084,7 +1084,8 @@ int main(int argc, FAR char *argv[])
 
       /* Perform garbage collection, integrity checks */
 
-      fstest_gc(buf.f_bfree);
+      ret = fstest_gc(buf.f_bfree);
+      UNUSED(ret);
 
       /* Show memory usage */
 


### PR DESCRIPTION
test.