### PR TITLE
Fix parallel buid errors in examples/elf

### DIFF
--- a/examples/elf/Makefile
+++ b/examples/elf/Makefile
@@ -51,18 +51,11 @@ ROOTDEPPATH := --dep-path tests
 
 VPATH += :tests
 
-ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
-  FSIMG_HDR = $(TESTS_DIR)/romfs.h
-else
-  FSIMG_HDR = $(TESTS_DIR)/cromfs.h
-endif
-
-elf_main.c: tests/symtab.c
-
-tests/symtab.c tests/dirlist.h $(FSIMG_HDR):
+context::
 	@$(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
 	@$(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
+	$(call CLEAN)
 
 include $(APPDIR)/Application.mk

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -141,7 +141,8 @@ $(DIRLIST_HDR) : populate
 # Create the exported symbol table
 
 $(SYMTAB_SRC): populate
-	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@
+	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@_tmp
+	$(Q) mv $@_tmp $@
 
 # Clean each subdirectory
 


### PR DESCRIPTION
### Summary

- This PR fixes build errors in examples/elf in parallel build.
- I applied the same logic in examples/posix_spawn/Makefile which adds an explicit context:: target.
- Also, I modified tests/Makefile to avoid compiling incomplete symtab.c

### Impact

- This PR affects examples/elf only.

### Testing

- I tested this PR for maix-bit:elf configuration with -j1 to -j24 options.
