### PR TITLE
examples: discover: Use htonl() instead of HTONL() in discover_main.c

### DIFF
--- a/examples/discover/discover_main.c
+++ b/examples/discover/discover_main.c
@@ -116,18 +116,18 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_EXAMPLES_DISCOVER_DHCPC
   addr.s_addr = 0;
 #else
-  addr.s_addr = HTONL(CONFIG_EXAMPLES_DISCOVER_IPADDR);
+  addr.s_addr = htonl(CONFIG_EXAMPLES_DISCOVER_IPADDR);
 #endif
   netlib_set_ipv4addr("eth0", &addr);
 
   /* Set up the default router address */
 
-  addr.s_addr = HTONL(CONFIG_EXAMPLES_DISCOVER_DRIPADDR);
+  addr.s_addr = htonl(CONFIG_EXAMPLES_DISCOVER_DRIPADDR);
   netlib_set_dripv4addr("eth0", &addr);
 
   /* Setup the subnet mask */
 
-  addr.s_addr = HTONL(CONFIG_EXAMPLES_DISCOVER_NETMASK);
+  addr.s_addr = htonl(CONFIG_EXAMPLES_DISCOVER_NETMASK);
   netlib_set_ipv4netmask("eth0", &addr);
 
   /* New versions of netlib_set_ipvXaddr will not bring the network up,


### PR DESCRIPTION
### Summary

- This PR fixes compilation errors in discover_main.c

### Impact

-  This PR affects examples/discover apps only

### Testing

- This PR was tested with spresense:wifi by adding following configs

+CONFIG_NSH_NETINIT=n
+CONFIG_EXAMPLES_DISCOVER=y
+CONFIG_EXAMPLES_DISCOVER_DHCPC=y
