### PR TITLE
apps: Fix the nightly build warning

### DIFF
--- a/include/graphics/twm4nx/cwindow.hxx
+++ b/include/graphics/twm4nx/cwindow.hxx
@@ -825,6 +825,11 @@ namespace Twm4Nx
           {
             m_iconWidget->getSize(size);
           }
+        else
+          {
+            size.w = 0;
+            size.h = 0;
+          }
       }
 
       /**
@@ -841,6 +846,11 @@ namespace Twm4Nx
         if (m_iconWidget != (FAR CIconWidget *)0)
           {
             m_iconWidget->getPos(pos);
+          }
+        else
+          {
+            pos.x = 0;
+            pos.y = 0;
           }
       }
 

--- a/interpreters/bas/bas.c
+++ b/interpreters/bas/bas.c
@@ -2422,7 +2422,7 @@ void bas_interpreter(void)
                       if (Program_goLine(&g_program, line->u.integer, &where) ==
                           (struct Pc *)0)
                         {
-                          FS_putChars(STDCHANNEL, (NOSUCHLINE));
+                          FS_putChars(STDCHANNEL, _("No such line\n"));
                         }
                       else
                         {

--- a/interpreters/bas/bas_fs.c
+++ b/interpreters/bas/bas_fs.c
@@ -103,14 +103,6 @@ static int g_used;
 static const int g_open_mode[4] = { 0, O_RDONLY, O_WRONLY, O_RDWR };
 static char g_errmsgbuf[80];
 
-#ifdef CONFIG_INTERPRETER_BAS_VT100
-static const uint8_t g_vt100_colormap[8] =
-{
-  VT100_BLACK, VT100_BLUE,   VT100_GREEN,  VT100_CYAN,
-  VT100_RED,  VT100_MAGENTA, VT100_YELLOW, VT100_WHITE
-};
-#endif
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/interpreters/bas/bas_fs.c
+++ b/interpreters/bas/bas_fs.c
@@ -14,8 +14,8 @@
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
  * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
@@ -100,8 +100,11 @@
 static struct FileStream **g_file;
 static int g_capacity;
 static int g_used;
-static const int g_open_mode[4] = { 0, O_RDONLY, O_WRONLY, O_RDWR };
 static char g_errmsgbuf[80];
+static const int g_open_mode[4] =
+{
+  0, O_RDONLY, O_WRONLY, O_RDWR
+};
 
 /****************************************************************************
  * Public Data
@@ -205,7 +208,8 @@ static int opened(int dev, int mode)
 
     case 4:
       {
-        fd = (g_file[dev]->randomfd != -1 ? g_file[dev]->randomfd : g_file[dev]->binaryfd);
+        fd = (g_file[dev]->randomfd != -1 ?
+              g_file[dev]->randomfd : g_file[dev]->binaryfd);
         if (fd == -1)
           {
             snprintf(g_errmsgbuf, sizeof(g_errmsgbuf),
@@ -270,6 +274,7 @@ static int edit(int chn, int nl)
           FS_putChar(chn, *buf);
         }
     }
+
   do
     {
       FS_flush(chn);
@@ -301,7 +306,7 @@ static int edit(int chn, int nl)
 #ifdef CONFIG_INTERPRETER_BAS_VT100
               /* Could use vt100_clrtoeol */
 #endif
-              /* Is the previous character in the buffer 2 character escape sequence? */
+              /* Is the previous char in buffer 2 char escape sequence? */
 
               if (f->inBuf[f->inCapacity - 1] >= '\0' &&
                   f->inBuf[f->inCapacity - 1] < ' ')
@@ -311,7 +316,7 @@ static int edit(int chn, int nl)
                   FS_putChars(chn, "\b\b  \b\b");
                 }
               else
-                 {
+                {
                   /* Yes.. erase one characters */
 
                   FS_putChars(chn, "\b \b");
@@ -335,7 +340,7 @@ static int edit(int chn, int nl)
 #elif defined(CONFIG_EOL_IS_LF)
               if (ch != '\n')
 #elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-              if (ch != '\n' && ch != '\r' )
+              if (ch != '\n' && ch != '\r')
 #endif
                 {
                   /* No.. escape control characters other than newline and
@@ -540,7 +545,8 @@ int FS_openinChn(int chn, const char *name, int mode)
 
   /* Serial devices on Linux should be opened non-blocking, otherwise the
    * open() may block already.  Named pipes can not be opened non-blocking in
-   * write-only mode, so first try non-blocking, then blocking. */
+   * write-only mode, so first try non-blocking, then blocking.
+   */
 
   if ((fd = open(name, fl | O_NONBLOCK)) == -1)
     {
@@ -631,15 +637,16 @@ int FS_openoutChn(int chn, const char *name, int mode, int append)
 
   fl = g_open_mode[mode] | (append ? O_APPEND : 0);
 
-  /* Serial devices on Linux should be opened non-blocking, otherwise the */
-  /* open() may block already.  Named pipes can not be opened non-blocking */
-  /* in write-only mode, so first try non-blocking, then blocking.  */
+  /* Serial devices on Linux should be opened non-blocking, otherwise the
+   * open() may block already.  Named pipes can not be opened non-blocking
+   * in write-only mode, so first try non-blocking, then blocking.
+   */
 
   fd = open(name, fl | O_CREAT | (append ? 0 : O_TRUNC) | O_NONBLOCK, 0666);
   if (fd == -1)
     {
-      if (errno != ENXIO ||
-          (fd = open(name, fl | O_CREAT | (append ? 0 : O_TRUNC), 0666)) == -1)
+      if (errno != ENXIO || -1 ==
+          (fd = open(name, fl | O_CREAT | (append ? 0 : O_TRUNC), 0666)))
         {
           FS_errmsg = strerror(errno);
           return -1;
@@ -803,7 +810,8 @@ int FS_close(int dev)
   if (g_file[dev]->outfd >= 0)
     {
       if (g_file[dev]->tty &&
-          (g_file[dev]->outforeground != -1 || g_file[dev]->outbackground != -1))
+          (g_file[dev]->outforeground != -1 ||
+           g_file[dev]->outbackground != -1))
         {
           resetcolour(dev);
         }
@@ -928,7 +936,8 @@ int FS_truncate(int chn)
         }
     }
 
-  if ((o = lseek(fd, 0, SEEK_CUR)) == (off_t) - 1 || ftruncate(fd, o + 1) == -1)
+  if ((o = lseek(fd, 0, SEEK_CUR)) == (off_t) - 1 ||
+      ftruncate(fd, o + 1) == -1)
     {
       FS_errmsg = strerror(errno);
       return -1;
@@ -1143,8 +1152,8 @@ int FS_getbinaryString(int chn, struct String *s)
       return -1;
     }
 
-  if (s->length &&
-      (len = read(g_file[chn]->binaryfd, s->character, s->length)) != s->length)
+  if (s->length && s->length !=
+      (len = read(g_file[chn]->binaryfd, s->character, s->length)))
     {
       if (len == -1)
         {
@@ -1231,9 +1240,8 @@ int FS_nextcol(int dev)
     }
 
   f = g_file[dev];
-  if (f->outPos % f->outColWidth
-      && f->outLineWidth
-      && ((f->outPos / f->outColWidth + 2) * f->outColWidth) > f->outLineWidth)
+  if (f->outPos % f->outColWidth && f->outLineWidth &&
+      ((f->outPos / f->outColWidth + 2) * f->outColWidth) > f->outLineWidth)
     {
       return FS_putChar(dev, '\n');
     }
@@ -1497,7 +1505,7 @@ int FS_inkeyChar(int dev, int ms)
   FD_SET(f->infd, &just_infd);
   timeout.tv_sec = ms / 1000;
   timeout.tv_usec = (ms % 1000) * 1000;
-  switch (select(f->infd + 1, &just_infd, (fd_set *) 0, (fd_set *) 0, &timeout))
+  switch (select(f->infd + 1, &just_infd, NULL, NULL, &timeout))
     {
     case 1:
       {
@@ -1635,8 +1643,9 @@ long int FS_lof(int chn)
 
   assert(fd != -1);
 
-  /* Get the size of the file */
-  /* Save the current file position */
+  /* Get the size of the file
+   * Save the current file position
+   */
 
   curpos = lseek(fd, 0, SEEK_CUR);
   if (curpos == (off_t)-1)
@@ -1679,7 +1688,8 @@ long int FS_recLength(int chn)
 void FS_field(int chn, struct String *s, long int position, long int length)
 {
   assert(g_file[chn]);
-  String_joinField(s, &g_file[chn]->field, g_file[chn]->recBuf + position, length);
+  String_joinField(s, &g_file[chn]->field,
+                   g_file[chn]->recBuf + position, length);
 }
 
 int FS_seek(int chn, long int record)

--- a/interpreters/bas/bas_token.c
+++ b/interpreters/bas/bas_token.c
@@ -1525,16 +1525,6 @@ static void yy_flex_strncpy (char *,yyconst char *,int);
 static int yy_flex_strlen (yyconst char *);
 #endif
 
-#ifndef YY_NO_INPUT
-
-#ifdef __cplusplus
-static int yyinput (void);
-#else
-static int input (void);
-#endif
-
-#endif
-
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
 #ifdef __ia64__
@@ -4037,80 +4027,6 @@ static int yy_get_next_buffer (void)
 
     return yy_is_jam ? 0 : yy_current_state;
 }
-
-#ifndef YY_NO_INPUT
-#ifdef __cplusplus
-    static int yyinput (void)
-#else
-    static int input  (void)
-#endif
-
-{
-  int c;
-
-  *(yy_c_buf_p) = (yy_hold_char);
-
-  if (*(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR)
-    {
-    /* yy_c_buf_p now points to the character we want to return.
-     * If this occurs *before* the EOB characters, then it's a
-     * valid NUL; if not, then we've hit the end of the buffer.
-     */
-    if ((yy_c_buf_p) < &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)])
-      /* This was really a NUL. */
-      *(yy_c_buf_p) = '\0';
-
-    else
-      { /* need more input */
-      yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
-      ++(yy_c_buf_p);
-
-      switch (yy_get_next_buffer())
-        {
-        case EOB_ACT_LAST_MATCH:
-          /* This happens because yy_g_n_b()
-           * sees that we've accumulated a
-           * token and flags that we need to
-           * try matching the token before
-           * proceeding.  But for input(),
-           * there's no matching to consider.
-           * So convert the EOB_ACT_LAST_MATCH
-           * to EOB_ACT_END_OF_FILE.
-           */
-
-          /* Reset buffer status. */
-          yyrestart(yyin);
-
-          /*FALLTHROUGH*/
-
-        case EOB_ACT_END_OF_FILE:
-          {
-          if (yywrap())
-            return EOF;
-
-          if (! (yy_did_buffer_switch_on_eof))
-            YY_NEW_FILE;
-#ifdef __cplusplus
-          return yyinput();
-#else
-          return input();
-#endif
-          }
-
-        case EOB_ACT_CONTINUE_SCAN:
-          (yy_c_buf_p) = (yytext_ptr) + offset;
-          break;
-        }
-      }
-    }
-
-  c = *(unsigned char *) (yy_c_buf_p);  /* cast for 8-bit char's */
-  *(yy_c_buf_p) = '\0';  /* preserve yytext */
-  (yy_hold_char) = *++(yy_c_buf_p);
-
-  return c;
-}
-#endif /* ifndef YY_NO_INPUT */
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -91,6 +91,7 @@ static inline FAR const char *nsh_getwd(const char *wd)
  * Name: nsh_getdirpath
  ****************************************************************************/
 
+#ifndef CONFIG_DISABLE_ENVIRON
 static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
                                    const char *dirpath, const char *relpath)
 {
@@ -125,6 +126,7 @@ static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
 
   return alloc;
 }
+#endif
 
 /****************************************************************************
  * Name: nsh_dumpvar

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * apps/nshlib/nsh_envcmds.c
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2018 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2012, 2018 Gregory Nutt. All rights
+ *   reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -95,7 +96,7 @@ static inline FAR const char *nsh_getwd(const char *wd)
 static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
                                    const char *dirpath, const char *relpath)
 {
-  char *alloc;
+  FAR char *alloc;
   int len;
 
   /* Handle the special case where the dirpath is simply "/" */
@@ -103,7 +104,7 @@ static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
   if (strcmp(dirpath, "/") == 0)
     {
       len   = strlen(relpath) + 2;
-      alloc = (char*)malloc(len);
+      alloc = (FAR char *)malloc(len);
       if (alloc)
         {
           sprintf(alloc, "/%s", relpath);
@@ -112,7 +113,7 @@ static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
   else
     {
       len = strlen(dirpath) + strlen(relpath) + 2;
-      alloc = (char*)malloc(len);
+      alloc = (FAR char *)malloc(len);
       if (alloc)
         {
           sprintf(alloc, "%s/%s", dirpath, relpath);
@@ -389,23 +390,24 @@ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
           else
             {
               value = &argv[1][1];
-              while(*value && *value != ' ')
+              while (*value && *value != ' ')
                 {
                   popt = strchr(opts, *value++);
                   if (popt == NULL)
                     {
-                      nsh_error(vtbl, g_fmtarginvalid, argv[0], "set", NSH_ERRNO);
+                      nsh_error(vtbl, g_fmtarginvalid,
+                                argv[0], "set", NSH_ERRNO);
                       ret = -EINVAL;
                       break;
                     }
 
                   if (op == '+')
                     {
-                      vtbl->np.np_flags |= 1 << (popt-opts);
+                      vtbl->np.np_flags |= 1 << (popt - opts);
                     }
                   else
                     {
-                      vtbl->np.np_flags &= ~(1 << (popt-opts));
+                      vtbl->np.np_flags &= ~(1 << (popt - opts));
                     }
                 }
 
@@ -416,8 +418,8 @@ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
                 }
 #endif
             }
-         }
-      }
+        }
+    }
 
 #ifdef NSH_HAVE_VARS
   if (ret == OK && (argc == 3 || argc == 4))
@@ -431,7 +433,7 @@ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
       /* Trim whitespace from the value */
 
-      value = nsh_trimspaces(argv[ndx+1]);
+      value = nsh_trimspaces(argv[ndx + 1]);
 
 #ifdef CONFIG_NSH_VARS
 #ifndef CONFIG_DISABLE_ENVIRON
@@ -442,8 +444,8 @@ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
        * a local variable that shadows the environment variable.
        */
 
-     oldvalue = getenv(argv[ndx]);
-     if (oldvalue == NULL)
+      oldvalue = getenv(argv[ndx]);
+      if (oldvalue == NULL)
 #endif
         {
           /* Set the NSH variable */

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -420,7 +420,7 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
  * Name: nsh_addrconv
  ****************************************************************************/
 
-#ifdef HAVE_HWADDR
+#if !defined(CONFIG_NSH_DISABLE_IFCONFIG) && defined(HAVE_HWADDR)
 static inline bool nsh_addrconv(FAR const char *hwstr,
                                 FAR mac_addr_t *macaddr)
 {
@@ -442,7 +442,7 @@ static inline bool nsh_addrconv(FAR const char *hwstr,
  * Name: nsh_sethwaddr
  ****************************************************************************/
 
-#ifdef HAVE_HWADDR
+#if !defined(CONFIG_NSH_DISABLE_IFCONFIG) && defined(HAVE_HWADDR)
 static inline void nsh_sethwaddr(FAR const char *ifname,
                                  FAR mac_addr_t *macaddr)
 {

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -265,7 +265,7 @@ int tftpc_parseargs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv,
         }
     }
 
-  /* If a bad argument was encountered, then return without processing the command */
+  /* If a bad argument was encountered, then return without processing */
 
   if (badarg)
     {
@@ -669,7 +669,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
                 }
 
 #ifdef HAVE_HWADDR
-              /* REVISIT: How will we handle Ethernet and SLIP networks together? */
+              /* REVISIT: How will we handle Ethernet and SLIP together? */
 
               else if (!strcmp(tmp, "hw"))
                 {


### PR DESCRIPTION
src/cwindowfactory.cxx: In member function 'void Twm4Nx::CWindowFactory::redrawIcons(const nxgl_rect_s*)':
src/cwindowfactory.cxx:461:38: warning: 'iconPos.nxgl_point_s::y' may be used uninitialized in this function [-Wmaybe-uninitialized]
  461 |           iconBounds.pt2.y = iconPos.y + iconSize.h - 1;
      |                              ~~~~~~~~^
src/cwindowfactory.cxx:460:38: warning: 'iconPos.nxgl_point_s::x' may be used uninitialized in this function [-Wmaybe-uninitialized]
  460 |           iconBounds.pt2.x = iconPos.x + iconSize.w - 1;
      |                              ~~~~~~~~^

nsh_netcmds.c:424:20: warning: 'nsh_addrconv' defined but not used [-Wunused-function]
 static inline bool nsh_addrconv(FAR const char *hwstr,
                    ^
nsh_netcmds.c:446:20: warning: 'nsh_sethwaddr' defined but not used [-Wunused-function]
 static inline void nsh_sethwaddr(FAR const char *ifname,
                    ^

nsh_envcmds.c:94:21: warning: 'nsh_getdirpath' defined but not used [-Wunused-function]
 static inline char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
                     ^

In file included from bas.c:84:0:
bas.c: In function 'bas_interpreter':
bas_error.h:110:37: warning: left-hand operand of comma expression has no effect [-Wunused-value]
 #define NOSUCHLINE         STATIC+40, _("No such line")
                                     ^
bas.c:2425:52: note: in expansion of macro 'NOSUCHLINE'
                           FS_putChars(STDCHANNEL, (NOSUCHLINE));
                                                    ^~~~~~~~~~
bas_fs.c:107:22: warning: 'g_vt100_colormap' defined but not used [-Wunused-const-variable=]
 static const uint8_t g_vt100_colormap[8] =
                      ^~~~~~~~~~~~~~~~
<stdout>:4048:16: warning: 'input' defined but not used [-Wunused-function]

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I62610b4c90e67637250cbd0107c2935c8abc542f