### PR TITLE
Remove the additional UNLINKDIR to fix parallel build break

### DIFF
--- a/platform/Makefile
+++ b/platform/Makefile
@@ -67,7 +67,6 @@ $(TOPDIR)$(DELIM).config:
 
 $(PLATFORMDIR): $(TOPDIR)$(DELIM).config
 	@echo "LN: platform$(DELIM)board to $(LINKDIR)"
-	$(Q) $(DIRUNLINK) $(PLATFORMDIR)
 	$(Q) $(DIRLINK) $(LINKDIR) $(PLATFORMDIR)
 
 dirlinks: $(PLATFORMDIR)


### PR DESCRIPTION
Remove the additional unlink to fix errors in parallel build as below.
cc1: fatal error: ./board/dummy.c: No such file or directory

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>