### PR TITLE
nsh/parse: try the builtin configuration first

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -503,55 +503,18 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 #endif
   int ret;
 
-  /* Does this command correspond to an application filename?
-   * nsh_fileapp() returns:
-   *
-   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could not
-   *               be started (possibly because it does not exist).
-   *    0 (OK)     if the application task corresponding to 'argv[0]' was
-   *               and successfully started.  If CONFIG_SCHED_WAITPID is
-   *               defined, this return value also indicates that the
-   *               application returned successful status (EXIT_SUCCESS)
-   *    1          If CONFIG_SCHED_WAITPID is defined, then this return value
-   *               indicates that the application task was spawned successfully
-   *               but returned failure exit status.
-   *
-   * Note the priority is not effected by nice-ness.
-   */
-
-#ifdef CONFIG_NSH_FILE_APPS
-  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile, oflags);
-  if (ret >= 0)
-    {
-      /* nsh_fileapp() returned 0 or 1.  This means that the built-in
-       * command was successfully started (although it may not have ran
-       * successfully).  So certainly it is not an NSH command.
-       */
-
-      /* Save the result:  success if 0; failure if 1 */
-
-      return nsh_saveresult(vtbl, ret != OK);
-    }
-
-  /* No, not a file name command (or, at least, we were unable to start a
-   * program of that name).  Maybe it is a built-in application or an NSH
-   * command.
-   */
-
-#endif
-
   /* Does this command correspond to a built-in command?
    * nsh_builtin() returns:
    *
-   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could not
-   *               be started (possibly because it doesn not exist).
+   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could
+   *               not be started (possibly because it doesn not exist).
    *    0 (OK)     if the application task corresponding to 'argv[0]' was
    *               and successfully started.  If CONFIG_SCHED_WAITPID is
    *               defined, this return value also indicates that the
    *               application returned successful status (EXIT_SUCCESS)
    *    1          If CONFIG_SCHED_WAITPID is defined, then this return value
-   *               indicates that the application task was spawned successfully
-   *               but returned failure exit status.
+   *               indicates that the application task was spawned
+   *               successfully but returned failure exit status.
    *
    * Note the priority if not effected by nice-ness.
    */
@@ -575,7 +538,44 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     }
 
   /* No, not a built in command (or, at least, we were unable to start a
-   * built-in command of that name).  Treat it like an NSH command.
+   * built-in command of that name). Maybe it is a built-in application
+   * or an NSH command.
+   */
+
+#endif
+
+  /* Does this command correspond to an application filename?
+   * nsh_fileapp() returns:
+   *
+   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could
+   *               not be started (possibly because it does not exist).
+   *    0 (OK)     if the application task corresponding to 'argv[0]' was
+   *               and successfully started.  If CONFIG_SCHED_WAITPID is
+   *               defined, this return value also indicates that the
+   *               application returned successful status (EXIT_SUCCESS)
+   *    1          If CONFIG_SCHED_WAITPID is defined, then this return value
+   *               indicates that the application task was spawned
+   *               successfully but returned failure exit status.
+   *
+   * Note the priority is not effected by nice-ness.
+   */
+
+#ifdef CONFIG_NSH_FILE_APPS
+  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile, oflags);
+  if (ret >= 0)
+    {
+      /* nsh_fileapp() returned 0 or 1.  This means that the built-in
+       * command was successfully started (although it may not have ran
+       * successfully).  So certainly it is not an NSH command.
+       */
+
+      /* Save the result:  success if 0; failure if 1 */
+
+      return nsh_saveresult(vtbl, ret != OK);
+    }
+
+  /* No, not a file name command (or, at least, we were unable to start a
+   * program of that name). Treat it like an NSH command.
    */
 
 #endif


### PR DESCRIPTION
In the case of enable the BUILTIN_APPS/FILE_APPS at the same
time, try the builtin list first to ensure that the relevant
configuration(stacksize, priority) can be set normally.

Change-Id: Ib99b39f884dfc651f4e47481d366a27ff984717f
Signed-off-by: chao.an <anchao@xiaomi.com>