### PR TITLE
examples/tcpblaster: Fix the nightly build warning

### DIFF
--- a/examples/tcpblaster/tcpblaster_client.c
+++ b/examples/tcpblaster/tcpblaster_client.c
@@ -79,9 +79,8 @@ void tcpblaster_client(void)
   int i;
   char timebuff[100];
 
-
   setbuf(stdout, NULL);
-  
+
   /* Allocate buffers */
 
   outbuf = (FAR char *)malloc(SENDSIZE);
@@ -103,21 +102,23 @@ void tcpblaster_client(void)
   /* Set up the server address */
 
 #ifdef CONFIG_EXAMPLES_TCPBLASTER_IPv6
-  server.sin6_family            = AF_INET6;
-  server.sin6_port              = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
-  memcpy(server.sin6_addr.s6_addr16, g_tcpblasterserver_ipv6, 8 * sizeof(uint16_t));
-  addrlen                       = sizeof(struct sockaddr_in6);
+  server.sin6_family     = AF_INET6;
+  server.sin6_port       = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
+  memcpy(server.sin6_addr.s6_addr16,
+         g_tcpblasterserver_ipv6, 8 * sizeof(uint16_t));
+  addrlen                = sizeof(struct sockaddr_in6);
 
-  printf("Connecting to IPv6 Address: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
+  printf("Connecting to IPv6 Address: "
+         "%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
          g_tcpblasterserver_ipv6[0], g_tcpblasterserver_ipv6[1],
          g_tcpblasterserver_ipv6[2], g_tcpblasterserver_ipv6[3],
          g_tcpblasterserver_ipv6[4], g_tcpblasterserver_ipv6[5],
          g_tcpblasterserver_ipv6[6], g_tcpblasterserver_ipv6[7]);
 #else
-  server.sin_family             = AF_INET;
-  server.sin_port               = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
-  server.sin_addr.s_addr        = (in_addr_t)g_tcpblasterserver_ipv4;
-  addrlen                       = sizeof(struct sockaddr_in);
+  server.sin_family      = AF_INET;
+  server.sin_port        = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
+  server.sin_addr.s_addr = (in_addr_t)g_tcpblasterserver_ipv4;
+  addrlen                = sizeof(struct sockaddr_in);
 
   printf("Connecting to IPv4 Address: %08lx\n",
          (unsigned long)g_tcpblasterserver_ipv4);
@@ -227,12 +228,15 @@ void tcpblaster_client(void)
               elapsed.tv_nsec = curr.tv_nsec + borrow;
             }
 
-          strftime(timebuff, 100, "%Y-%m-%d %H:%M:%S.000", localtime (&curr));
+          strftime(timebuff, 100,
+                   "%Y-%m-%d %H:%M:%S.000", localtime(&curr.tv_sec));
 
-          fkbrecvd = (float)sendtotal / 1024.0;
-          felapsed = (float)elapsed.tv_sec + (float)elapsed.tv_nsec / 1000000000.0;
-          printf("[%s] %d: Sent %d %d-byte buffers:  %7.1f KB (avg %5.1f KB) in %6.2f seconds (%7.1f KB/second)\n",
-                  timebuff, groupcount, sendcount, SENDSIZE, fkbrecvd, fkbrecvd/sendcount, felapsed, fkbrecvd/felapsed);
+          fkbrecvd = sendtotal / 1024.0f;
+          felapsed = elapsed.tv_sec + elapsed.tv_nsec / 1000000000.0f;
+          printf("[%s] %d: Sent %d %d-byte buffers: %7.1fKB "
+                 "(avg %5.1f KB) in %6.2f seconds (%7.1f KB/second)\n",
+                 timebuff, groupcount, sendcount, SENDSIZE, fkbrecvd,
+                 fkbrecvd / sendcount, felapsed, fkbrecvd / felapsed);
 
           if (partials > 0)
             {

--- a/examples/tcpblaster/tcpblaster_server.c
+++ b/examples/tcpblaster/tcpblaster_server.c
@@ -115,23 +115,25 @@ void tcpblaster_server(void)
 
 #ifdef CONFIG_EXAMPLES_TCPBLASTER_IPv6
 
-  myaddr.sin6_family            = AF_INET6;
-  myaddr.sin6_port              = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
+  myaddr.sin6_family = AF_INET6;
+  myaddr.sin6_port   = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
 #if defined(CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK) && !defined(CONFIG_NET_LOOPBACK)
-  memcpy(myaddr.sin6_addr.s6_addr16, g_tcpblasterserver_ipv6, 8 * sizeof(uint16_t));
+  memcpy(myaddr.sin6_addr.s6_addr16,
+         g_tcpblasterserver_ipv6, 8 * sizeof(uint16_t));
 #else
   memset(myaddr.sin6_addr.s6_addr16, 0, 8 * sizeof(uint16_t));
 #endif
   addrlen = sizeof(struct sockaddr_in6);
 
-  printf("Binding to IPv6 Address: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
+  printf("Binding to IPv6 Address: "
+         "%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
          myaddr.sin6_addr.s6_addr16[0], myaddr.sin6_addr.s6_addr16[1],
          myaddr.sin6_addr.s6_addr16[2], myaddr.sin6_addr.s6_addr16[3],
          myaddr.sin6_addr.s6_addr16[4], myaddr.sin6_addr.s6_addr16[5],
          myaddr.sin6_addr.s6_addr16[6], myaddr.sin6_addr.s6_addr16[7]);
 #else
-  myaddr.sin_family             = AF_INET;
-  myaddr.sin_port               = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
+  myaddr.sin_family  = AF_INET;
+  myaddr.sin_port    = HTONS(CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
 
 #if defined(CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK) && !defined(CONFIG_NET_LOOPBACK)
   myaddr.sin_addr.s_addr        = (in_addr_t)g_tcpblasterserver_ipv4;
@@ -177,7 +179,7 @@ void tcpblaster_server(void)
   ling.l_onoff  = 1;
   ling.l_linger = 30;     /* timeout is seconds */
 
-  if (setsockopt(acceptsd, SOL_SOCKET, SO_LINGER, &ling, sizeof(struct linger)) < 0)
+  if (setsockopt(acceptsd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling)) < 0)
     {
       printf("server: setsockopt SO_LINGER failure: %d\n", errno);
       goto errout_with_acceptsd;
@@ -253,12 +255,15 @@ void tcpblaster_server(void)
               elapsed.tv_nsec = curr.tv_nsec + borrow;
             }
 
-          strftime(timebuff, 100, "%Y-%m-%d %H:%M:%S.000", localtime (&curr));
+          strftime(timebuff, 100,
+                   "%Y-%m-%d %H:%M:%S.000", localtime(&curr.tv_sec));
 
-          fkbsent  = (float)recvtotal / 1024.0;
-          felapsed = (float)elapsed.tv_sec + (float)elapsed.tv_nsec / 1000000000.0;
-          printf("[%s] %d: Received %d buffers: %7.1f KB (buffer average size: %5.1f KB) in %6.2f seconds (%7.1f KB/second)\n",
-                  timebuff, groupcount, recvcount, fkbsent, fkbsent/recvcount, felapsed, fkbsent/felapsed);
+          fkbsent  = recvtotal / 1024.0f;
+          felapsed = elapsed.tv_sec + elapsed.tv_nsec / 1000000000.0f;
+          printf("[%s] %d: Received %d buffers: %7.1f KB (buffer average"
+                 "size: %5.1f KB) in %6.2f seconds (%7.1f KB/second)\n",
+                 timebuff, groupcount, recvcount, fkbsent,
+                 fkbsent / recvcount, felapsed, fkbsent / felapsed);
 
           recvcount       = 0;
           recvtotal       = 0;


### PR DESCRIPTION
tcpblaster_server.c: In function 'tcpblaster_server':
tcpblaster_server.c:256:71: warning: passing argument 1 of 'localtime' from incompatible pointer type [-Wincompatible-pointer-types]
           strftime(timebuff, 100, "%Y-%m-%d %H:%M:%S.000", localtime (&curr));
                                                                       ^
In file included from tcpblaster_server.c:50:0:
/usr/include/time.h:123:19: note: expected 'const time_t * {aka const long int *}' but argument is of type 'struct timespec *'
 extern struct tm *localtime (const time_t *__timer) __THROW;
                   ^~~~~~~~~
tcpblaster_client.c: In function 'tcpblaster_client':
tcpblaster_client.c:230:71: warning: passing argument 1 of 'localtime' from incompatible pointer type [-Wincompatible-pointer-types]
           strftime(timebuff, 100, "%Y-%m-%d %H:%M:%S.000", localtime (&curr));
                                                                       ^
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>