### PR TITLE
Initial checkin nuttx-apps github action CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: PR Check CI
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-18.04
+    container: liuguo09/ubuntu-nuttx:18.04
+
+    steps:
+    - name: Checkout apps repo
+      uses: actions/checkout@v2
+      with:
+        path: apps
+        fetch-depth: 0
+
+    - name: Checkout nuttx repo
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx
+        path: nuttx
+        fetch-depth: 0
+
+    - name: Check Pull Request
+      run: |
+        cd apps
+        ranges=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
+        git log --oneline $ranges
+        commits=`git log --reverse --format=format:%H $ranges`
+        echo "../nuttx/tools/checkpatch.sh -g $commits"
+        ../nuttx/tools/checkpatch.sh -g $commits
+
+  build:
+    needs: check
+    runs-on: ubuntu-18.04
+    container: liuguo09/ubuntu-nuttx:18.04
+
+    strategy:
+      matrix:
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, arm-14, arm-15, mips-riscv-x86, sim]
+
+    steps:
+    - name: Checkout apps repo
+      uses: actions/checkout@v2
+      with:
+        path: apps
+        fetch-depth: 0
+
+    - name: Checkout nuttx repo
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx
+        path: nuttx
+        fetch-depth: 0
+
+    - name: Fetch nuttx tags
+      run: |
+        cd nuttx
+        git fetch --tags
+
+    - name: Checkout testing repo
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx-testing
+        path: testing
+
+    - name: Run builds
+      run: |
+        cd testing
+        ./cibuild.sh -x testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
Github action CI workflow steps as below:
1. Use docker container with build essential tools preinstalled
2. nxstyle check pull request with checkpatch.sh
3. Call testing cibuild.sh to do jobs matrix check builds

Now split full testlist into sim/mips-riscv-x86/arm01~arm15 totally 17 jobs to do parallel builds.
All the jobs could be finished in half an hour at most. We could reduce the build time later by refine the configs in each job.

Also note that the pull request check is by default whole file check.

For example, refer to the check build in my own fork:
https://github.com/liuguo09/incubator-nuttx-apps/pull/3/checks

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>