### PR TITLE
netinit: Unregister notification at the end in netinit_monitor

### DIFF
--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -760,7 +760,8 @@ static int netinit_monitor(void)
   /* TODO: Stop the PHY notifications and remove the signal handler. */
 
 errout_with_notification:
-#  warning Missing logic
+  ifr.ifr_mii_notify_event.sigev_notify = SIGEV_NONE;
+  ioctl(sd, SIOCMIINOTIFY, (unsigned long)&ifr);
 errout_with_sigaction:
   sigaction(CONFIG_NETINIT_SIGNO, &oact, NULL);
 errout_with_socket:


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: If82ab372e552205c8ae09068f0b19c710a6345ba