### PR TITLE
Fix BOARDIOC_FINALINIT get skipped when CONFIG_NSH_ROMFSETC isn't enabled

### DIFF
--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -294,6 +294,12 @@ int nsh_consolemain(int argc, FAR char *argv[])
   netinit_bringup();
 #endif
 
+#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
+  /* Perform architecture-specific final-initialization (if configured) */
+
+  boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
   /* First map stderr and stdout to alternative devices */
 
   ret = nsh_clone_console(pstate);

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -104,6 +104,12 @@ int nsh_consolemain(int argc, FAR char *argv[])
   netinit_bringup();
 #endif
 
+#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
+  /* Perform architecture-specific final-initialization (if configured) */
+
+  boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
   /* Execute the session */
 
   ret = nsh_session(pstate, true);

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -196,12 +196,6 @@ int nsh_initscript(FAR struct nsh_vtbl_s *vtbl)
 
       vtbl->np.np_flags = NSH_NP_SET_OPTIONS_INIT;
 #endif
-
-#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
-      /* Perform architecture-specific final-initialization (if configured) */
-
-      boardctl(BOARDIOC_FINALINIT, 0);
-#endif
     }
 
   return ret;

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -259,11 +259,19 @@ int nsh_telnetstart(sa_family_t family)
 
       /* Execute the startup script.  If standard console is also defined,
        * then we will not bother with the initscript here (although it is
-       * safe to call nshinitscript multiple times).
+       * safe to call nsh_initscript multiple times).
        */
 
 #if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
       nsh_initscript(vtbl);
+#endif
+
+      /* Perform architecture-specific final-initialization(if configured) */
+
+#if defined(CONFIG_NSH_ARCHINIT) && \
+    defined(CONFIG_BOARDCTL_FINALINIT) && \
+    !defined(CONFIG_NSH_CONSOLE)
+      boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
       /* Configure the telnet daemon */

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -326,6 +326,12 @@ int nsh_consolemain(int argc, FAR char *argv[])
   netinit_bringup();
 #endif
 
+#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
+  /* Perform architecture-specific final-initialization (if configured) */
+
+  boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
   /* Now loop, executing creating a session for each USB connection */
 
   for (; ; )


### PR DESCRIPTION
Fix the regression discuss here: https://github.com/apache/incubator-nuttx-apps/pull/185