### PR TITLE
CI: remove the additional pull docker container step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,6 @@ jobs:
         username: ${GITHUB_ACTOR}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Run Pull Container
-      uses: ./testing/.github/actions/ci-container
-
     - name: Run builds
       uses: ./testing/.github/actions/ci-container
       env:


### PR DESCRIPTION
There is chance pull docker container failure in build jobs,
remove the additional pull docker container step may make it
more stable. Meanwhile, it also saves some time for build job.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>