### PR TITLE
Revert "Avoid calling ARCHIVE in multiple places"

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -129,6 +129,12 @@ $(CXXOBJS): %$(SUFFIX)$(OBJEXT): %$(CXXEXT)
 		$(call ELFCOMPILEXX, $<, $@), $(call COMPILEXX, $<, $@))
 
 .built: $(OBJS)
+ifeq ($(WINTOOL),y)
+	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $(OBJS))
+else
+	$(call ARCHIVE, $(BIN), $(OBJS))
+endif
+	$(Q) touch $@
 
 ifeq ($(BUILD_MODULE),y)
 
@@ -157,9 +163,6 @@ endif
 
 install:: $(PROGLIST)
 
-show-objs:
-	@echo ""
-
 else
 
 MAINNAME := $(addsuffix _main,$(PROGNAME))
@@ -181,9 +184,6 @@ $(MAINOBJ): %$(SUFFIX)$(OBJEXT): %.c
 endif
 
 install::
-
-show-objs:
-	@echo $(addprefix $(CWD)$(DELIM),$(OBJS))
 
 endif # BUILD_MODULE
 

--- a/Directory.mk
+++ b/Directory.mk
@@ -54,7 +54,6 @@ $(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),context)))
 $(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),depend)))
 $(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 $(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),show-objs)))
 
 nothing:
 
@@ -75,7 +74,5 @@ distclean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_distclean)
 ifneq ($(MENUDESC),)
 	$(call DELFILE, Kconfig)
 endif
-
-show-objs: $(foreach SDIR, $(SUBDIRS), $(SDIR)_show-objs)
 
 -include Make.dep

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ endif
 SYMTABSRC = symtab_apps.c
 SYMTABOBJ = $(SYMTABSRC:.c=$(OBJEXT))
 
-APPOBJS = $(shell $(MAKE) show-objs TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)")
-
 # Build targets
 
 all: $(BIN)
@@ -65,11 +63,6 @@ all: $(BIN)
 
 define MAKE_template
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
-
-endef
-
-define MAKE_template_quiet
-	@ $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" V=0 Q=@
 
 endef
 
@@ -112,11 +105,6 @@ else
 ifeq ($(CONFIG_BUILD_LOADABLE),)
 
 $(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
-ifeq ($(WINTOOL),y)
-	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $(APPOBJS))
-else
-	$(call ARCHIVE, $(BIN), $(APPOBJS))
-endif
 
 else
 
@@ -129,9 +117,9 @@ $(SYMTABOBJ): %$(OBJEXT): %.c
 
 $(BIN): $(SYMTABOBJ)
 ifeq ($(WINTOOL),y)
-	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $(APPOBJS) $(SYMTABOBJ))
+	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $^)
 else
-	$(call ARCHIVE, $(BIN), $(APPOBJS) $(SYMTABOBJ))
+	$(call ARCHIVE, $(BIN), $^)
 endif
 
 endif # !CONFIG_BUILD_LOADABLE
@@ -166,9 +154,6 @@ Kconfig:
 	$(Q) $(MKKCONFIG)
 
 preconfig: Kconfig
-
-show-objs:
-	$(foreach SDIR, $(CONFIGURED_APPS), $(call MAKE_template_quiet,$(SDIR),show-objs))
 
 export:
 ifneq ($(EXPORTDIR),)


### PR DESCRIPTION
This reverts commit 52222cb020c70f14b2ff766c96da87c3c4bfd32c.

This broke the build.

To reproduce
For apps and nuttx `git fetch nuttx`
For apps and nuttx `git checkout master`
For apps and nuttx `git reset -hard nuttx/master`

`make distclean`
`./tools/configure.sh  imxrt1060-evk:nsh`
`make oldconfig`
`make`


```
Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/platform'
arm-none-eabi-ar rcs  /home/david_s5/src/PX4/repos/mainline/NuttX/apps/libapps.a  make[1]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps' make[2]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib' /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_init.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_parse.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_console.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_script.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_system.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_command.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_fscmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_ddcmd.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_proccmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_mmcmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_timcmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_envcmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_syscmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_dbgcmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_session.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_fsutils.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_builtin.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_mntcmds.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_consolemain.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib/nsh_test.home.david_s5.src.PX4.repos.mainline.NuttX.apps.nshlib.o make[2]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/nshlib' make[2]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/builtin' /home/david_s5/src/PX4/repos/mainline/NuttX/apps/builtin/builtin_list.home.david_s5.src.PX4.repos.mainline.NuttX.apps.builtin.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/builtin/exec_builtin.home.david_s5.src.PX4.repos.mainline.NuttX.apps.builtin.o make[2]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/builtin' make[2]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/readline' /home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/readline/readline.home.david_s5.src.PX4.repos.mainline.NuttX.apps.system.readline.o /home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/readline/readline_common.home.david_s5.src.PX4.repos.mainline.NuttX.apps.system.readline.o make[2]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/readline' make[2]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/nsh' /home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/nsh/nsh_main.home.david_s5.src.PX4.repos.mainline.NuttX.apps.system.nsh.o make[2]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/system/nsh' make[2]: Entering directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/platform' /home/david_s5/src/PX4/repos/mainline/NuttX/apps/platform/dummy.home.david_s5.src.PX4.repos.mainline.NuttX.apps.platform.o make[2]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/platform' make[1]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps'
arm-none-eabi-ar: make[1]:: No such file or directory
Makefile:118: recipe for target '/home/david_s5/src/PX4/repos/mainline/NuttX/apps/libapps.a' failed
make[1]: *** [/home/david_s5/src/PX4/repos/mainline/NuttX/apps/libapps.a] Error 1
make[1]: Leaving directory '/home/david_s5/src/PX4/repos/mainline/NuttX/apps'
tools/LibTargets.mk:198: recipe for target '../apps/libapps.a' failed
```

