### PR TITLE
examples/thttpd: align to elf/posix_spawn exmaples to fix depend buil…

### DIFF
--- a/examples/thttpd/Makefile
+++ b/examples/thttpd/Makefile
@@ -62,9 +62,6 @@ build:
 context::
 	+$(Q) $(CONTENT_MAKE) context TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
-depend::
-	+$(Q) $(CONTENT_MAKE) depend TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
-
 clean::
 	+$(Q) $(CONTENT_MAKE) clean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 


### PR DESCRIPTION
…d warning

Build warning logs as below:
arm-none-eabi-gcc: warning: ./hello/Makefile: linker input file unused because linking not done

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>