### PR TITLE
Fix usrsocktest errors

### DIFF
--- a/examples/usrsocktest/usrsocktest_block_recv.c
+++ b/examples/usrsocktest/usrsocktest_block_recv.c
@@ -265,7 +265,8 @@ static void NoBlockConnect(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("a", data, 1);
   TEST_ASSERT_EQUAL(sizeof(remoteaddr), addrlen);
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(6, usrsocktest_daemon_get_recv_bytes());
@@ -282,7 +283,8 @@ static void NoBlockConnect(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(5, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("abcde", data, 5);
   TEST_ASSERT_EQUAL(sizeof(remoteaddr), addrlen);
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(11, usrsocktest_daemon_get_recv_bytes());

--- a/examples/usrsocktest/usrsocktest_noblock_recv.c
+++ b/examples/usrsocktest/usrsocktest_noblock_recv.c
@@ -197,7 +197,8 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(3, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", data, 3);
   TEST_ASSERT_EQUAL(addrlen, sizeof(remoteaddr));
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(datalen + ret, usrsocktest_daemon_get_recv_bytes());


### PR DESCRIPTION
### Summary

- This PR fixes a part of usrsocktest errors. (i.e. errors in NoBlockRecv and BlockRecv)
- Actually, the test cases checked sockaddr_in values which contain padding field, however, the field should be ignored because it contains random values.

### Impact

- This PR affects a usrsocktest application only.

### Limitations / TODO

- There still remain errors and need more investigation.

### Testing

- I tested this PR with spresense:wifi which I added usrsocktest application.
