### PR TITLE
testing: ostest: Add workaround for SMP in cond.c

### DIFF
--- a/testing/ostest/cond.c
+++ b/testing/ostest/cond.c
@@ -181,6 +181,19 @@ static void *thread_signaler(void *parameter)
           signaler_nerrors++;
         }
 
+#if CONFIG_SMP_NCPUS > 1
+      /* Workaround for SMP:
+       * In multi-core environment, thread_signaler would be excecuted prior
+       * to the thread_waiter, even though priority of thread_signaler is
+       * lower than the thread_waiter. In this case, thread_signaler will
+       * aquire mutex before the thread_waiter aquires it and will show
+       * the error message such as "thread_signaler: ERROR waiter state...".
+       * To avoid this situaltion, we add the following usleep()
+       */
+
+      usleep(10 * 1000);
+#endif
+
       signaler_nloops++;
     }
 


### PR DESCRIPTION
### Summary

- This PR adds workaround for SMP in cond.c to avoid error messages in cond_test.

### Impact

- Only ostest (actually cond_test) will be affected.

### Testing

-  I tested this PR with spresense:smp (Cortex-M4F in dual core mode), maix-bit:smp (RV64GC in dual core mode) and sabre-6quad:smp (Cortex-A9 in quad core mode).
