### PR TITLE
Remove CONFIG_CAN_PASS_STRUCT

### DIFF
--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -176,11 +176,7 @@ static void configdata_loopmemusage(void)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous loop */
 
@@ -189,11 +185,7 @@ static void configdata_loopmemusage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 }
 #endif
 
@@ -203,11 +195,8 @@ static void configdata_loopmemusage(void)
 
 static void configdata_endmemusage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
+
   printf("\nFinal memory usage:\n");
   configdata_showmemusage(&g_mmbefore, &g_mmafter);
 
@@ -679,11 +668,7 @@ int main(int argc, FAR char *argv[])
 
   /* Initialize the before memory values */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmbefore = mallinfo();
-#else
-  mallinfo(&g_mmbefore);
-#endif
 
   /* Loop seveal times ... create some config data items, delete them
    * randomly, verify them randomly, add new config items.

--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -57,16 +57,21 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* The default is to use the RAM MTD device at drivers/mtd/rammtd.c.  But
  * an architecture-specific MTD driver can be used instead by defining
- * CONFIG_EXAMPLES_CONFIGDATA_ARCHINIT.  In this case, the initialization logic
- * will call configdata_archinitialize() to obtain the MTD driver instance.
+ * CONFIG_EXAMPLES_CONFIGDATA_ARCHINIT.  In this case, the initialization
+ * logic will call configdata_archinitialize() to obtain the MTD driver
+ * instance.
  */
 
 #ifndef CONFIG_EXAMPLES_CONFIGDATA_ARCHINIT
 
-/* This must exactly match the default configuration in drivers/mtd/rammtd.c */
+/* This must exactly match the default configuration in
+ * drivers/mtd/rammtd.c
+ */
 
 #  ifndef CONFIG_RAMMTD_ERASESIZE
 #    define CONFIG_RAMMTD_ERASESIZE 4096
@@ -119,19 +124,24 @@ struct configdata_entrydesc_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* Pre-allocated simulated flash */
 
 #ifndef CONFIG_EXAMPLES_CONFIGDATA_ARCHINIT
-static uint8_t g_simflash[EXAMPLES_CONFIGDATA_BUFSIZE<<1];
+static uint8_t g_simflash[EXAMPLES_CONFIGDATA_BUFSIZE << 1];
 #endif
 
 static uint8_t g_entryimage[CONFIG_EXAMPLES_CONFIGDATA_MAXSIZE];
-static struct configdata_entrydesc_s g_entries[CONFIG_EXAMPLES_CONFIGDATA_MAXENTRIES];
+static struct configdata_entrydesc_s
+  g_entries[CONFIG_EXAMPLES_CONFIGDATA_MAXENTRIES];
+
 static int g_nentries;
 static int g_ndeleted;
 static int g_fd;
-static int g_ntests, g_nverified;
-static int g_ntotalalloc, g_ntotaldelete;
+static int g_ntests;
+static int g_nverified;
+static int g_ntotalalloc;
+static int g_ntotaldelete;
 
 static struct mallinfo g_mmbefore;
 static struct mallinfo g_mmafter;
@@ -216,7 +226,7 @@ static inline uint16_t configdata_randid(void)
   int value;
 
 retry:
-  value = rand() & 0x7FFF;
+  value = rand() & 0x7fff;
   if (value == 0)
     {
       value = 100;
@@ -275,7 +285,8 @@ static void configdata_freeentry(FAR struct configdata_entrydesc_s *entry)
  * Name: configdata_wrentry
  ****************************************************************************/
 
-static inline int configdata_wrentry(FAR struct configdata_entrydesc_s *entry)
+static inline int
+  configdata_wrentry(FAR struct configdata_entrydesc_s *entry)
 {
   size_t x;
   int ret;
@@ -291,7 +302,7 @@ static inline int configdata_wrentry(FAR struct configdata_entrydesc_s *entry)
 
   for (x = 0; x < entry->len; x++)
     {
-      g_entryimage[x] = rand() & 0xFF;
+      g_entryimage[x] = rand() & 0xff;
     }
 
   /* Calculate the crc32 for the data */
@@ -357,7 +368,8 @@ static int configdata_fillconfig(void)
  * Name: configdata_rdentry
  ****************************************************************************/
 
-static inline int configdata_rdentry(FAR struct configdata_entrydesc_s *entry)
+static inline int
+  configdata_rdentry(FAR struct configdata_entrydesc_s *entry)
 {
   struct config_data_s config;
   uint32_t crc;
@@ -435,7 +447,9 @@ static int configdata_verifyconfig(void)
             }
           else
             {
-              /* Check if this entry has been deleted and should report an error */
+              /* Check if this entry has been deleted and should report an
+               * error.
+               */
 
               if (entry->deleted)
                 {
@@ -448,7 +462,8 @@ static int configdata_verifyconfig(void)
                 {
                   g_nverified++;
 #if CONFIG_EXAMPLES_CONFIGDATA_VERBOSE != 0
-                  printf("  Verifed entry %04X, %d\n", entry->id, entry->instance);
+                  printf("  Verifed entry %04X, %d\n",
+                         entry->id, entry->instance);
 #endif
                 }
             }
@@ -493,7 +508,7 @@ static int configdata_delentries(void)
 
       /* And delete the next undeleted file after that random index */
 
-      for (j = ndx + 1; j != ndx;)
+      for (j = ndx + 1; j != ndx; )
         {
           entry = &g_entries[j];
           if (entry->id && !entry->deleted)
@@ -504,7 +519,7 @@ static int configdata_delentries(void)
               ret = ioctl(g_fd, CFGDIOC_SETCONFIG, (unsigned long) &hdr);
               if (ret < 0)
                 {
-                  printf("ERROR: Delete %d failed: %d\n", i+1, errno);
+                  printf("ERROR: Delete %d failed: %d\n", i + 1, errno);
                   printf("  Entry id:    %04X\n", entry->id);
                   printf("  Entry size:  %d\n", entry->len);
                   printf("  Entry index: %d\n", j);
@@ -569,7 +584,9 @@ static void configdata_cleardeleted(void)
     {
       /* Find next non-deleted entry after the deleted one */
 
-      for (x = nextdeleted + 1; x < CONFIG_EXAMPLES_CONFIGDATA_MAXENTRIES; x++)
+      for (x = nextdeleted + 1;
+           x < CONFIG_EXAMPLES_CONFIGDATA_MAXENTRIES;
+           x++)
         {
           if (g_entries[x].id && !g_entries[x].deleted)
             {
@@ -594,6 +611,7 @@ static void configdata_cleardeleted(void)
       else
         {
           /* Just remove the entry */
+
           g_entries[nextdeleted].id = 0;
           g_entries[nextdeleted].deleted = FALSE;
         }
@@ -683,9 +701,9 @@ int main(int argc, FAR char *argv[])
   for (i = 1; i <= CONFIG_EXAMPLES_CONFIGDATA_NLOOPS; i++)
 #endif
     {
-      /* Write config data to the /dev/config device until either (1) all of the
-       * open file structures are utilized or until (2) CONFIGDATA reports an error
-       * (hopefully that the /dev/config device is full)
+      /* Write config data to the /dev/config device until either (1) all of
+       * the open file structures are utilized or until (2) CONFIGDATA
+       * reports an error (hopefully that the /dev/config device is full)
        */
 
 #ifndef CONFIG_EXAMPLES_CONFIGDATA_SILENT
@@ -774,9 +792,12 @@ int main(int argc, FAR char *argv[])
 #endif
     }
 
+#if 0
   /* Delete all files then show memory usage again */
 
-  //configdata_delallfiles();
+  configdata_delallfiles();
+#endif
+
   configdata_endmemusage();
   fflush(stdout);
   return 0;

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -101,8 +101,8 @@
 #  undef MOUNTPT
 #endif
 
-/* If CONFIG_DEBUG_FEATURES is enabled, use info/err instead of printf so that the
- * output will be synchronous with the debug output.
+/* If CONFIG_DEBUG_FEATURES is enabled, use info/err instead of printf so
+ * that the output will be synchronous with the debug output.
  */
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
@@ -137,7 +137,8 @@ static unsigned int g_mminitial;  /* Initial memory usage */
 static unsigned int g_mmstep;     /* Memory Usage at beginning of test step */
 
 static const char delimiter[] =
-  "****************************************************************************";
+  "**************************************"
+  "**************************************";
 
 #ifndef CONFIG_LIB_ENVPATH
 static char fullpath[128];
@@ -170,7 +171,8 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 
   printf("\nMemory Usage %s:\n", msg);
   printf("  Before: %8u After: %8u Change: %8d\n",
-         *previous, mmcurrent.uordblks, (int)mmcurrent.uordblks - (int)*previous);
+         *previous, mmcurrent.uordblks,
+         (int)mmcurrent.uordblks - (int)*previous);
 
   /* Set up for the next test */
 
@@ -260,7 +262,8 @@ int main(int argc, FAR char *argv[])
   message("Mounting ROMFS filesystem at target=%s with source=%s\n",
          MOUNTPT, CONFIG_EXAMPLES_ELF_DEVPATH);
 
-  ret = mount(CONFIG_EXAMPLES_ELF_DEVPATH, MOUNTPT, "romfs", MS_RDONLY, NULL);
+  ret = mount(CONFIG_EXAMPLES_ELF_DEVPATH, MOUNTPT, "romfs",
+              MS_RDONLY, NULL);
   if (ret < 0)
     {
       errmsg("ERROR: mount(%s,%s,romfs) failed: %s\n",
@@ -322,7 +325,7 @@ int main(int argc, FAR char *argv[])
               CONFIG_EXAMPLES_ELF_FSTYPE, MS_RDONLY, NULL);
   if (ret < 0)
     {
-      errmsg("ERROR: mount(%s, %s, %s) failed: %d\n",\
+      errmsg("ERROR: mount(%s, %s, %s) failed: %d\n",
              CONFIG_EXAMPLES_ELF_DEVPATH, CONFIG_EXAMPLES_ELF_FSTYPE,
              MOUNTPT, errno);
     }

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * examples/elf/elf_main.c
  *
- *   Copyright (C) 2012, 2017-2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -179,11 +164,7 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -204,11 +185,7 @@ static void mm_initmonitor(void)
 {
   struct mallinfo mmcurrent;
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mminitial = mmcurrent.uordblks;
   g_mmstep    = mmcurrent.uordblks;

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -92,8 +92,8 @@
 #  define CONFIG_EXAMPLES_ELF_DEVPATH "/dev/ram0"
 #endif
 
-/* If CONFIG_DEBUG_FEATURES is enabled, use info/err instead of printf so that the
- * output will be synchronous with the debug output.
+/* If CONFIG_DEBUG_FEATURES is enabled, use info/err instead of printf so
+ * that the output will be synchronous with the debug output.
  */
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
@@ -126,7 +126,8 @@ static unsigned int g_mminitial;  /* Initial memory usage */
 static unsigned int g_mmstep;     /* Memory Usage at beginning of test step */
 
 static const char delimiter[] =
-  "****************************************************************************";
+  "**************************************"
+  "**************************************";
 static const char g_redirect[] = "redirect";
 static const char g_hello[]    = "hello";
 static const char g_data[]     = "testdata.txt";
@@ -134,7 +135,9 @@ static const char g_data[]     = "testdata.txt";
 static char fullpath[128];
 
 static char * const g_argv[4] =
-  { "Argument 1", "Argument 2", "Argument 3", NULL };
+{
+  "Argument 1", "Argument 2", "Argument 3", NULL
+};
 
 /****************************************************************************
  * Symbols from Auto-Generated Code
@@ -163,7 +166,8 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 
   printf("\nMemory Usage %s:\n", msg);
   printf("  Before: %8u After: %8u Change: %8d\n",
-         *previous, mmcurrent.uordblks, (int)mmcurrent.uordblks - (int)*previous);
+         *previous, mmcurrent.uordblks,
+         (int)mmcurrent.uordblks - (int)*previous);
 
   /* Set up for the next test */
 
@@ -218,9 +222,12 @@ int main(int argc, FAR char *argv[])
 
   /* Create a ROM disk for the ROMFS filesystem */
 
-  message("Registering romdisk at /dev/ram%d\n", CONFIG_EXAMPLES_ELF_DEVMINOR);
-  ret = romdisk_register(CONFIG_EXAMPLES_ELF_DEVMINOR, (FAR uint8_t *)romfs_img,
-                         NSECTORS(romfs_img_len), SECTORSIZE);
+  message("Registering romdisk at /dev/ram%d\n",
+          CONFIG_EXAMPLES_ELF_DEVMINOR);
+
+  ret = romdisk_register(CONFIG_EXAMPLES_ELF_DEVMINOR,
+                         (FAR uint8_t *)romfs_img, NSECTORS(romfs_img_len),
+                         SECTORSIZE);
   if (ret < 0)
     {
       errmsg("ERROR: romdisk_register failed: %d\n", ret);
@@ -234,7 +241,8 @@ int main(int argc, FAR char *argv[])
   message("Mounting ROMFS filesystem at target=%s with source=%s\n",
          MOUNTPT, CONFIG_EXAMPLES_ELF_DEVPATH);
 
-  ret = mount(CONFIG_EXAMPLES_ELF_DEVPATH, MOUNTPT, "romfs", MS_RDONLY, NULL);
+  ret = mount(CONFIG_EXAMPLES_ELF_DEVPATH, MOUNTPT, "romfs",
+              MS_RDONLY, NULL);
   if (ret < 0)
     {
       errmsg("ERROR: mount(%s,%s,romfs) failed: %s\n",
@@ -258,9 +266,9 @@ int main(int argc, FAR char *argv[])
   symdesc.nsymbols = g_spawn_nexports;
   boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
 
-  /*************************************************************************
+  /**************************************************************************
    * Case 1: Simple program with arguments
-   *************************************************************************/
+   **************************************************************************/
 
   /* Output a separator so that we can clearly discriminate the output of
    * this program from the others.
@@ -305,7 +313,8 @@ int main(int argc, FAR char *argv[])
 
   mm_update(&g_mmstep, "before posix_spawn");
 
-  ret = posix_spawn(&pid, filepath, &file_actions, &attr, NULL, (FAR char * const*)&g_argv);
+  ret = posix_spawn(&pid, filepath, &file_actions, &attr, NULL,
+                    (FAR char * const *)&g_argv);
   if (ret != 0)
     {
       errmsg("ERROR: posix_spawn failed: %d\n", ret);
@@ -334,9 +343,9 @@ int main(int argc, FAR char *argv[])
 
   mm_update(&g_mmstep, "after file_action/attr destruction");
 
-  /*************************************************************************
+  /**************************************************************************
    * Case 2: Simple program with redirection of stdin to a file input
-   *************************************************************************/
+   **************************************************************************/
 
   /* Output a separator so that we can clearly discriminate the output of
    * this program from the others.
@@ -375,7 +384,8 @@ int main(int argc, FAR char *argv[])
   posix_spawn_file_actions_dump(&file_actions);
 
   snprintf(fullpath, 128, "%s/%s", MOUNTPT, g_data);
-  ret = posix_spawn_file_actions_addopen(&file_actions, 0, fullpath, O_RDONLY, 0644);
+  ret = posix_spawn_file_actions_addopen(&file_actions, 0, fullpath,
+                                         O_RDONLY, 0644);
   if (ret != 0)
     {
       errmsg("ERROR: posix_spawn_file_actions_addopen failed: %d\n", ret);
@@ -418,6 +428,7 @@ int main(int argc, FAR char *argv[])
     {
       errmsg("ERROR: posix_spawn_file_actions_destroy failed: %d\n", ret);
     }
+
   posix_spawn_file_actions_dump(&file_actions);
 
   ret = posix_spawnattr_destroy(&attr);
@@ -425,6 +436,7 @@ int main(int argc, FAR char *argv[])
     {
       errmsg("ERROR: posix_spawnattr_destroy failed: %d\n", ret);
     }
+
   posix_spawnattr_dump(&attr);
 
   mm_update(&g_mmstep, "after file_action/attr destruction");

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * examples/posix_spawn/spawn_main.c
  *
- *   Copyright (C) 2013, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -172,11 +157,7 @@ static void mm_update(FAR unsigned int *previous, FAR const char *msg)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -197,11 +178,7 @@ static void mm_initmonitor(void)
 {
   struct mallinfo mmcurrent;
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mminitial = mmcurrent.uordblks;
   g_mmstep    = mmcurrent.uordblks;

--- a/examples/stat/stat_main.c
+++ b/examples/stat/stat_main.c
@@ -127,47 +127,47 @@ static void dump_stat(FAR struct stat *buf)
 
   if ((buf->st_mode & S_IRUSR) != 0)
     {
-      details[1]='r';
+      details[1] = 'r';
     }
 
   if ((buf->st_mode & S_IWUSR) != 0)
     {
-      details[2]='w';
+      details[2] = 'w';
     }
 
   if ((buf->st_mode & S_IXUSR) != 0)
     {
-      details[3]='x';
+      details[3] = 'x';
     }
 
   if ((buf->st_mode & S_IRGRP) != 0)
     {
-      details[4]='r';
+      details[4] = 'r';
     }
 
   if ((buf->st_mode & S_IWGRP) != 0)
     {
-      details[5]='w';
+      details[5] = 'w';
     }
 
   if ((buf->st_mode & S_IXGRP) != 0)
     {
-      details[6]='x';
+      details[6] = 'x';
     }
 
   if ((buf->st_mode & S_IROTH) != 0)
     {
-      details[7]='r';
+      details[7] = 'r';
     }
 
   if ((buf->st_mode & S_IWOTH) != 0)
     {
-      details[8]='w';
+      details[8] = 'w';
     }
 
   if ((buf->st_mode & S_IXOTH) != 0)
     {
-      details[9]='x';
+      details[9] = 'x';
     }
 
   printf("stat buffer:\n");

--- a/examples/stat/stat_main.c
+++ b/examples/stat/stat_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * examples/stat/stat_main.c
  *
- *   Copyright (C) 2008, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -78,11 +63,7 @@ static void stepusage(void)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous loop */
 
@@ -90,20 +71,12 @@ static void stepusage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 }
 
 static void endusage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
   showusage(&g_mmbefore, &g_mmafter, "End-of-test memory leak");
 }
 
@@ -251,13 +224,8 @@ int main(int argc, FAR char *argv[])
 
   /* Set up memory monitoring */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
-  g_mmbefore = mallinfo();
+  g_mmbefore   = mallinfo();
   g_mmprevious = g_mmbefore;
-#else
-  mallinfo(&g_mmbefore);
-  memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
-#endif
 
   /* Try stat first */
 

--- a/examples/usrsocktest/usrsocktest_main.c
+++ b/examples/usrsocktest/usrsocktest_main.c
@@ -97,17 +97,16 @@ bool usrsocktest_test_failed = false;
 
 static void get_mallinfo(struct mallinfo *mem)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   *mem = mallinfo();
-#else
-  mallinfo(mem);
-#endif
 }
 
 static void print_mallinfo(const struct mallinfo *mem, const char *title)
 {
   if (title)
-    printf("%s:\n", title);
+    {
+      printf("%s:\n", title);
+    }
+
   printf("       %11s%11s%11s%11s\n", "total", "used", "free", "largest");
   printf("Mem:   %11d%11d%11d%11d\n",
          mem->arena, mem->uordblks, mem->fordblks, mem->mxordblk);

--- a/examples/usrsocktest/usrsocktest_main.c
+++ b/examples/usrsocktest/usrsocktest_main.c
@@ -144,7 +144,7 @@ static void run_tests(FAR const char *name, void (CODE *test_fn)(void))
 }
 
 /****************************************************************************
- * Name: runAllTests
+ * Name: run_all_tests
  *
  * Description:
  *   Sequentially runs all included test groups
@@ -160,7 +160,7 @@ static void run_tests(FAR const char *name, void (CODE *test_fn)(void))
  *
  ****************************************************************************/
 
-static void runAllTests(void)
+static void run_all_tests(void)
 {
   RUN_TEST_GROUP(CharDev);
   RUN_TEST_GROUP(NoDaemon);
@@ -247,7 +247,8 @@ bool usrsocktest_assert_print_buf(FAR const char *func,
 
 int main(int argc, FAR char *argv[])
 {
-  struct mallinfo mem_before, mem_after;
+  struct mallinfo mem_before;
+  struct mallinfo mem_after;
 
   memset(&overall, 0, sizeof(overall));
 
@@ -257,7 +258,7 @@ int main(int argc, FAR char *argv[])
 
   get_mallinfo(&mem_before);
 
-  runAllTests();
+  run_all_tests();
 
   printf("Unit-test groups done... OK:%d, FAILED:%d, TOTAL:%d\n",
          overall.ok, overall.failed, overall.ok + overall.failed);

--- a/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarray_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarray_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CButtonArray/cbuttonarray_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -99,11 +84,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -129,11 +110,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmPrevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CCheckBox/ccheckbox_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CCheckBox/ccheckbox_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CCheckBox/ccheckbox_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbutton_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbutton_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CGlyphButton/cglyphbutton_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -89,11 +74,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -116,11 +97,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/cglyphsliderhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/cglyphsliderhorizontal_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/cglyphsliderhorizontal_main.cxx
 //
-//   Copyright (C) 2012-2013 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CImage/cimage_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CImage/cimage_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CImage/cimage_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -106,11 +91,7 @@ static void updateMemoryUsage(FAR struct mallinfo *previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -119,11 +100,7 @@ static void updateMemoryUsage(FAR struct mallinfo *previous,
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = mmcurrent;
-#else
-  memcpy(&g_mmprevious, &mmcurrent, sizeof(struct mallinfo));
-#endif
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -132,13 +109,8 @@ static void updateMemoryUsage(FAR struct mallinfo *previous,
 
 static void initMemoryUsage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
-  g_mmInitial = mallinfo();
+  g_mmInitial  = mallinfo();
   g_mmprevious = g_mmInitial;
-#else
-  mallinfo(&g_mmInitial);
-  memcpy(&g_mmprevious, &g_mmInitial, sizeof(struct mallinfo));
-#endif
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/graphics/nxwidgets/UnitTests/CKeypad/ckeypad_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CKeypad/ckeypad_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CKeypad/ckeypad_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -89,11 +74,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -119,11 +100,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmPrevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarray_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarray_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CLatchButtonArray/clatchbuttonarry_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -125,11 +110,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -155,11 +136,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmPrevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CListBox/clistbox_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CListBox/clistbox_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CListBox/clistbox_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -125,11 +110,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -155,11 +136,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmPrevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CProgressBar/cprogressbar_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CProgressBar/cprogressbar_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CProgressBar/cprogressbar_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CRadioButton/cradiobutton_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CRadioButton/cradiobutton_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CRadioButton/cradiobutton_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/cscrollbarhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/cscrollbarhorizontal_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/cscrollbarhorizontal_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CScrollbarVertical/cscrollbarvertical_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CScrollbarVertical/cscrollbarvertical_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CScrollbarVertical/cscrollbarvertical_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CSliderHorizonal/csliderhorizontal_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CSliderHorizonal/csliderhorizontal_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CSliderHorizontal/csliderhorizontal_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/graphics/nxwidgets/UnitTests/CSliderVertical/cslidervertical_main.cxx
+++ b/graphics/nxwidgets/UnitTests/CSliderVertical/cslidervertical_main.cxx
@@ -1,35 +1,20 @@
 /////////////////////////////////////////////////////////////////////////////
 // apps/graphics/nxwidgets/UnitTests/CSliderVertical/cslidervertical_main.cxx
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX, NxWidgets, nor the names of its contributors
-//    me be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -90,11 +75,7 @@ static void updateMemoryUsage(unsigned int previous,
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -117,11 +98,7 @@ static void initMemoryUsage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mmcurrent = mallinfo();
-#else
-  mallinfo(&mmcurrent);
-#endif
 
   g_mmInitial  = mmcurrent.uordblks;
   g_mmprevious = mmcurrent.uordblks;

--- a/netutils/thttpd/thttpd_alloc.c
+++ b/netutils/thttpd/thttpd_alloc.c
@@ -74,7 +74,8 @@ void httpd_memstats(void)
 
   mm = mallinfo();
 
-  ninfo("arena: %08x ordblks: %08x mxordblk: %08x uordblks: %08x fordblks: %08x\n",
+  ninfo("arena: %08x ordblks: %08x mxordblk: %08x uordblks: %08x "
+        "fordblks: %08x\n",
        mm.arena, mm.ordblks, mm.mxordblk, mm.uordblks, mm.fordblks);
 }
 #endif
@@ -97,6 +98,7 @@ FAR void *httpd_malloc(size_t nbytes)
       g_nallocations++;
       g_allocated += nbytes;
     }
+
   httpd_memstats();
   return ptr;
 }
@@ -117,6 +119,7 @@ FAR void *httpd_realloc(FAR void *oldptr, size_t oldsize, size_t newsize)
             oldsize, newsize, oldptr, ptr);
       g_allocated += (newsize - oldsize);
     }
+
   httpd_memstats();
   return ptr;
 }
@@ -146,6 +149,7 @@ FAR char *httpd_strdup(const char *str)
       g_nallocations++;
       g_allocated += (strlen(str)+1);
     }
+
   httpd_memstats();
   return newstr;
 }
@@ -158,7 +162,8 @@ void httpd_realloc_str(char **pstr, size_t *maxsize, size_t size)
   size_t oldsize;
   if (*maxsize == 0)
     {
-      *maxsize = MAX(CONFIG_THTTPD_MINSTRSIZE, size + CONFIG_THTTPD_REALLOCINCR);
+      *maxsize = MAX(CONFIG_THTTPD_MINSTRSIZE,
+                     size + CONFIG_THTTPD_REALLOCINCR);
       *pstr    = NEW(char, *maxsize + 1);
     }
   else if (size > *maxsize)

--- a/netutils/thttpd/thttpd_alloc.c
+++ b/netutils/thttpd/thttpd_alloc.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * netutils/thttpd/thttpd_alloc.c
  *
- *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -87,11 +72,8 @@ void httpd_memstats(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   mm = mallinfo();
-#else
-  mallinfo(&mm);
-#endif
+
   ninfo("arena: %08x ordblks: %08x mxordblk: %08x uordblks: %08x fordblks: %08x\n",
        mm.arena, mm.ordblks, mm.mxordblk, mm.uordblks, mm.fordblks);
 }

--- a/system/composite/composite_main.c
+++ b/system/composite/composite_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * system/composite/composite_main.c
  *
- *   Copyright (C) 2012-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -124,11 +109,7 @@ static void check_test_memory_usage(FAR const char *msg)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmcurrent = mallinfo();
-#else
-  mallinfo(&g_composite.mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -137,11 +118,7 @@ static void check_test_memory_usage(FAR const char *msg)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmprevious = g_composite.mmcurrent;
-#else
-  memcpy(&g_composite.mmprevious, &g_composite.mmcurrent, sizeof(struct mallinfo));
-#endif
 }
 #else
 #  define check_test_memory_usage(msg)
@@ -156,11 +133,7 @@ static void final_memory_usage(FAR const char *msg)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmcurrent = mallinfo();
-#else
-  mallinfo(&g_composite.mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -443,13 +416,8 @@ int main(int argc, FAR char *argv[])
   usbtrace_enable(TRACE_BITSET);
 
 #ifdef CONFIG_SYSTEM_COMPOSITE_DEBUGMM
-#  ifdef CONFIG_CAN_PASS_STRUCTS
   g_composite.mmstart    = mallinfo();
   g_composite.mmprevious = g_composite.mmstart;
-#  else
-  mallinfo(&g_composite.mmstart);
-  memcpy(&g_composite.mmprevious, &g_composite.mmstart, sizeof(struct mallinfo));
-#  endif
 #endif
 
   /* Perform architecture-specific initialization */

--- a/system/composite/composite_main.c
+++ b/system/composite/composite_main.c
@@ -335,6 +335,7 @@ static int composite_enumerate(struct usbtrace_s *trace, void *arg)
           break;
         }
     }
+
   return OK;
 }
 #endif
@@ -385,13 +386,14 @@ int main(int argc, FAR char *argv[])
   int config = CONFIG_SYSTEM_COMPOSITE_DEFCONFIG;
   int ret;
 
-  /* If this program is implemented as the NSH 'conn' command, then we need to
-   * do a little error checking to assure that we are not being called re-entrantly.
+  /* If this program is implemented as the NSH 'conn' command, then we need
+   * to do a little error checking to assure that we are not being called
+   * re-entrantly.
    */
 
-   /* Check if there is a non-NULL USB mass storage device handle (meaning that the
-    * USB mass storage device is already configured).
-    */
+  /* Check if there is a non-NULL USB mass storage device handle (meaning
+   * that the composite device is already configured).
+   */
 
   if (g_composite.cmphandle)
     {
@@ -433,7 +435,8 @@ int main(int argc, FAR char *argv[])
   ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
   if (ret < 0)
     {
-      printf("conn_main: boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", -ret);
+      printf("conn_main: boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n",
+             -ret);
       return 1;
     }
 
@@ -450,7 +453,8 @@ int main(int argc, FAR char *argv[])
   ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
   if (ret < 0)
     {
-      printf("conn_main: boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", -ret);
+      printf("conn_main: boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n",
+             -ret);
       return 1;
     }
 
@@ -461,7 +465,7 @@ int main(int argc, FAR char *argv[])
 
   /* Now looping */
 
-  for (;;)
+  for (; ; )
     {
       /* Sleep for a bit */
 
@@ -481,11 +485,11 @@ int main(int argc, FAR char *argv[])
     }
 #endif
 
-   /* Dump debug memory usage */
+  /* Dump debug memory usage */
 
-   printf("conn_main: Exiting\n");
-   final_memory_usage("Final memory usage");
-   return 0;
+  printf("conn_main: Exiting\n");
+  final_memory_usage("Final memory usage");
+  return 0;
 }
 
 /****************************************************************************
@@ -526,7 +530,7 @@ int disconn_main(int argc, char *argv[])
       return EXIT_FAILURE;
     }
 
-  /* Then disconnect the device and uninitialize the USB mass storage driver */
+  /* Then disconnect the device and uninitialize the composite driver */
 
   ctrl.usbdev   = BOARDIOC_USBDEV_COMPOSITE;
   ctrl.action   = BOARDIOC_USBDEV_DISCONNECT;

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * system/usbmsc/usbmsc_main.c
  *
- *   Copyright (C) 2008-2012, 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -149,11 +134,7 @@ static void check_test_memory_usage(FAR const char *msg)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmcurrent = mallinfo();
-#else
-  mallinfo(&g_usbmsc.mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -162,11 +143,7 @@ static void check_test_memory_usage(FAR const char *msg)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmprevious = g_usbmsc.mmcurrent;
-#else
-  memcpy(&g_usbmsc.mmprevious, &g_usbmsc.mmcurrent, sizeof(struct mallinfo));
-#endif
 }
 #else
 #  define check_test_memory_usage(msg)
@@ -181,11 +158,7 @@ static void final_memory_usage(FAR const char *msg)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmcurrent = mallinfo();
-#else
-  mallinfo(&g_usbmsc.mmcurrent);
-#endif
 
   /* Show the change from the previous time */
 
@@ -455,13 +428,8 @@ int main(int argc, FAR char *argv[])
     }
 
 #ifdef CONFIG_SYSTEM_USBMSC_DEBUGMM
-#  ifdef CONFIG_CAN_PASS_STRUCTS
   g_usbmsc.mmstart    = mallinfo();
   g_usbmsc.mmprevious = g_usbmsc.mmstart;
-#  else
-  mallinfo(&g_usbmsc.mmstart);
-  memcpy(&g_usbmsc.mmprevious, &g_usbmsc.mmstart, sizeof(struct mallinfo));
-#  endif
 #endif
 
   /* Initialize USB trace output IDs */

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -477,11 +477,15 @@ int main(int argc, FAR char *argv[])
   printf("mcsonn_main: handle=%p\n", handle);
   check_test_memory_usage("After usbmsc_configure()");
 
-  printf("mcsonn_main: Bind LUN=0 to %s\n", CONFIG_SYSTEM_USBMSC_DEVPATH1);
+  printf("mcsonn_main: Bind LUN=0 to %s\n",
+         CONFIG_SYSTEM_USBMSC_DEVPATH1);
+
 #ifdef CONFIG_SYSTEM_USBMSC_WRITEPROTECT1
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH1, 0, 0, 0, true);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH1, 0, 0, 0,
+                       true);
 #else
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH1, 0, 0, 0, false);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH1, 0, 0, 0,
+                       false);
 #endif
   if (ret < 0)
     {
@@ -495,11 +499,15 @@ int main(int argc, FAR char *argv[])
 
 #if CONFIG_SYSTEM_USBMSC_NLUNS > 1
 
-  printf("mcsonn_main: Bind LUN=1 to %s\n", CONFIG_SYSTEM_USBMSC_DEVPATH2);
+  printf("mcsonn_main: Bind LUN=1 to %s\n",
+         CONFIG_SYSTEM_USBMSC_DEVPATH2);
+
 #ifdef CONFIG_SYSTEM_USBMSC_WRITEPROTECT2
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH2, 1, 0, 0, true);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH2, 1, 0, 0,
+                       true);
 #else
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH2, 1, 0, 0, false);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH2, 1, 0, 0,
+                       false);
 #endif
   if (ret < 0)
     {
@@ -513,11 +521,15 @@ int main(int argc, FAR char *argv[])
 
 #if CONFIG_SYSTEM_USBMSC_NLUNS > 2
 
-  printf("mcsonn_main: Bind LUN=2 to %s\n", CONFIG_SYSTEM_USBMSC_DEVPATH3);
+  printf("mcsonn_main: Bind LUN=2 to %s\n",
+         CONFIG_SYSTEM_USBMSC_DEVPATH3);
+
 #ifdef CONFIG_SYSTEM_USBMSC_WRITEPROTECT3
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH3, 2, 0, 0, true);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH3, 2, 0, 0,
+                       true);
 #else
-  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH3, 2, 0, 0, false);
+  ret = usbmsc_bindlun(handle, CONFIG_SYSTEM_USBMSC_DEVPATH3, 2, 0, 0,
+                       false);
 #endif
   if (ret < 0)
     {
@@ -597,7 +609,9 @@ int msdis_main(int argc, char *argv[])
 
   check_test_memory_usage("Since MS connection");
 
-  /* Then disconnect the device and uninitialize the USB mass storage driver */
+  /* Then disconnect the device and uninitialize the USB mass storage
+   * driver.
+   */
 
   usbmsc_disconnect(g_usbmsc.mshandle);
   g_usbmsc.mshandle = NULL;

--- a/system/zmodem/host/nuttx/compiler.h
+++ b/system/zmodem/host/nuttx/compiler.h
@@ -94,8 +94,8 @@
 # define naked_function __attribute__ ((naked,no_instrument_function))
 
 /* The inline_function attribute informs GCC that the function should always
- * be inlined, regardless of the level of optimization.  The noinline_function
- * indicates that the function should never be inlined.
+ * be inlined, regardless of the level of optimization.  The
+ * noinline_function indicates that the function should never be inlined.
  */
 
 # define inline_function __attribute__ ((always_inline,no_instrument_function))
@@ -242,13 +242,15 @@
 
 /* Pragmas
  *
- * Disable warnings for unused function arguments */
+ * Disable warnings for unused function arguments.
+ */
 
 # pragma disable_warning 85
 
 /* Attributes
  *
- * SDCC does not support weak symbols */
+ * SDCC does not support weak symbols.
+ */
 
 # undef  CONFIG_HAVE_WEAKFUNCTIONS
 # define weak_alias(name, aliasname)
@@ -369,7 +371,9 @@
 # define weak_const_function
 # define restrict
 
-/* The Zilog compiler does not support the noreturn, packed, naked attributes */
+/* The Zilog compiler does not support the noreturn, packed, naked
+ * attributes.
+ */
 
 # define noreturn_function
 # define begin_packed_struct
@@ -394,8 +398,8 @@
  * Z8Encore!:  Far is 16-bits; near is 8-bits of address.
  *             The supported model is (1) all code on ROM, and (2) all data
  *             and stacks in internal (far) RAM.
- * Z8Acclaim:  In Z80 mode, all pointers are 16-bits.  In ADL mode, all pointers
- *             are 24 bits.
+ * Z8Acclaim:  In Z80 mode, all pointers are 16-bits.  In ADL mode, all
+ *             pointers are 24 bits.
  */
 
 #  if defined(__ZNEO__)
@@ -433,10 +437,10 @@
 # undef  CONFIG_HAVE_INLINE
 # define inline
 
-/* Older Zilog compilers support both types double and long long, but the size
- * is 32-bits (same as long and single precision) so it is safer to say that
- * they are not supported.  Later versions are more ANSII compliant and
- * simply do not support long long or double.
+/* Older Zilog compilers support both types double and long long, but the
+ * size is 32-bits (same as long and single precision) so it is safer to
+ * say that they are not supported.  Later versions are more ANSII compliant
+ * and simply do not support long long or double.
  */
 
 # undef  CONFIG_HAVE_LONG_LONG
@@ -444,12 +448,12 @@
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
 
-/* ICCARM-specific definitions ***********************************************/
+/* ICCARM-specific definitions **********************************************/
 
 #elif defined(__ICCARM__)
 
 # define CONFIG_CPP_HAVE_VARARGS 1 /* Supports variable argument macros */
-# define CONFIG_HAVE_FILENAME 1 /* Has __FILE__ */
+# define CONFIG_HAVE_FILENAME 1    /* Has __FILE__ */
 # define CONFIG_HAVE_FLOAT 1
 
 /* Indicate that a local variable is not used */

--- a/system/zmodem/host/nuttx/compiler.h
+++ b/system/zmodem/host/nuttx/compiler.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * include/nuttx/compiler.h
  *
- *   Copyright (C) 2013, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -241,10 +226,6 @@
 # define CONFIG_HAVE_DOUBLE 1
 # define CONFIG_HAVE_LONG_DOUBLE 1
 
-/* Structures and unions can be assigned and passed as values */
-
-# define CONFIG_CAN_PASS_STRUCTS 1
-
 /* SDCC-specific definitions ************************************************/
 
 #elif defined(SDCC)
@@ -351,12 +332,6 @@
 # define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
-
-/* Structures and unions cannot be passed as values or used
- * in assignments.
- */
-
-# undef  CONFIG_CAN_PASS_STRUCTS
 
 /* Zilog-specific definitions ***********************************************/
 
@@ -469,10 +444,6 @@
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
 
-/* Structures and unions can be assigned and passed as values */
-
-# define CONFIG_CAN_PASS_STRUCTS 1
-
 /* ICCARM-specific definitions ***********************************************/
 
 #elif defined(__ICCARM__)
@@ -550,7 +521,6 @@
 # define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
-# undef  CONFIG_CAN_PASS_STRUCTS
 
 #endif
 

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -42,6 +42,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_TESTING_FSTEST_MAXNAME
@@ -93,6 +94,7 @@ struct fstest_filedesc_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* Pre-allocated simulated flash */
 
 static uint8_t g_fileimage[CONFIG_TESTING_FSTEST_MAXFILE];
@@ -201,7 +203,7 @@ static inline void fstest_randname(FAR struct fstest_filedesc_s *file)
   namelen  = (rand() % maxname) + 1;
   alloclen = namelen + dirlen;
 
-  file->name = (FAR char*)malloc(alloclen + 1);
+  file->name = (FAR char *)malloc(alloclen + 1);
   if (!file->name)
     {
       printf("ERROR: Failed to allocate name, length=%d\n", namelen);
@@ -408,7 +410,7 @@ static inline int fstest_wrfile(FAR struct fstest_filedesc_s *file)
         {
           int errcode = errno;
 
-          /* If the write failed because an interrupt occurred or because there
+          /* If the write failed because an interrupt occurred or because
            * there is no space on the device, then don't complain.
            */
 
@@ -494,14 +496,14 @@ static int fstest_fillfs(void)
             }
 
 #if CONFIG_TESTING_FSTEST_VERBOSE != 0
-         printf("  Created file %s\n", file->name);
+          printf("  Created file %s\n", file->name);
 #endif
-         g_nfiles++;
+          g_nfiles++;
 
-         if (g_media_full)
-           {
-             break;
-           }
+          if (g_media_full)
+            {
+              break;
+            }
         }
     }
 
@@ -595,11 +597,14 @@ static inline int fstest_rdfile(FAR struct fstest_filedesc_s *file)
       return ERROR;
     }
 
-  /* Read all of the data info the file image buffer using random read sizes */
+  /* Read all of the data info the file image buffer using random read
+   * sizes.
+   */
 
   for (ntotalread = 0; ntotalread < file->len; )
     {
-      nbytesread = fstest_rdblock(fd, file, ntotalread, file->len - ntotalread);
+      nbytesread = fstest_rdblock(fd, file, ntotalread,
+                                  file->len - ntotalread);
       if (nbytesread < 0)
         {
           close(fd);
@@ -799,7 +804,7 @@ static int fstest_delfiles(void)
               ret = unlink(file->name);
               if (ret < 0)
                 {
-                  printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+                  printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                   printf("  File name:  %s\n", file->name);
                   printf("  File size:  %d\n", file->len);
                   printf("  File index: %d\n", j);
@@ -851,7 +856,7 @@ static int fstest_delallfiles(void)
           ret = unlink(file->name);
           if (ret < 0)
             {
-               printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+               printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                printf("  File name:  %s\n", file->name);
                printf("  File size:  %d\n", file->len);
                printf("  File index: %d\n", i);

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * testing/fstest/fstest_main.c
  *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -150,11 +135,7 @@ static void fstest_loopmemusage(void)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous loop */
 
@@ -163,11 +144,7 @@ static void fstest_loopmemusage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 }
 
 /****************************************************************************
@@ -176,11 +153,8 @@ static void fstest_loopmemusage(void)
 
 static void fstest_endmemusage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
+
   printf("\nFinal memory usage:\n");
   fstest_showmemusage(&g_mmbefore, &g_mmafter);
 }
@@ -963,13 +937,8 @@ int main(int argc, FAR char *argv[])
 
   /* Set up memory monitoring */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
-#else
-  mallinfo(&g_mmbefore);
-  memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
-#endif
 
   /* Loop a few times ... file the file system with some random, files,
    * delete some files randomly, fill the file system with more random file,

--- a/testing/nxffs/nxffs_main.c
+++ b/testing/nxffs/nxffs_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * testing/nxffs/nxffs_main.c
  *
- *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -181,11 +166,7 @@ static void nxffs_loopmemusage(void)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous loop */
 
@@ -194,11 +175,7 @@ static void nxffs_loopmemusage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 }
 
 /****************************************************************************
@@ -207,13 +184,10 @@ static void nxffs_loopmemusage(void)
 
 static void nxffs_endmemusage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
-      g_mmafter = mallinfo();
-#else
-      mallinfo(&g_mmafter);
-#endif
-      printf("\nFinal memory usage:\n");
-      nxffs_showmemusage(&g_mmbefore, &g_mmafter);
+  g_mmafter = mallinfo();
+
+  printf("\nFinal memory usage:\n");
+  nxffs_showmemusage(&g_mmbefore, &g_mmafter);
 }
 
 /****************************************************************************
@@ -829,13 +803,8 @@ int main(int argc, FAR char *argv[])
 
   /* Set up memory monitoring */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
-  g_mmbefore = mallinfo();
+  g_mmbefore   = mallinfo();
   g_mmprevious = g_mmbefore;
-#else
-  mallinfo(&g_mmbefore);
-  memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
-#endif
 
   /* Loop a few times ... file the file system with some random, files,
    * delete some files randomly, fill the file system with more random file,

--- a/testing/nxffs/nxffs_main.c
+++ b/testing/nxffs/nxffs_main.c
@@ -43,7 +43,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* The default is to use the RAM MTD device at drivers/mtd/rammtd.c.  But
  * an architecture-specific MTD driver can be used instead by defining
  * CONFIG_TESTING_NXFFS_ARCHINIT.  In this case, the initialization logic
@@ -52,7 +54,9 @@
 
 #ifndef CONFIG_TESTING_NXFFS_ARCHINIT
 
-/* This must exactly match the default configuration in drivers/mtd/rammtd.c */
+/* This must exactly match the default configuration in
+ * drivers/mtd/rammtd.c
+ */
 
 #  ifndef CONFIG_RAMMTD_ERASESIZE
 #    define CONFIG_RAMMTD_ERASESIZE 4096
@@ -114,6 +118,7 @@ struct nxffs_filedesc_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* Pre-allocated simulated flash */
 
 #ifndef CONFIG_TESTING_NXFFS_ARCHINIT
@@ -232,7 +237,7 @@ static inline void nxffs_randname(FAR struct nxffs_filedesc_s *file)
   namelen  = (rand() % maxname) + 1;
   alloclen = namelen + dirlen;
 
-  file->name = (FAR char*)malloc(alloclen + 1);
+  file->name = (FAR char *)malloc(alloclen + 1);
   if (!file->name)
     {
       printf("ERROR: Failed to allocate name, length=%d\n", namelen);
@@ -262,6 +267,7 @@ static inline void nxffs_randfile(FAR struct nxffs_filedesc_s *file)
     {
       g_fileimage[i] = nxffs_randchar();
     }
+
   file->crc = crc32(g_fileimage, file->len);
 }
 
@@ -275,6 +281,7 @@ static void nxffs_freefile(FAR struct nxffs_filedesc_s *file)
     {
       free(file->name);
     }
+
   memset(file, 0, sizeof(struct nxffs_filedesc_s));
 }
 
@@ -305,6 +312,7 @@ static inline int nxffs_wrfile(FAR struct nxffs_filedesc_s *file)
           printf("  File name: %s\n", file->name);
           printf("  File size: %lu\n", (unsigned long)file->len);
         }
+
       nxffs_freefile(file);
       return ERROR;
     }
@@ -458,6 +466,7 @@ static ssize_t nxffs_rdblock(int fd, FAR struct nxffs_filedesc_s *file,
       printf("  Read size:    %ld\n", (long)len);
       printf("  Bytes read:   %ld\n", (long)nbytesread);
     }
+
   return nbytesread;
 }
 
@@ -483,6 +492,7 @@ static inline int nxffs_rdfile(FAR struct nxffs_filedesc_s *file)
           printf("  File name: %s\n", file->name);
           printf("  File size: %lu\n", (unsigned long)file->len);
         }
+
       return ERROR;
     }
 
@@ -490,7 +500,8 @@ static inline int nxffs_rdfile(FAR struct nxffs_filedesc_s *file)
 
   for (ntotalread = 0; ntotalread < file->len; )
     {
-      nbytesread = nxffs_rdblock(fd, file, ntotalread, file->len - ntotalread);
+      nbytesread = nxffs_rdblock(fd, file, ntotalread,
+                                 file->len - ntotalread);
       if (nbytesread < 0)
         {
           close(fd);
@@ -645,7 +656,7 @@ static int nxffs_delfiles(void)
               ret = unlink(file->name);
               if (ret < 0)
                 {
-                  printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+                  printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                   printf("  File name:  %s\n", file->name);
                   printf("  File size:  %lu\n", (unsigned long)file->len);
                   printf("  File index: %d\n", j);
@@ -684,7 +695,7 @@ static int nxffs_delallfiles(void)
           ret = unlink(file->name);
           if (ret < 0)
             {
-               printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+               printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                printf("  File name:  %s\n", file->name);
                printf("  File size:  %lu\n", (unsigned long)file->len);
                printf("  File index: %d\n", i);
@@ -741,6 +752,7 @@ static int nxffs_directory(void)
                  entryp->d_type == DTYPE_FILE ? "File " : "Error",
                  entryp->d_name);
         }
+
       number++;
     }
   while (entryp != NULL);
@@ -818,8 +830,8 @@ int main(int argc, FAR char *argv[])
 #endif
     {
       /* Write a files to the NXFFS file system until either (1) all of the
-       * open file structures are utilized or until (2) NXFFS reports an error
-       * (hopefully that the file system is full)
+       * open file structures are utilized or until (2) NXFFS reports an
+       * error (hopefully that the file system is full)
        */
 
       printf("\n=== FILLING %u =============================\n", i);
@@ -867,6 +879,7 @@ int main(int argc, FAR char *argv[])
           printf("  Number of files: %d\n", g_nfiles);
           printf("  Number deleted:  %d\n", g_ndeleted);
         }
+
       nxffs_dump(mtd, CONFIG_TESTING_NXFFS_VERBOSE);
 
       /* Directory listing */

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * apps/testing/ostest/ostest_main.c
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2014-2015, 2018 Gregory Nutt. All
- *     rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -139,11 +123,7 @@ static void check_test_memory_usage(void)
 
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous time */
 
@@ -152,11 +132,7 @@ static void check_test_memory_usage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 
   /* If so enabled, show the use of priority inheritance resources */
 
@@ -224,13 +200,8 @@ static int user_main(int argc, char *argv[])
 
   usleep(HALF_SECOND_USEC);
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
-#else
-  mallinfo(&g_mmbefore);
-  memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
-#endif
 
   printf("\nuser_main: Begin argument test\n");
   printf("user_main: Started with argc=%d\n", argc);
@@ -553,11 +524,7 @@ static int user_main(int argc, char *argv[])
 
       usleep(HALF_SECOND_USEC);
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
       g_mmafter = mallinfo();
-#else
-      mallinfo(&g_mmafter);
-#endif
 
       printf("\nFinal memory usage:\n");
       show_memory_usage(&g_mmbefore, &g_mmafter);

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -68,9 +68,12 @@ static const char write_data2[] = "stdio_test: write fd=2\n";
  * pointer types.
  */
 
-static const char *g_argv[NARGS+1];
+static const char *g_argv[NARGS + 1];
 #else
-static const char *g_argv[NARGS+1] = { arg1, arg2, arg3, arg4, NULL };
+static const char *g_argv[NARGS + 1] =
+{
+  arg1, arg2, arg3, arg4, NULL
+};
 #endif
 
 static struct mallinfo g_mmbefore;
@@ -144,7 +147,8 @@ static void check_test_memory_usage(void)
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_ENVIRON
-static void show_variable(const char *var_name, const char *exptd_value, bool var_valid)
+static void show_variable(const char *var_name, const char *exptd_value,
+                          bool var_valid)
 {
   char *actual_value = getenv(var_name);
   if (actual_value)
@@ -153,24 +157,33 @@ static void show_variable(const char *var_name, const char *exptd_value, bool va
         {
           if (strcmp(actual_value, exptd_value) == 0)
             {
-              printf("show_variable: Variable=%s has value=%s\n", var_name, exptd_value);
+              printf("show_variable: Variable=%s has value=%s\n",
+                     var_name, exptd_value);
             }
           else
             {
-              printf("show_variable: ERROR Variable=%s has the wrong value\n", var_name);
-              printf("show_variable:       found=%s expected=%s\n", actual_value, exptd_value);
+              printf("show_variable: ERROR Variable=%s has the wrong "
+                     "value\n",
+                     var_name);
+              printf("show_variable:       found=%s expected=%s\n",
+                     actual_value, exptd_value);
             }
         }
       else
         {
-          printf("show_variable: ERROR Variable=%s has a value when it should not\n", var_name);
-          printf("show_variable:       value=%s\n", actual_value);
+          printf("show_variable: ERROR Variable=%s has a value when it "
+                 "should not\n",
+                 var_name);
+          printf("show_variable:       value=%s\n",
+                 actual_value);
         }
     }
   else if (var_valid)
     {
-      printf("show_variable: ERROR Variable=%s has no value\n", var_name);
-      printf("show_variable:       Should have had value=%s\n", exptd_value);
+      printf("show_variable: ERROR Variable=%s has no value\n",
+             var_name);
+      printf("show_variable:       Should have had value=%s\n",
+             exptd_value);
     }
   else
     {
@@ -178,7 +191,8 @@ static void show_variable(const char *var_name, const char *exptd_value, bool va
     }
 }
 
-static void show_environment(bool var1_valid, bool var2_valid, bool var3_valid)
+static void show_environment(bool var1_valid, bool var2_valid,
+                             bool var3_valid)
 {
   show_variable(g_var1_name, g_var1_value, var1_valid);
   show_variable(g_var2_name, g_var2_value, var2_valid);
@@ -211,7 +225,7 @@ static int user_main(int argc, char *argv[])
   if (argc != NARGS + 1)
     {
       printf("user_main: Error expected argc=%d got argc=%d\n",
-             NARGS+1, argc);
+             NARGS + 1, argc);
     }
 
   for (i = 0; i <= NARGS; i++)
@@ -221,10 +235,11 @@ static int user_main(int argc, char *argv[])
 
   for (i = 1; i <= NARGS; i++)
     {
-      if (strcmp(argv[i], g_argv[i-1]) != 0)
+      if (strcmp(argv[i], g_argv[i - 1]) != 0)
         {
-          printf("user_main: ERROR argv[%d]:  Expected \"%s\" found \"%s\"\n",
-                 i, g_argv[i-1], argv[i]);
+          printf("user_main: ERROR argv[%d]:  "
+                 "Expected \"%s\" found \"%s\"\n",
+                 i, g_argv[i - 1], argv[i]);
         }
     }
 
@@ -241,18 +256,18 @@ static int user_main(int argc, char *argv[])
    */
 
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)
-  {
-    struct sigaction sa;
-    int ret;
+    {
+      struct sigaction sa;
+      int ret;
 
-    sa.sa_handler = SIG_IGN;
-    sa.sa_flags = SA_NOCLDWAIT;
-    ret = sigaction(SIGCHLD, &sa, NULL);
-    if (ret < 0)
-      {
-        printf("user_main: ERROR: sigaction failed: %d\n", errno);
-      }
-  }
+      sa.sa_handler = SIG_IGN;
+      sa.sa_flags = SA_NOCLDWAIT;
+      ret = sigaction(SIGCHLD, &sa, NULL);
+      if (ret < 0)
+        {
+          printf("user_main: ERROR: sigaction failed: %d\n", errno);
+        }
+    }
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON
@@ -281,7 +296,7 @@ static int user_main(int argc, char *argv[])
 #if CONFIG_TESTING_OSTEST_LOOPS > 1
   for (i = 0; i < CONFIG_TESTING_OSTEST_LOOPS; i++)
 #elif CONFIG_TESTING_OSTEST_LOOPS == 0
-  for (;;)
+  for (; ; )
 #endif
     {
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
@@ -390,11 +405,12 @@ static int user_main(int argc, char *argv[])
 #endif
 
 #ifndef CONFIG_DISABLE_PTHREAD
-    /* Verify pthreads and condition variables */
+      /* Verify pthreads and condition variables */
 
       printf("\nuser_main: condition variable test\n");
 #ifdef CONFIG_PRIORITY_INHERITANCE
-      printf("\n           Skipping, Test logic incompatible with priority inheritance\n");
+      printf("\n           Skipping, "
+             "Test logic incompatible with priority inheritance\n");
 #else
       cond_test();
       check_test_memory_usage();
@@ -622,7 +638,8 @@ int main(int argc, FAR char **argv)
 
       if (waitpid(result, &ostest_result, 0) != result)
         {
-          printf("ostest_main: ERROR Failed to wait for user_main to terminate\n");
+          printf("ostest_main: ERROR Failed to wait for user_main to "
+                 "terminate\n");
           ostest_result = ERROR;
         }
 #endif
@@ -632,7 +649,7 @@ int main(int argc, FAR char **argv)
 
 #ifdef CONFIG_TESTING_OSTEST_POWEROFF
   /* Power down, providing the test result.  This is really only an
-   *interesting case when used with the NuttX simulator.  In that case,
+   * interesting case when used with the NuttX simulator.  In that case,
    * test management logic can received the result of the test.
    */
 

--- a/testing/ostest/sigev_thread.c
+++ b/testing/ostest/sigev_thread.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * testing/ostest/sigev_thread.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -68,17 +53,9 @@ static int g_value_received;
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
 static void sigev_thread_callback(union sigval value)
-#else
-static void sigev_thread_callback(FAR void *sival_ptr)
-#endif
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   int sival_int = value.sival_int;
-#else
-  int sival_int = (int)((intptr_t)sival_ptr);
-#endif
 
   printf("sigev_thread_callback: Received value %d\n" , sival_int);
 

--- a/testing/ostest/sigev_thread.c
+++ b/testing/ostest/sigev_thread.c
@@ -74,13 +74,13 @@ void sigev_thread_test(void)
   timer_t timerid;
   int status;
 
-  printf("sigev_thread_test: Initializing semaphore to 0\n" );
+  printf("sigev_thread_test: Initializing semaphore to 0\n");
   sem_init(&g_sigev_thread_sem, 0, 0);
   g_value_received = -1;
 
   /* Create the POSIX timer */
 
-  printf("sigev_thread_test: Creating timer\n" );
+  printf("sigev_thread_test: Creating timer\n");
 
   notify.sigev_notify            = SIGEV_THREAD;
   notify.sigev_signo             = MY_TIMER_SIGNAL;
@@ -97,7 +97,7 @@ void sigev_thread_test(void)
 
   /* Start the POSIX timer */
 
-  printf("sigev_thread_test: Starting timer\n" );
+  printf("sigev_thread_test: Starting timer\n");
 
   timer.it_value.tv_sec     = 2;
   timer.it_value.tv_nsec    = 0;
@@ -113,7 +113,7 @@ void sigev_thread_test(void)
 
   /* Take the semaphore */
 
-  printf("sigev_thread_test: Waiting on semaphore\n" );
+  printf("sigev_thread_test: Waiting on semaphore\n");
 
   do
     {
@@ -123,7 +123,8 @@ void sigev_thread_test(void)
           int error = errno;
           if (error == EINTR)
             {
-              printf("sigev_thread_test: sem_wait() interrupted by signal\n" );
+              printf("sigev_thread_test: sem_wait() interrupted by "
+                     "signal\n");
             }
           else
             {
@@ -135,7 +136,7 @@ void sigev_thread_test(void)
     }
   while (status < 0);
 
-  printf("sigev_thread_test: Awakened with no error!\n" );
+  printf("sigev_thread_test: Awakened with no error!\n");
 
   /* Check sigval */
 
@@ -151,12 +152,12 @@ errorout:
 
   /* Then delete the timer */
 
-  printf("sigev_thread_test: Deleting timer\n" );
+  printf("sigev_thread_test: Deleting timer\n");
   status = timer_delete(timerid);
   if (status != OK)
     {
       printf("sigev_thread_test: timer_create failed, errno=%d\n", errno);
     }
 
-  printf("sigev_thread_test: Done\n" );
+  printf("sigev_thread_test: Done\n");
 }

--- a/testing/ostest/sighand.c
+++ b/testing/ostest/sighand.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * apps/testing/ostest/sighand.c
  *
- *   Copyright (C) 2007, 2008, 2011, 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -300,11 +285,7 @@ void sighand_test(void)
          waiterpid, WAKEUP_SIGNAL, SIGVALUE_INT);
 
   sigvalue.sival_int = SIGVALUE_INT;
-#ifdef CONFIG_CAN_PASS_STRUCTS
   status = sigqueue(waiterpid, WAKEUP_SIGNAL, sigvalue);
-#else
-  status = sigqueue(waiterpid, WAKEUP_SIGNAL, sigvalue.sival_ptr);
-#endif
   if (status != OK)
     {
       printf("sighand_test: ERROR sigqueue failed\n" );

--- a/testing/ostest/sighand.c
+++ b/testing/ostest/sighand.c
@@ -18,6 +18,10 @@
  *
  ****************************************************************************/
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -143,7 +147,7 @@ static int waiter_main(int argc, char *argv[])
   struct sigaction oact;
   int status;
 
-  printf("waiter_main: Waiter started\n" );
+  printf("waiter_main: Waiter started\n");
 
   printf("waiter_main: Unmasking signal %d\n" , WAKEUP_SIGNAL);
   sigemptyset(&set);
@@ -155,7 +159,7 @@ static int waiter_main(int argc, char *argv[])
               status);
     }
 
-  printf("waiter_main: Registering signal handler\n" );
+  printf("waiter_main: Registering signal handler\n");
   act.sa_sigaction = wakeup_action;
   act.sa_flags  = SA_SIGINFO;
 
@@ -175,7 +179,7 @@ static int waiter_main(int argc, char *argv[])
 
   /* Take the semaphore */
 
-  printf("waiter_main: Waiting on semaphore\n" );
+  printf("waiter_main: Waiting on semaphore\n");
   FFLUSH();
 
   status = sem_wait(&sem);
@@ -184,7 +188,8 @@ static int waiter_main(int argc, char *argv[])
       int error = errno;
       if (error == EINTR)
         {
-          printf("waiter_main: sem_wait() successfully interrupted by signal\n" );
+          printf("waiter_main: sem_wait() successfully interrupted by "
+                 "signal\n");
         }
       else
         {
@@ -193,7 +198,7 @@ static int waiter_main(int argc, char *argv[])
     }
   else
     {
-      printf("waiter_main: ERROR awakened with no error!\n" );
+      printf("waiter_main: ERROR awakened with no error!\n");
     }
 
   /* Detach the signal handler */
@@ -201,7 +206,7 @@ static int waiter_main(int argc, char *argv[])
   act.sa_handler = SIG_DFL;
   sigaction(WAKEUP_SIGNAL, &act, &oact);
 
-  printf("waiter_main: done\n" );
+  printf("waiter_main: done\n");
   FFLUSH();
 
   threadexited = true;
@@ -224,7 +229,7 @@ void sighand_test(void)
   pid_t waiterpid;
   int status;
 
-  printf("sighand_test: Initializing semaphore to 0\n" );
+  printf("sighand_test: Initializing semaphore to 0\n");
   sem_init(&sem, 0, 0);
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
@@ -239,7 +244,7 @@ void sighand_test(void)
               status);
     }
 
-  printf("sighand_test: Registering SIGCHLD handler\n" );
+  printf("sighand_test: Registering SIGCHLD handler\n");
   act.sa_sigaction = death_of_child;
   act.sa_flags  = SA_SIGINFO;
 
@@ -255,11 +260,11 @@ void sighand_test(void)
 
   /* Start waiter thread  */
 
-  printf("sighand_test: Starting waiter task\n" );
+  printf("sighand_test: Starting waiter task\n");
   status = sched_getparam (0, &param);
   if (status != OK)
     {
-      printf("sighand_test: ERROR sched_getparam() failed\n" );
+      printf("sighand_test: ERROR sched_getparam() failed\n");
       param.sched_priority = PTHREAD_DEFAULT_PRIORITY;
     }
 
@@ -267,7 +272,7 @@ void sighand_test(void)
                            STACKSIZE, waiter_main, NULL);
   if (waiterpid == ERROR)
     {
-      printf("sighand_test: ERROR failed to start waiter_main\n" );
+      printf("sighand_test: ERROR failed to start waiter_main\n");
     }
   else
     {
@@ -288,7 +293,7 @@ void sighand_test(void)
   status = sigqueue(waiterpid, WAKEUP_SIGNAL, sigvalue);
   if (status != OK)
     {
-      printf("sighand_test: ERROR sigqueue failed\n" );
+      printf("sighand_test: ERROR sigqueue failed\n");
       task_delete(waiterpid);
     }
 
@@ -301,12 +306,12 @@ void sighand_test(void)
 
   if (!threadexited)
     {
-      printf("sighand_test: ERROR waiter task did not exit\n" );
+      printf("sighand_test: ERROR waiter task did not exit\n");
     }
 
   if (!sigreceived)
     {
-      printf("sighand_test: ERROR signal handler did not run\n" );
+      printf("sighand_test: ERROR signal handler did not run\n");
     }
 
   /* Detach the signal handler */
@@ -316,6 +321,6 @@ void sighand_test(void)
   sigaction(SIGCHLD, &act, &oact);
 #endif
 
-  printf("sighand_test: done\n" );
+  printf("sighand_test: done\n");
   FFLUSH();
 }

--- a/testing/smart/smart_main.c
+++ b/testing/smart/smart_main.c
@@ -46,7 +46,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* The default is to use the RAM MTD device at drivers/mtd/rammtd.c.  But
  * an architecture-specific MTD driver can be used instead by defining
  * CONFIG_TESTING_SMART_ARCHINIT.  In this case, the initialization logic
@@ -55,7 +57,9 @@
 
 #ifndef CONFIG_TESTING_SMART_ARCHINIT
 
-/* This must exactly match the default configuration in drivers/mtd/rammtd.c */
+/* This must exactly match the default configuration in
+ * drivers/mtd/rammtd.c
+ */
 
 #  ifndef CONFIG_RAMMTD_ERASESIZE
 #    define CONFIG_RAMMTD_ERASESIZE 4096
@@ -117,6 +121,7 @@ struct smart_filedesc_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* Pre-allocated simulated flash */
 
 #ifndef CONFIG_TESTING_SMART_ARCHINIT
@@ -235,7 +240,7 @@ static inline void smart_randname(FAR struct smart_filedesc_s *file)
   namelen  = (rand() % maxname) + 1;
   alloclen = namelen + dirlen;
 
-  file->name = (FAR char*)malloc(alloclen + 1);
+  file->name = (FAR char *)malloc(alloclen + 1);
   if (!file->name)
     {
       printf("ERROR: Failed to allocate name, length=%d\n", namelen);
@@ -498,7 +503,8 @@ static inline int smart_rdfile(FAR struct smart_filedesc_s *file)
 
   for (ntotalread = 0; ntotalread < file->len; )
     {
-      nbytesread = smart_rdblock(fd, file, ntotalread, file->len - ntotalread);
+      nbytesread = smart_rdblock(fd, file, ntotalread,
+                                 file->len - ntotalread);
       if (nbytesread < 0)
         {
           close(fd);
@@ -652,7 +658,7 @@ static int smart_delfiles(void)
               ret = unlink(file->name);
               if (ret < 0)
                 {
-                  printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+                  printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                   printf("  File name:  %s\n", file->name);
                   printf("  File size:  %d\n", file->len);
                   printf("  File index: %d\n", j);
@@ -691,7 +697,7 @@ static int smart_delallfiles(void)
           ret = unlink(file->name);
           if (ret < 0)
             {
-               printf("ERROR: Unlink %d failed: %d\n", i+1, errno);
+               printf("ERROR: Unlink %d failed: %d\n", i + 1, errno);
                printf("  File name:  %s\n", file->name);
                printf("  File size:  %d\n", file->len);
                printf("  File index: %d\n", i);
@@ -810,7 +816,8 @@ int main(int argc, FAR char *argv[])
 
   /* Mount the file system */
 
-  ret = mount("/dev/smart1", CONFIG_TESTING_SMART_MOUNTPT, "smartfs", 0, NULL);
+  ret = mount("/dev/smart1", CONFIG_TESTING_SMART_MOUNTPT, "smartfs",
+              0, NULL);
   if (ret < 0)
     {
       printf("ERROR: Failed to mount the SMART volume: %d\n", errno);
@@ -835,8 +842,8 @@ int main(int argc, FAR char *argv[])
 #endif
     {
       /* Write a files to the SMART file system until either (1) all of the
-       * open file structures are utilized or until (2) SMART reports an error
-       * (hopefully that the file system is full)
+       * open file structures are utilized or until (2) SMART reports an
+       * error (hopefully that the file system is full)
        */
 
       printf("\n=== FILLING %u =============================\n", i);

--- a/testing/smart/smart_main.c
+++ b/testing/smart/smart_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * testing/smart/smart_main.c
  *
- *   Copyright (C) 2011, 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -184,11 +169,7 @@ static void smart_loopmemusage(void)
 {
   /* Get the current memory usage */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
 
   /* Show the change from the previous loop */
 
@@ -197,11 +178,7 @@ static void smart_loopmemusage(void)
 
   /* Set up for the next test */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmprevious = g_mmafter;
-#else
-  memcpy(&g_mmprevious, &g_mmafter, sizeof(struct mallinfo));
-#endif
 }
 
 /****************************************************************************
@@ -210,11 +187,8 @@ static void smart_loopmemusage(void)
 
 static void smart_endmemusage(void)
 {
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmafter = mallinfo();
-#else
-  mallinfo(&g_mmafter);
-#endif
+
   printf("\nFinal memory usage:\n");
   smart_showmemusage(&g_mmbefore, &g_mmafter);
 }
@@ -846,13 +820,8 @@ int main(int argc, FAR char *argv[])
 
   /* Set up memory monitoring */
 
-#ifdef CONFIG_CAN_PASS_STRUCTS
   g_mmbefore = mallinfo();
   g_mmprevious = g_mmbefore;
-#else
-  mallinfo(&g_mmbefore);
-  memcpy(&g_mmprevious, &g_mmbefore, sizeof(struct mallinfo));
-#endif
 
   /* Loop a few times ... file the file system with some random, files,
    * delete some files randomly, fill the file system with more random file,


### PR DESCRIPTION
This is the companion to PR #766.  It removes the CONFIG_CAN_PASS_STRUCT option as recommended by Issue #620

NuttX PR #766 depends on PR being in place but not vice versa.  This PR should be merge-able without #766 and then PR #766 should also pass its checks.