### PR TITLE
tcpblaster reporting and documentation improvements

### DIFF
--- a/examples/tcpblaster/Kconfig
+++ b/examples/tcpblaster/Kconfig
@@ -17,7 +17,14 @@ config EXAMPLES_TCPBLASTER_SENDSIZE
 	int "Payload size"
 	default 4096
 	---help---
-		This setting determines size of each test packet sent to the server.
+		This setting determines size of each TCP send that is sent to the server.
+
+config EXAMPLES_TCPBLASTER_GROUPSIZE
+	int "Group size"
+	default 50
+	---help---
+		This setting determines how many TCP sends are sent to the server before printing statistics
+		and starting again.
 
 config EXAMPLES_TCPBLASTER_PROGNAME1
 	string "Target1 program name"

--- a/examples/tcpblaster/Makefile
+++ b/examples/tcpblaster/Makefile
@@ -11,7 +11,7 @@
 # 1. Redistributions of source code must retain the above copyright
 #    notice, this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
+#    notice, this list of conditions and the following dsclaimer in
 #    the documentation and/or other materials provided with the
 #    distribution.
 # 3. Neither the name NuttX nor the names of its contributors may be

--- a/examples/tcpblaster/README.txt
+++ b/examples/tcpblaster/README.txt
@@ -1,0 +1,40 @@
+tcpblaster Performance Test Example
+===================================
+
+To set up, do `make menuconfig` and select the Apps > Examples > tcpblaster. By default, nuttx will the be the client
+which sends data; and the host computer (Linux, macOS, or Windows) will be the server.
+
+Set up networking so the nuttx computer can ping the host, and the host can ping nuttx. Now you are ready to run the
+test.
+
+On host:
+
+    $ ./tcpserver
+    Binding to IPv4 Address: 00000000
+    server: Accepting connections on port 5471
+
+On nuttx:
+
+    nsh> tcpclient
+    Connecting to IPv4 Address: 0100000a
+    client: Connected
+    [2014-07-31 00:16:15.000] 0: Sent 200 4096-byte buffers:    800.0 KB (avg   4.0 KB) in   0.18 seconds ( 4444.4 KB/second)
+
+Now on the host you should see something like:
+
+    $ ./tcpserver
+    Binding to IPv4 Address: 00000000
+    server: Accepting connections on port 5471
+    server: Connection accepted -- receiving
+    [2020-02-22 16:17:07.000] 0: Received 200 buffers:   502.9 KB (buffer average size:   2.5 KB) in   0.12 seconds ( 4194.8 KB/second)
+    [2020-02-22 16:17:07.000] 1: Received 200 buffers:   393.1 KB (buffer average size:   2.0 KB) in   0.09 seconds ( 4299.4 KB/second)
+
+
+This will tell you the link speed in KB/sec – kilobytes per second. If you want kilobits, multiply by 8.
+
+You can use the `make menuconfig` to reverse the setup, and have nuttx be the server, and the host be the client. If you
+do that, start the server first (nuttx), then start the client (host).
+
+
+
+

--- a/examples/tcpblaster/tcpblaster.h
+++ b/examples/tcpblaster/tcpblaster.h
@@ -115,6 +115,12 @@
 #  define SENDSIZE 4096
 #endif
 
+#ifdef CONFIG_EXAMPLES_TCPBLASTER_GROUPSIZE
+#  define GROUPSIZE CONFIG_EXAMPLES_TCPBLASTER_GROUPSIZE
+#else
+#  define GROUPSIZE 50
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
### Summary

* Improves reporting with timestamp, group count, and clarified bandwidth (changes message that incorrectly shows Kb [kilobits] to KB [kilobytes])
* Adds group configuration (was hardcoded at 50 buffers per send; this is now configurable)
* Adds README that shows how to configure and run

### Impact

* None if you don't use tcpblaster
* tcpblaster is now more configurable and has clearer reporting that allows for hang-detection on long runtimes

### Testing

* Manual on the simulator, SAMA5D3-Xplained (SAMA5D36), and Linux.

### How To Verify 

* Run tcpblaster as per the README