### PR TITLE
build: Use flock to serialize ar steps as workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ cscope.out
 /external
 /.context
 /.config
-/.depend
 /*.lib
+/*.lock
 /romfs.img
 /boot_romfsimg.h
 /symtab_apps.c

--- a/Application.mk
+++ b/Application.mk
@@ -130,9 +130,9 @@ $(CXXOBJS): %$(SUFFIX)$(OBJEXT): %$(CXXEXT)
 
 .built: $(OBJS)
 ifeq ($(WINTOOL),y)
-	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $(OBJS))
+	$(call ARLOCK, "${shell cygpath -w $(BIN)}", $(OBJS))
 else
-	$(call ARCHIVE, $(BIN), $(OBJS))
+	$(call ARLOCK, $(BIN), $(OBJS))
 endif
 	$(Q) touch $@
 

--- a/Make.defs
+++ b/Make.defs
@@ -52,7 +52,7 @@ CLEANDIRS := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
 CONFIGURED_APPS :=
 
 define Add_Application
-  include $(1)Make.defs
+	include $(1)Make.defs
 endef
 
 $(foreach BDIR, $(BUILDIRS), $(eval $(call Add_Application,$(BDIR))))
@@ -98,6 +98,10 @@ define REGISTER
 	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
 endif
+
+define ARLOCK
+	$(Q) flock $1.lock $(call ARCHIVE, $1, $(2))
+endef
 
 # Tools
 

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,9 @@ $(SYMTABOBJ): %$(OBJEXT): %.c
 
 $(BIN): $(SYMTABOBJ)
 ifeq ($(WINTOOL),y)
-	$(call ARCHIVE, "${shell cygpath -w $(BIN)}", $^)
+	$(call ARLOCK, "${shell cygpath -w $(BIN)}", $^)
 else
-	$(call ARCHIVE, $(BIN), $^)
+	$(call ARLOCK, $(BIN), $^)
 endif
 
 endif # !CONFIG_BUILD_LOADABLE
@@ -198,6 +198,7 @@ else
 		fi; \
 	)
 endif
+	$(call DELFILE, *.lock)
 	$(call DELFILE, .depend)
 	$(call DELFILE, $(SYMTABSRC))
 	$(call DELFILE, $(SYMTABOBJ))


### PR DESCRIPTION
Use flock to serialize ar steps to avoid parallel build break
sometimes.

Change-Id: I3a916b3b27422cdb6d718f7d554361565457fa08
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>