### PR TITLE
examples/posix_spawn: Fix parallel build errors at link time

### DIFF
--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -78,7 +78,8 @@ $(ROMFS_HDR) : $(ROMFS_IMG)
 # Create the exported symbol table
 
 $(SYMTAB_SRC): $(ROMFS_IMG)
-	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@
+	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@_tmp
+	$(Q) mv $@_tmp $@
 
 # Clean each subdirectory
 


### PR DESCRIPTION
During generating symtab.c, compile seqeuence would start with
incomplete symtab.c. This change will fix such a situation.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>