### PR TITLE
example/module: update SYMTAB_SRC dependency to fix FSROOT not populated

### DIFF
--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -122,14 +122,14 @@ endif
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): build
+$(SYMTAB_SRC): populate
 	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@
 
 else
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): build populate
+$(SYMTAB_SRC): populate
 	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@
 
 endif


### PR DESCRIPTION
In parallel build, for example maix-bit:module config, it reports:
nm: 'a.out': No such file
This is caused by FSROOT not populated with chardev when symtab.c
generated. So update SYMTAB_SRC dependency to fix it.

Change-Id: I5bb5d17db41f3bba98ae70a2acdd2ec594736611
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>