### PR TITLE
Update workflow to let build jobs do not depend on check nxstyle job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,6 @@ jobs:
         ../nuttx/tools/checkpatch.sh -g $commits
 
   build:
-    needs: check
     runs-on: ubuntu-18.04
     container: liuguo09/ubuntu-nuttx:18.04
 


### PR DESCRIPTION
As discussion in https://github.com/apache/incubator-nuttx/pull/549 shows,
update github action workflow to let build jobs do not depend on nxstyle
check job in order to make sure each PR (including some nxstyle waiving cases)
be built at least.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>