### PR TITLE
examples/elf/tests: correct symtab.c dependency to fix parallel build…

### DIFF
--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -140,7 +140,7 @@ $(DIRLIST_HDR) : populate
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): build
+$(SYMTAB_SRC): populate
 	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@
 
 # Clean each subdirectory


### PR DESCRIPTION
… break

Correct symtab dependency from build to populate instead, or tests
subdirectory programs would be built twice which resulted in errors
as below:
arm-none-eabi-ld: hello++3.o: file not recognized: file truncated

Change-Id: Iff6859a0c93291a584d75dda4ba9c99f50f9bac3
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>