### PR TITLE
examples: Fix the parallel build break

### DIFF
--- a/examples/elf/Makefile
+++ b/examples/elf/Makefile
@@ -51,11 +51,14 @@ ROOTDEPPATH := --dep-path tests
 
 VPATH += :tests
 
-context::
-	@$(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+elf_main.c: build
+tests/symtab.c: build
+
+.PHONY: build
+build:
+	+$(Q) $(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
-	@$(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
-	$(call CLEAN)
+	+$(Q) $(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
 
 include $(APPDIR)/Application.mk

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = errno hello helloxx longjmp mutex pthread signal task struct
 BUILD_SUBDIRS = errno hello struct signal
@@ -77,45 +76,29 @@ endif
 
 define DIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSIMG_DIR="$(FSIMG_DIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSIMG_DIR="$(FSIMG_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
 all: $(FSIMG_HDR) $(DIRLIST_HDR) $(SYMTAB_SRC)
-.PHONY: all build clean install populate
+.PHONY: all clean install
 
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),build, all)))
-$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
-
-# Build program(s) in each sud-directory
-
-build: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_build)
+$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
+$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install)))
 
 # Install each program in the file system image directory
 
 install: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_install)
-ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
-	$(Q) $(STRIP) $(wildcard $(FSIMG_SUBDIR)/*)
-endif
-
-# Create the file system image directory
-
-$(FSIMG_DIR):
-	$(Q) mkdir $(FSIMG_DIR)
-
-# Populate the file system image directory
-
-populate:  $(FSIMG_DIR) build install
 
 ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
 # Create the romfs.img file from the populated romfs directory
 
-$(ROMFS_IMG): populate
-	$(Q) genromfs -f $@ -d $(FSIMG_DIR) -V "ELFTEST"
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(FSIMG_DIR) -V "ELFTEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(FSIMG_HDR) : $(ROMFS_IMG)
+$(FSIMG_HDR): $(ROMFS_IMG)
 	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
 else
@@ -126,19 +109,21 @@ $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
 
 # Create the cromfs.h header file from the populated cromfs directory
 
-$(FSIMG_HDR) : populate $(NXTOOLDIR)/$(GENCROMFSEXE)
-	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $(FSIMG_HDR)
+$(FSIMG_HDR): install $(NXTOOLDIR)/$(GENCROMFSEXE)
+	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 endif
 
 # Create the dirlist.h header file from the file system image directory
 
-$(DIRLIST_HDR) : populate
-	$(Q) $(TESTS_DIR)/mkdirlist.sh $(FSIMG_DIR) >$@
+$(DIRLIST_HDR): install
+	$(Q) $(TESTS_DIR)/mkdirlist.sh $(FSIMG_DIR) >$@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): populate
+$(SYMTAB_SRC): install
 	$(Q) $(TESTS_DIR)/mksymtab.sh $(FSIMG_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 

--- a/examples/elf/tests/errno/Makefile
+++ b/examples/elf/tests/errno/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/hello/Makefile
+++ b/examples/elf/tests/hello/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/helloxx/Makefile
+++ b/examples/elf/tests/helloxx/Makefile
@@ -105,7 +105,7 @@ LDLIBSTDC_STUBS_DIR	= $(TOPDIR)/libxx
 LDLIBSTDC_STUBS_LIB	= $(LDLIBSTDC_STUBS_DIR)/liblibxx.a
 
 all: $(BIN1) $(BIN2) $(BIN3) $(BIN4) $(BIN5)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.cpp
 	@echo "CC: $<"
@@ -154,24 +154,39 @@ endif
 $(FSIMG_DIR)/$(BIN1): $(BIN1)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN1) $(FSIMG_DIR)/$(BIN1)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN1)
+endif
 
 $(FSIMG_DIR)/$(BIN2): $(BIN2)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN2) $(FSIMG_DIR)/$(BIN2)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN2)
+endif
 
 ifeq ($(CONFIG_BINFMT_CONSTRUCTORS),y)
 $(FSIMG_DIR)/$(BIN3): $(BIN3)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN3) $(FSIMG_DIR)/$(BIN3)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN3)
+endif
 
 ifeq ($(CONFIG_EXAMPLES_ELF_UCLIBCXX),y)
 $(FSIMG_DIR)/$(BIN4): $(BIN4)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN4) $(FSIMG_DIR)/$(BIN4)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN4)
+endif
 
 $(FSIMG_DIR)/$(BIN5): $(BIN5)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN5) $(FSIMG_DIR)/$(BIN5)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN5)
+endif
 endif
 endif
 

--- a/examples/elf/tests/longjmp/Makefile
+++ b/examples/elf/tests/longjmp/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/mutex/Makefile
+++ b/examples/elf/tests/mutex/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/pthread/Makefile
+++ b/examples/elf/tests/pthread/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/signal/Makefile
+++ b/examples/elf/tests/signal/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/struct/Makefile
+++ b/examples/elf/tests/struct/Makefile
@@ -73,7 +73,7 @@ SRCS = struct_main.c struct_dummy.c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -86,6 +86,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/elf/tests/task/Makefile
+++ b/examples/elf/tests/task/Makefile
@@ -72,7 +72,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -85,6 +85,9 @@ $(BIN): $(OBJS)
 $(FSIMG_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN) $(FSIMG_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN)
+endif
 
 install: $(FSIMG_DIR)/$(BIN)
 

--- a/examples/module/Makefile
+++ b/examples/module/Makefile
@@ -55,10 +55,16 @@ ROOTDEPPATH += --dep-path drivers
 
 # Build targets
 
-context::
-	@$(MAKE) -C drivers TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+module_main.c: build
+ifeq ($(CONFIG_BUILD_FLAT),y)
+drivers/mod_symtab.c: build
+endif
+
+.PHONY: build
+build:
+	+$(Q) $(MAKE) -C drivers TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
-	@$(MAKE) -C drivers TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
+	+$(Q) $(MAKE) -C drivers TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
 
 include $(APPDIR)/Application.mk

--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = chardev
 BUILD_SUBDIRS = chardev
@@ -44,8 +43,12 @@ MODULE_DIR = $(APPDIR)/examples/module
 DRIVER_DIR = $(MODULE_DIR)/drivers
 FSROOT_DIR = $(DRIVER_DIR)/fsroot
 SYMTAB_SRC = $(DRIVER_DIR)/mod_symtab.c
-PASS1_SYMTAB = $(TOPDIR)/pass1/mod_symtab.c
 
+ifneq ($(CONFIG_BUILD_FLAT),y)
+  PASS1_SYMTAB = $(TOPDIR)/pass1/mod_symtab.c
+endif
+
+ifeq ($(CONFIG_EXAMPLES_MODULE_BUILTINFS),y)
 ifeq ($(CONFIG_EXAMPLES_MODULE_ROMFS),y)
   ROMFS_IMG = $(DRIVER_DIR)/romfs.img
   FSIMG_HDR = $(DRIVER_DIR)/romfs.h
@@ -56,80 +59,66 @@ else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
 
   FSIMG_HDR = $(DRIVER_DIR)/cromfs.h
 endif
+endif
 
 define DIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(FSIMG_HDR) $(DIRLIST_HDR) $(SYMTAB_SRC) $(PASS1_SYMTAB)
-.PHONY: all build clean install populate
+all: $(FSIMG_HDR) $(SYMTAB_SRC) $(PASS1_SYMTAB)
+.PHONY: all clean install
 
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),build, all)))
-$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
-
-# Build program(s) in each sud-directory
-
-build: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_build)
+$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
+$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install)))
 
 # Install each program in the fsroot directory
 
 install: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_install)
-ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
-	$(Q) $(STRIP) $(wildcard $(FSIMG_SUBDIR)$(DELIM)*)
-endif
-
-# Create the fsroot directory
-
-$(FSROOT_DIR):
-	$(Q) mkdir $(FSROOT_DIR)
-
-# Populate the fsroot directory
-
-populate:  $(FSROOT_DIR) build install
 
 ifeq ($(CONFIG_EXAMPLES_MODULE_BUILTINFS),y)
 ifeq ($(CONFIG_EXAMPLES_MODULE_ROMFS),y)
 # Create the romfs.img file from the populated fsroot directory
 
-$(ROMFS_IMG): populate
-	$(Q) genromfs -f $@ -d $(FSROOT_DIR) -V "MODULETEST"
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(FSROOT_DIR) -V "MODULETEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(FSIMG_HDR) : $(ROMFS_IMG)
+$(FSIMG_HDR): $(ROMFS_IMG)
 	$(Q) (cd $(DRIVER_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
 else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
 # Make sure that the NuttX gencromfs tool has been built
 
 $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
-       $(Q) $(MAKE) -C $(NXTOOLDIR) -f Makefile.host $(GENCROMFSEXE)
+	$(Q) $(MAKE) -C $(NXTOOLDIR) -f Makefile.host $(GENCROMFSEXE)
 
 # Create the cromfs.h header file from the populated cromfs directory
 
-$(FSIMG_HDR) : populate $(NXTOOLDIR)/$(GENCROMFSEXE)
-       $(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $(FSIMG_HDR)
+$(FSIMG_HDR): install $(NXTOOLDIR)/$(GENCROMFSEXE)
+	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 endif
 endif
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): populate
+$(SYMTAB_SRC): install
 	$(Q) $(DRIVER_DIR)/mksymtab.sh $(FSROOT_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Copy the symbol table into the kernel pass1/ build directory
 
-$(PASS1_SYMTAB): $(SYMTAB_SRC)
 ifneq ($(CONFIG_BUILD_FLAT),y)
+$(PASS1_SYMTAB): $(SYMTAB_SRC)
 	$(Q) install -m 0644 $(SYMTAB_SRC) $(PASS1_SYMTAB)
 endif
 
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(ALL_SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(FSIMG_HDR) $(DIRLIST_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(FSIMG_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(FSROOT_DIR)

--- a/examples/module/drivers/chardev/Makefile
+++ b/examples/module/drivers/chardev/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 OBJEXT ?= .o
 DELIM ?= /
@@ -65,8 +64,8 @@ LDLIBPATH +=  -L $(NUTTXLIB)
 endif
 
 ifeq ($(CONFIG_EXAMPLES_MODULE_LIBC),y)
-ifeq ($(CONFIG_BUILD_PROTECTED),y)
-LDLIBS += -luc
+ifneq ($(CONFIG_BUILD_FLAT),y)
+LDLIBS += -lkc
 else
 LDLIBS += -lc
 endif
@@ -78,7 +77,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -91,6 +90,9 @@ $(BIN): $(OBJS)
 $(FSROOT_DIR)/$(BIN): $(BIN)
 	$(Q) mkdir -p $(FSROOT_DIR)
 	$(Q) install $(BIN) $(FSROOT_DIR)/$(BIN)
+ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
+	$(Q) $(STRIP) $(FSROOT_DIR)/$(BIN)
+endif
 
 install: $(FSROOT_DIR)/$(BIN)
 

--- a/examples/nxflat/Makefile
+++ b/examples/nxflat/Makefile
@@ -44,7 +44,13 @@ PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = 2048
 MODULE = $(CONFIG_EXAMPLES_NXFLAT)
 
-context::
-	@$(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+nxflat_main.c: build
+
+.PHONY: build
+build:
+	+$(Q) $(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+
+clean::
+	+$(Q) $(MAKE) -C tests TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
 
 include $(APPDIR)/Application.mk

--- a/examples/nxflat/tests/Makefile
+++ b/examples/nxflat/tests/Makefile
@@ -55,55 +55,44 @@ SYMTAB		= $(TESTS_DIR)/symtab.h
 
 define DIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
 all: $(ROMFS_HDR) $(ROMFS_DIRLIST) $(SYMTAB)
-.PHONY: all build clean install populate
+.PHONY: all clean install
 
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),build, all)))
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
-
-# Build program(s) in each sud-directory
-
-build: $(foreach DIR, $(SUBDIRS), $(DIR)_build)
+$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
+$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),install)))
 
 # Install each program in the romfs directory
 
 install: $(foreach DIR, $(SUBDIRS), $(DIR)_install)
 
-# Create the romfs directory
-
-$(ROMFS_DIR):
-	@mkdir $(ROMFS_DIR)
-
-# Populate the romfs directory
-
-populate:  $(ROMFS_DIR) build install
-
 # Create the romfs.img file from the populated romfs directory
 
-$(ROMFS_IMG): populate
-	@genromfs -f $@ -d $(ROMFS_DIR) -V "NXFLATTEST"
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "NXFLATTEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(ROMFS_HDR) : $(ROMFS_IMG)
-	@(cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_HDR): $(ROMFS_IMG)
+	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
 # Create the dirlist.h header file from the romfs directory
 
-$(ROMFS_DIRLIST) : populate
-	@$(TESTS_DIR)/mkdirlist.sh $(ROMFS_DIR) >$@
+$(ROMFS_DIRLIST): install
+	$(Q) $(TESTS_DIR)/mkdirlist.sh $(ROMFS_DIR) >$@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the exported symbol table list from the derived *-thunk.S files
 
-$(SYMTAB): build
-	@$(TESTS_DIR)/mksymtab.sh $(TESTS_DIR) >$@
+$(SYMTAB): install
+	$(Q) $(TESTS_DIR)/mksymtab.sh $(ROMFS_DIR) >$@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(SUBDIRS), $(DIR)_clean)
-	@rm -f $(ROMFS_HDR) $(ROMFS_DIRLIST) $(ROMFS_IMG) $(SYMTAB)
-	@rm -rf $(ROMFS_DIR)
+	$(Q) rm -f $(ROMFS_HDR) $(ROMFS_DIRLIST) $(ROMFS_IMG) $(SYMTAB)
+	$(Q) rm -rf $(ROMFS_DIR)

--- a/examples/posix_spawn/Makefile
+++ b/examples/posix_spawn/Makefile
@@ -51,34 +51,14 @@ ROOTDEPPATH	+= --dep-path filesystem
 
 VPATH += filesystem
 
-context::
-	@$(MAKE) -C filesystem TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+spawn_main.c: build
+filesystem/symtab.c: build
+
+.PHONY: build
+build:
+	+$(Q) $(MAKE) -C filesystem TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
-	@$(MAKE) -C filesystem TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
-	$(call CLEAN)
-
-# There are no dependencies in this directory.  Some of more important
-# and more obvious dependencies are hard-coded here:
-
-spawn_main.o: spawn_main.c \
-	$(TOPDIR)/include/nuttx/config.h \
-	$(TOPDIR)/include/nuttx/compiler.h \
-	$(TOPDIR)/include/sys/mount.h \
-	$(TOPDIR)/include/stdio.h \
-	$(TOPDIR)/include/stdlib.h \
-	$(TOPDIR)/include/unistd.h \
-	$(TOPDIR)/include/string.h \
-	$(TOPDIR)/include/fcntl.h \
-	$(TOPDIR)/include/spawn.h \
-	$(TOPDIR)/include/debug.h \
-	$(TOPDIR)/include/errno.h \
-	$(TOPDIR)/include/nuttx/drivers/ramdisk.h \
-	$(TOPDIR)/include/nuttx/symtab.h \
-	filesystem/romfs.h
-
-symtab.o: filesystem/symtab.c \
-	$(TOPDIR)/include/nuttx/compiler.h \
-	$(TOPDIR)/include/nuttx/symtab.h
+	+$(Q) $(MAKE) -C filesystem TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
 
 include $(APPDIR)/Application.mk

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 SPAWN_DIR = $(APPDIR)$(DELIM)examples$(DELIM)posix_spawn
 FILESYSTEM_DIR = $(SPAWN_DIR)$(DELIM)filesystem
@@ -44,12 +43,7 @@ ROMFS_HDR = $(FILESYSTEM_DIR)$(DELIM)romfs.h
 SYMTAB_SRC = $(FILESYSTEM_DIR)$(DELIM)symtab.c
 
 all: $(ROMFS_HDR) $(SYMTAB_SRC)
-.PHONY: all hello/hello redirect/redirect clean populate
-
-# Create the romfs directory
-
-$(ROMFS_DIR):
-	$(Q) mkdir $(ROMFS_DIR)
+.PHONY: all hello/hello redirect/redirect clean
 
 # Build the hello test program
 
@@ -64,15 +58,16 @@ redirect/redirect:
 # Create the romfs.img file from the romfs directory
 # REVISIT: ELF binaries should be stripped so that they are not so big
 
-$(ROMFS_IMG): hello/hello redirect/redirect testdata.txt $(ROMFS_DIR)
+$(ROMFS_IMG): hello/hello redirect/redirect testdata.txt
 	$(Q) $(MAKE) -C hello install TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)"
 	$(Q) $(MAKE) -C redirect install TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)"
 	$(Q) install -m 0644 testdata.txt $(ROMFS_DIR)/testdata.txt
-	$(Q) genromfs -f $@ -d $(ROMFS_DIR) -V "POSIXSPAWN"
+	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "POSIXSPAWN"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(ROMFS_HDR) : $(ROMFS_IMG)
+$(ROMFS_HDR): $(ROMFS_IMG)
 	$(Q) (cd $(FILESYSTEM_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
 # Create the exported symbol table

--- a/examples/posix_spawn/filesystem/hello/Makefile
+++ b/examples/posix_spawn/filesystem/hello/Makefile
@@ -41,7 +41,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=.o)
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %.o: %.c
 	@echo "CC: $<"

--- a/examples/posix_spawn/filesystem/redirect/Makefile
+++ b/examples/posix_spawn/filesystem/redirect/Makefile
@@ -41,7 +41,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=.o)
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %.o: %.c
 	@echo "CC: $<"

--- a/examples/sotest/Makefile
+++ b/examples/sotest/Makefile
@@ -56,10 +56,14 @@ ROOTDEPPATH += --dep-path lib
 
 VPATH = lib
 
-context::
-	@$(MAKE) -C lib TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+sotest_main.c: build
+lib/sot_symtab.c: build
+
+.PHONY: build
+build:
+	+$(Q) $(MAKE) -C lib TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
-	@$(MAKE) -C lib TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
+	+$(Q) $(MAKE) -C lib TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) clean
 
 include $(APPDIR)/Application.mk

--- a/examples/sotest/lib/Makefile
+++ b/examples/sotest/lib/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = sotest
 BUILD_SUBDIRS = sotest
@@ -47,60 +46,49 @@ endif
 SOTEST_DIR = $(APPDIR)/examples/sotest
 LIB_DIR = $(SOTEST_DIR)/lib
 FSROOT_DIR = $(LIB_DIR)/fsroot
-ROMFS_IMG = $(LIB_DIR)/romfs.img
-ROMFS_HDR = $(LIB_DIR)/romfs.h
 SYMTAB_SRC = $(LIB_DIR)/sot_symtab.c
+
+ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
+  ROMFS_IMG = $(LIB_DIR)/romfs.img
+  ROMFS_HDR = $(LIB_DIR)/romfs.h
+endif
 
 define DIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(ROMFS_HDR) $(DIRLIST_HDR) $(SYMTAB_SRC)
-.PHONY: all build clean install populate
+all: $(ROMFS_HDR) $(SYMTAB_SRC)
+.PHONY: all clean install
 
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),build, all)))
-$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
-$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
-
-# Build program(s) in each sud-directory
-
-build: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_build)
+$(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
+$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install)))
 
 # Install each program in the fsroot directory
 
 install: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_install)
 
-# Create the fsroot directory
-
-$(FSROOT_DIR):
-	$(Q) mkdir $(FSROOT_DIR)
-
-# Populate the fsroot directory
-
-populate:  $(FSROOT_DIR) build install
-
+ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
 # Create the romfs.img file from the populated fsroot directory
 
-$(ROMFS_IMG): populate
-ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
-	$(Q) genromfs -f $@ -d $(FSROOT_DIR) -V "SOTESTTEST"
-endif
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(FSROOT_DIR) -V "SOTESTTEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(ROMFS_HDR) : $(ROMFS_IMG)
-ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
+$(ROMFS_HDR): $(ROMFS_IMG)
 	$(Q) (cd $(LIB_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 endif
 
 # Create the exported symbol table
 
-$(SYMTAB_SRC): build
-	$(Q) $(LIB_DIR)/mksymtab.sh $(FSROOT_DIR) >$@
+$(SYMTAB_SRC): install
+	$(Q) $(LIB_DIR)/mksymtab.sh $(FSROOT_DIR) >$@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(ALL_SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(ROMFS_HDR) $(DIRLIST_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(ROMFS_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(FSROOT_DIR)

--- a/examples/sotest/lib/modprint/Makefile
+++ b/examples/sotest/lib/modprint/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 OBJEXT ?= .o
 DELIM ?= /
@@ -44,9 +43,6 @@ NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
 else
 NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
 endif
-
-KDEFINE = ${shell $(DEFINE) "$(CC)" __KERNEL__}
-CMODULEFLAGS += $(KDEFINE)
 
 LDLIBPATH =
 LDLIBS =
@@ -78,7 +74,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"

--- a/examples/sotest/lib/sotest/Makefile
+++ b/examples/sotest/lib/sotest/Makefile
@@ -34,7 +34,6 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
-include $(APPDIR)/Make.defs
 
 OBJEXT ?= .o
 DELIM ?= /
@@ -44,9 +43,6 @@ NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
 else
 NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
 endif
-
-KDEFINE = ${shell $(DEFINE) "$(CC)" __KERNEL__}
-CMODULEFLAGS += $(KDEFINE)
 
 LDLIBPATH =
 LDLIBS =
@@ -78,7 +74,7 @@ SRCS = $(BIN).c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"

--- a/examples/thttpd/Makefile
+++ b/examples/thttpd/Makefile
@@ -51,18 +51,24 @@ PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = 2048
 MODULE = $(CONFIG_EXAMPLES_THTTPD)
 
-# Common build
+thttpd_main.c: build
 
-all::
+.PHONY: build
+build:
+	+$(Q) $(CONTENT_MAKE) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+
+# Common build
 
 context::
 	+$(Q) $(CONTENT_MAKE) context TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 depend::
-	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
 	+$(Q) $(CONTENT_MAKE) depend TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 clean::
 	+$(Q) $(CONTENT_MAKE) clean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+
+distclean::
+	+$(Q) $(CONTENT_MAKE) distclean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 include $(APPDIR)/Application.mk

--- a/examples/thttpd/content/Makefile.binfs
+++ b/examples/thttpd/content/Makefile.binfs
@@ -39,47 +39,42 @@ PROGNAME = hello tasks
 PRIORITY = $(CONFIG_THTTPD_CGI_PRIORITY)
 STACKSIZE = $(CONFIG_THTTPD_CGI_STACKSIZE)
 
+CSRCS = hello.c tasks.c
+
+ROOTDEPPATH += --dep-path hello --dep-path tasks
+VPATH += :hello:tasks
+
+include $(APPDIR)/Application.mk
+
 THTTPD_DIR = $(APPDIR)/examples/thttpd
 CONTENT_DIR = $(THTTPD_DIR)/content
 ROMFS_DIR = $(CONTENT_DIR)/romfs
 ROMFS_IMG = $(CONTENT_DIR)/romfs.img
 ROMFS_HDR = $(CONTENT_DIR)/romfs.h
 
-CSRCS = hello.c tasks.c
-
-ROOTDEPPATH += --dep-path hello --dep-path tasks
-VPATH += :hello:tasks
-
-# Create the romfs directory
-
-$(ROMFS_DIR):
-	@mkdir -p $(ROMFS_DIR)
-
 # Populate the romfs directory
 
 $(ROMFS_DIR)/index.html : $(CONTENT_DIR)/index.html
-	@cp -a $< $@ || { echo "cp of index.html failed"; exit 1; }
+	$(Q) mkdir -p $(ROMFS_DIR)
+	$(Q) cp -a $< $@ || { echo "cp of index.html failed"; exit 1; }
 
 $(ROMFS_DIR)/style.css : $(CONTENT_DIR)/style.css
-	@cp -a $< $@ || { echo "cp of $< failed"; exit 1; }
-
-populate: $(ROMFS_DIR) $(ROMFS_DIR)/index.html  $(ROMFS_DIR)/style.css
+	$(Q) mkdir -p $(ROMFS_DIR)
+	$(Q) cp -a $< $@ || { echo "cp of $< failed"; exit 1; }
 
 # Create the romfs.img file from the populated romfs directory
 
-$(ROMFS_IMG): populate
-	@genromfs -f $@ -d $(ROMFS_DIR) -V "THTTPDTEST"
+$(ROMFS_IMG): $(ROMFS_DIR)/index.html $(ROMFS_DIR)/style.css
+	$(Q) genromfs -f $@ -d $(ROMFS_DIR) -V "THTTPDTEST"
 
 # Create the romfs.h header file from the romfs.img file
 
-$(ROMFS_HDR) : $(ROMFS_IMG)
-	@(cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_HDR): $(ROMFS_IMG)
+	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
-context:: $(ROMFS_HDR)
+all:: $(ROMFS_HDR)
 
 clean::
-	$(call DELFILE$(ROMFS_HDR))
+	$(call DELFILE, $(ROMFS_HDR))
 	$(call DELFILE, $(ROMFS_IMG))
-	@rm -rf $(ROMFS_DIR)
-
-include $(APPDIR)/Application.mk
+	$(Q) rm -rf $(ROMFS_DIR)

--- a/examples/thttpd/content/Makefile.nxflat
+++ b/examples/thttpd/content/Makefile.nxflat
@@ -46,61 +46,38 @@ SYMTAB = $(CONTENT_DIR)/symtab.h
 
 define DIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) CGI_DIR="$(ROMFSCGI_DIR)"
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) CGI_DIR="$(ROMFSCGI_DIR)"
 endef
 
 all: $(ROMFS_HDR) $(SYMTAB)
-.PHONY: all build clean install populate headers binaries context depend
+.PHONY: all clean distclean install context depend
 
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),build,all)))
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
-$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
-
-# Build program(s) in each sud-directory
-
-build: $(foreach DIR, $(SUBDIRS), $(DIR)_build)
+$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
+$(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),install)))
 
 # Install each program in the romfs directory
 
 install: $(foreach DIR, $(SUBDIRS), $(DIR)_install)
-	@( for file in $(INSTALL_FILES); do\
+	$(Q) ( for file in $(INSTALL_FILES); do\
 		install -m 0644 -D $${file} $(ROMFS_DIR)/$${file}; \
 	done; )
 
-# Create the romfs directory
-
-$(ROMFS_DIR):
-	@mkdir -p $(ROMFS_DIR)
-
-$(ROMFSCGI_DIR): $(ROMFS_DIR)
-	@mkdir -p $(ROMFSCGI_DIR)
-
-# Populate the romfs directory
-
-populate:  $(ROMFSCGI_DIR) build install
-
 # Create the romfs.img file from the populated romfs directory
 
-$(ROMFS_IMG): populate
-	@genromfs -f $@ -d $(ROMFS_DIR) -V "THTTPDTEST"
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "THTTPDTEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the romfs.h header file from the romfs.img file
 
-$(ROMFS_HDR) : $(ROMFS_IMG)
-	@(cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_HDR): $(ROMFS_IMG)
+	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
 
 # Create the exported symbol table list from the derived *-thunk.S files
 
-$(SYMTAB): build
-	@$(CONTENT_DIR)/mksymtab.sh $(CONTENT_DIR) >$@
-
-# Make ROMFS header file and symbols tables.
-
-headers: $(ROMFS_HDR) $(SYMTAB)
-
-# No binaries need to be build
-
-binaries:
+$(SYMTAB): install
+	$(Q) $(CONTENT_DIR)/mksymtab.sh $(CONTENT_DIR) >$@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Nothing special needs to be done during the context phase
 
@@ -109,11 +86,10 @@ context:
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(SUBDIRS), $(DIR)_clean)
-	$(call DELFILE$(ROMFS_HDR))
+	$(call DELFILE, $(ROMFS_HDR))
 	$(call DELFILE, $(ROMFS_IMG))
 	$(call DELFILE, $(SYMTAB))
-	@rm -rf $(ROMFS_DIR)
-	$(call CLEAN)
+	$(Q) rm -rf $(ROMFS_DIR)
 
 distclean: clean
 

--- a/examples/thttpd/content/hello/Makefile
+++ b/examples/thttpd/content/hello/Makefile
@@ -44,7 +44,7 @@ R2SRC = $(BIN)-thunk.S
 R2OBJ = $(R2SRC:.S=.o)
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(R1OBJS): %.o: %.c
 	@echo "CC: $<"

--- a/examples/thttpd/content/tasks/Makefile
+++ b/examples/thttpd/content/tasks/Makefile
@@ -47,7 +47,7 @@ R2SRC = $(BIN)-thunk.S
 R2OBJ = $(R2SRC:.S=.o)
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: all clean install
 
 $(R1OBJS): %.o: %.c
 	@echo "CC: $<"


### PR DESCRIPTION
1.Remove build target to avoid build and install run parallelly
2.Invoke the sub Makefile just before the parent source code compile

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>