### PR TITLE
Revert "Remove libapps.a from LDLIBS"

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -153,10 +153,8 @@ endif
 CFLAGS   += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(APPDIR)$(DELIM)include"}
 CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(APPDIR)$(DELIM)include"}
 
-ifneq ($(CONFIG_BUILD_KERNEL),y)
 ifeq ($(WINTOOL),y)
   LDLIBS ?= "${shell cygpath -w $(BIN)}"
 else
   LDLIBS ?= $(BIN)
-endif
 endif

--- a/Make.defs
+++ b/Make.defs
@@ -152,3 +152,11 @@ endif
 
 CFLAGS   += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(APPDIR)$(DELIM)include"}
 CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(APPDIR)$(DELIM)include"}
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+ifeq ($(WINTOOL),y)
+  LDLIBS ?= "${shell cygpath -w $(BIN)}"
+else
+  LDLIBS ?= $(BIN)
+endif
+endif


### PR DESCRIPTION
It was necessary for PROTECTED build.

This reverts commit 4ee39e208048f075860179a0a2b60c3a651cf16e.