### PR TITLE
fix apps/include/graphics/nxwidgets/cwidgetcontrol.hxx:550:20: error:…

### DIFF
--- a/include/graphics/nxwidgets/cwidgetcontrol.hxx
+++ b/include/graphics/nxwidgets/cwidgetcontrol.hxx
@@ -547,7 +547,11 @@ namespace NXWidgets
 
     inline bool doubleClick(void)
     {
+#ifdef CONFIG_NX_XYINPUT
       return (bool)m_xyinput.doubleClick;
+#else
+      return false;
+#endif
     }
 
     /**


### PR DESCRIPTION
… ‘m_xyinput’ was not declared in this scope

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>