### PR TITLE
netlib: Remove AF_FAMILY and PF_FAMILY definition

### DIFF
--- a/netutils/netlib/netlib_getessid.c
+++ b/netutils/netlib/netlib_getessid.c
@@ -56,29 +56,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* The address family that we used to create the socket and in the IOCTL
- * data really does not matter.  It should, however, be valid in the current
- * configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define PF_FAMILY PF_INET
-#  define AF_FAMILY AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define PF_FAMILY PF_INET6
-#  define AF_FAMILY AF_INET6
-#elif defined(CONFIG_NET_IEEE802154)
-#  define PF_FAMILY PF_IEEE802154
-#  define AF_FAMILY AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define PF_FAMILY PF_BLUETOOTH
-#  define AF_FAMILY AF_BLUETOOTH
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -107,7 +84,8 @@ int netlib_getessid(FAR const char *ifname, FAR char *essid, size_t idlen)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(PF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct iwreq req;

--- a/netutils/netlib/netlib_getifstatus.c
+++ b/netutils/netlib/netlib_getifstatus.c
@@ -56,31 +56,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-/* The address family that we used to create the socket really does not
- * matter.  It should, however, be valid in the current configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define AF_FAMILY AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define AF_FAMILY AF_INET6
-#elif defined(CONFIG_NET_LOCAL)
-#  define AF_FAMILY AF_LOCAL
-#elif defined(CONFIG_NET_PKT)
-#  define AF_FAMILY AF_PACKET
-#elif defined(CONFIG_NET_IEEE802154)
-#  define AF_FAMILY AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define AF_FAMILY AF_BLUETOOTH
-#elif defined(CONFIG_NET_USRSOCK)
-#  define AF_FAMILY AF_INET
-#elif defined(CONFIG_NET_NETLINK)
-#  define AF_FAMILY AF_NETLINK
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -106,7 +81,8 @@ int netlib_getifstatus(FAR const char *ifname, FAR uint8_t *flags)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(AF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct ifreq req;

--- a/netutils/netlib/netlib_getmacaddr.c
+++ b/netutils/netlib/netlib_getmacaddr.c
@@ -55,27 +55,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-/* The address family that we used to create the socket really does not
- * matter.  It should, however, be valid in the current configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define AF_FAMILY AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define AF_FAMILY AF_INET6
-#elif defined(CONFIG_NET_PKT)
-#  define AF_FAMILY AF_PACKET
-#elif defined(CONFIG_NET_IEEE802154)
-#  define AF_FAMILY AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define AF_FAMILY AF_BLUETOOTH
-#elif defined(CONFIG_NET_USRSOCK)
-#  define AF_FAMILY AF_INET
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -101,7 +80,8 @@ int netlib_getmacaddr(const char *ifname, uint8_t *macaddr)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(AF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct ifreq req;
@@ -124,6 +104,7 @@ int netlib_getmacaddr(const char *ifname, uint8_t *macaddr)
           close(sockfd);
         }
     }
+
   return ret;
 }
 

--- a/netutils/netlib/netlib_setessid.c
+++ b/netutils/netlib/netlib_setessid.c
@@ -56,29 +56,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
- /* The address family that we used to create the socket and in the IOCTL
- * data really does not matter.  It should, however, be valid in the current
- * configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define PF_FAMILY PF_INET
-#  define AF_FAMILY AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define PF_FAMILY PF_INET6
-#  define AF_FAMILY AF_INET6
-#elif defined(CONFIG_NET_IEEE802154)
-#  define PF_FAMILY PF_IEEE802154
-#  define AF_FAMILY AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define PF_FAMILY PF_BLUETOOTH
-#  define AF_FAMILY AF_BLUETOOTH
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -106,7 +83,8 @@ int netlib_setessid(FAR const char *ifname, FAR const char *essid)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(PF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct iwreq req;

--- a/netutils/netlib/netlib_setifstatus.c
+++ b/netutils/netlib/netlib_setifstatus.c
@@ -55,31 +55,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-/* The address family that we used to create the socket really does not
- * matter.  It should, however, be valid in the current configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define AF_FAMILY  AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define AF_FAMILY  AF_INET6
-#elif defined(CONFIG_NET_LOCAL)
-#  define AF_FAMILY  AF_LOCAL
-#elif defined(CONFIG_NET_PKT)
-#  define AF_FAMILY  AF_PACKET
-#elif defined(CONFIG_NET_IEEE802154)
-#  define AF_FAMILY  AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define AF_FAMILY  AF_BLUETOOTH
-#elif defined(CONFIG_NET_USRSOCK)
-#  define AF_FAMILY  AF_INET
-#elif defined(CONFIG_NET_NETLINK)
-#  define AF_FAMILY  AF_NETLINK
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -104,7 +79,8 @@ int netlib_ifup(const char *ifname)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(AF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct ifreq req;
@@ -147,7 +123,8 @@ int netlib_ifdown(const char *ifname)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(AF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct ifreq req;

--- a/netutils/netlib/netlib_setmacaddr.c
+++ b/netutils/netlib/netlib_setmacaddr.c
@@ -55,34 +55,6 @@
 #ifdef CONFIG_NET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-/* The address family that we used to create the socket and in the IOCTL
- * data really does not matter.  It should, however, be valid in the current
- * configuration.
- */
-
-#if defined(CONFIG_NET_IPv4)
-#  define PF_FAMILY  PF_INET
-#  define AF_FAMILY  AF_INET
-#elif defined(CONFIG_NET_IPv6)
-#  define PF_FAMILY  PF_INET6
-#  define AF_FAMILY  AF_INET6
-#elif defined(CONFIG_NET_PKT)
-#  define PF_FAMILY  PF_PACKET
-#  define AF_FAMILY  AF_PACKET
-#elif defined(CONFIG_NET_IEEE802154)
-#  define PF_FAMILY  PF_IEEE802154
-#  define AF_FAMILY  AF_IEEE802154
-#elif defined(CONFIG_NET_BLUETOOTH)
-#  define PF_FAMILY  PF_BLUETOOTH
-#  define AF_FAMILY  AF_BLUETOOTH
-#elif defined(CONFIG_NET_USRSOCK)
-#  define PF_FAMILY  PF_INET
-#  define AF_FAMILY  AF_INET
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -109,7 +81,8 @@ int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr)
     {
       /* Get a socket (only so that we get access to the INET subsystem) */
 
-      int sockfd = socket(PF_FAMILY, NETLIB_SOCK_TYPE, 0);
+      int sockfd = socket(NETLIB_SOCK_FAMILY,
+                          NETLIB_SOCK_TYPE, NETLIB_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
           struct ifreq req;
@@ -120,7 +93,7 @@ int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr)
 
           /* Put the new MAC address into the request */
 
-          req.ifr_hwaddr.sa_family = AF_FAMILY;
+          req.ifr_hwaddr.sa_family = NETLIB_SOCK_FAMILY;
           memcpy(&req.ifr_hwaddr.sa_data, macaddr, IFHWADDRLEN);
 
           /* Perform the ioctl to set the MAC address */


### PR DESCRIPTION
use the common one(NETLIB_SOCK_FAMILY)

Change-Id: Ifc255f82f169d3bb37604c49006361a40c9933d1
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>