### PR TITLE
Nightly parallel build fix for elf/posix_spawn/module build break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ endif
 
 .depdirs: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_depend)
 
-.depend: context Makefile .depdirs
+.depend: Makefile .depdirs
 	$(Q) touch $@
 
 depend: .depend

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -141,8 +141,7 @@ $(DIRLIST_HDR) : populate
 # Create the exported symbol table
 
 $(SYMTAB_SRC): populate
-	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@_tmp
-	$(Q) mv $@_tmp $@
+	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@
 
 # Clean each subdirectory
 

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -78,8 +78,7 @@ $(ROMFS_HDR) : $(ROMFS_IMG)
 # Create the exported symbol table
 
 $(SYMTAB_SRC): $(ROMFS_IMG)
-	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@_tmp
-	$(Q) mv $@_tmp $@
+	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@
 
 # Clean each subdirectory
 


### PR DESCRIPTION
Makefile: remove context dependency to avoid apps context build twice
   
In nuttx pass1dep and pass2dep builds, context firstly would be built once.
It then call 'make -C apps depend' which would trigger the context built twice.
There is race condition between symtab.c generated by mksymtab.sh in second time
and compiling symtab.c in parallel build. So remove context dependency for apps
depend to make sure context build only one time for apps.
    
Parallel build break logs as below:
/home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/apps/examples/elf/elf_main.c:357: undefined reference to `g_elf_nexports'
riscv64-unknown-elf-ld: /home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/apps/examples/elf/elf_main.c:357: undefined reference to `g_elf_exports'
make[1]: *** [nuttx] Error 1
make: *** [pass2] Error 2