### PR TITLE
testing: ostest: Fix a warning in cond.c for non-SMP configurations.

### DIFF
--- a/testing/ostest/cond.c
+++ b/testing/ostest/cond.c
@@ -181,7 +181,7 @@ static void *thread_signaler(void *parameter)
           signaler_nerrors++;
         }
 
-#if CONFIG_SMP_NCPUS > 1
+#if defined(CONFIG_SMP) && (CONFIG_SMP_NCPUS > 1)
       /* Workaround for SMP:
        * In multi-core environment, thread_signaler would be excecuted prior
        * to the thread_waiter, even though priority of thread_signaler is


### PR DESCRIPTION
### Summary

- This PR will fix a warning in cond.c for non-SMP configurations.

cond.c: In function 'thread_signaler':
cond.c:184:5: warning: "CONFIG_SMP_NCPUS" is not defined, evaluates to 0 [-Wundef]
  184 | #if CONFIG_SMP_NCPUS > 1
      |     ^~~~~~~~~~~~~~~~

### Impact

- Only ostest (actually cond_test) will be affected.

### Testing

- I tested this PR with both  spresense:smp and spresense:wifi (non-SMP).
