### PR TITLE
examples: Fix elf/module/posix_spawn sometimes parallel build errors …

### DIFF
--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -141,7 +141,8 @@ $(DIRLIST_HDR) : populate
 # Create the exported symbol table
 
 $(SYMTAB_SRC): populate
-	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@
+	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@.tmp
+	$(Q) mv $@.tmp $@
 
 # Clean each subdirectory
 

--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -123,14 +123,16 @@ endif
 # Create the exported symbol table
 
 $(SYMTAB_SRC): populate
-	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@
+	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@.tmp
+	$(Q) mv $@.tmp $@
 
 else
 
 # Create the exported symbol table
 
 $(SYMTAB_SRC): populate
-	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@
+	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@.tmp
+	$(Q) mv $@.tmp $@
 
 endif
 

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -78,7 +78,8 @@ $(ROMFS_HDR) : $(ROMFS_IMG)
 # Create the exported symbol table
 
 $(SYMTAB_SRC): $(ROMFS_IMG)
-	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@
+	$(Q) $(FILESYSTEM_DIR)$(DELIM)mksymtab.sh $(ROMFS_DIR) >$@.tmp
+	$(Q) mv $@.tmp $@
 
 # Clean each subdirectory
 


### PR DESCRIPTION
…at link time

It seems in the time window mksymtab.sh redirect to symtab.c, there is chance symtab.c
would also be built meantime. Then if built before symtab.c write done, link errors may
occur. So use rename and mv operation to reduce the possibility.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>