### PR TITLE
CI: sync with testing repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,4 @@ jobs:
       with:
         run: |
           cd testing
-          ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -x -G testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
Namely the following commit:

    commit 29f2116356451ee3430332df28b953f76da2d284
    Author: YAMAMOTO Takashi <yamamoto@midokura.com>
    Date:   Fri Apr 3 13:56:42 2020 +0900

        Use testbuild -G ("git clean" instead of "make distclean")