### PR TITLE
Make.defs: Fix to exclude loadable apps from builtin app list

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -82,8 +82,8 @@ DEPCONFIG = $(TOPDIR)$(DELIM).config
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define REGISTER
 	$(Q) echo Register: $1
-	$(Q) echo { "$1", $2, $3, $4 }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
 	$(Q) if [ ! -z $4 ]; then \
+	        echo { "$1", $2, $3, $4 }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"; \
 	        echo "int $4(int argc, char *argv[]);" > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"; \
 	     fi;
 	$(Q) touch $(BUILTIN_REGISTRY)$(DELIM).updated"
@@ -91,8 +91,8 @@ endef
 else
 define REGISTER
 	$(Q) echo "Register: $1"
-	$(Q) echo "{ \"$1\", $2, $3, $4 }," > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
 	$(Q) if [ ! -z $4 ]; then \
+	        echo "{ \"$1\", $2, $3, $4 }," > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"; \
 	        echo "int $4(int argc, char *argv[]);" > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"; \
 	     fi;
 	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"


### PR DESCRIPTION
### Summary

- When an application is built as a loadable app, the application name should not be shown in the builtin app list (i.e. apps/builtin/buitlin_list.h) This PR does not create .bdat as well as .pdat if an application is built as a loadble.

### Impact

- This PR affects application build for both builtin and loadable.

### Testing

-  I checked this PR with spresense:rndis and spresense:wifi which include both builtin apps and loadable apps.

