### PR TITLE
webclient: use getaddrinfo to get IPv4 addresses on dual stack systems

### DIFF
--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -144,7 +144,6 @@ int web_posts_strlen(FAR char **name, FAR char **value, int len);
 int wget(FAR const char *url, FAR char *buffer, int buflen,
          wget_callback_t callback, FAR void *arg);
 
-
 int wget_post(FAR const char *url, FAR const char *posts, FAR char *buffer,
               int buflen, wget_callback_t callback, FAR void *arg);
 

--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  apps/include/netutils/webclient.h
+ * apps/include/netutils/webclient.h
  * Header file for the HTTP client
  *
  *   Copyright (C) 2007, 2009, 2011, 2015 Gregory Nutt. All rights reserved.
@@ -46,9 +46,7 @@
  * Included Files
  ****************************************************************************/
 
-#ifndef CONFIG_WEBCLIENT_HOST
-#  include <nuttx/config.h>
-#endif
+#include <nuttx/config.h>
 #include <sys/types.h>
 
 /****************************************************************************
@@ -93,6 +91,7 @@
  *       of valid bytes is datend - offset.
  *   buflen - A pointer to the length of the buffer.  If the callee wishes
  *       to change the size of the buffer, it may write to buflen.
+ *   arg    - User argument passed to callback.
  */
 
 typedef void (*wget_callback_t)(FAR char **buffer, int offset,
@@ -124,12 +123,6 @@ int web_posts_strlen(FAR char **name, FAR char **value, int len);
  *
  * Description:
  *   Obtain the requested file from an HTTP server using the GET method.
- *
- *   Note: If the function is passed a host name, it must already be in
- *   the resolver cache in order for the function to connect to the web
- *   server. It is therefore up to the calling module to implement the
- *   resolver calls and the signal handler used for reporting a resolve
- *   query answer.
  *
  * Input Parameters
  *   url      - A pointer to a string containing either the full URL to

--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -99,14 +99,14 @@ static inline uint16_t ping_newid(void)
  * Name: ping_gethostip
  *
  * Description:
- *   Call gethostbyname() to get the IP address associated with a hostname.
+ *   Call getaddrinfo() to get the IP address associated with a hostname.
  *
  * Input Parameters
  *   hostname - The host name to use in the nslookup.
- *   ipv4addr - The location to return the IPv4 address.
+ *   destr    - The location to return the IPv4 address.
  *
  * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
+ *   Zero (OK) on success; ERROR on failure.
  *
  ****************************************************************************/
 
@@ -136,7 +136,7 @@ static int ping_gethostip(FAR const char *hostname, FAR struct in_addr *dest)
 #else /* CONFIG_LIBC_NETDB */
   /* No host name support */
 
-  /* Convert strings to numeric IPv6 address */
+  /* Convert strings to numeric IPv4 address */
 
   int ret = inet_pton(AF_INET, hostname, dest);
 

--- a/netutils/ping/icmpv6_ping.c
+++ b/netutils/ping/icmpv6_ping.c
@@ -98,14 +98,14 @@ static inline uint16_t ping6_newid(void)
  * Name: ping6_gethostip
  *
  * Description:
- *   Call gethostbyname() to get the IP address associated with a hostname.
+ *   Call getaddrinfo() to get the IP address associated with a hostname.
  *
  * Input Parameters
  *   hostname - The host name to use in the nslookup.
- *   ipv4addr - The location to return the IPv4 address.
+ *   dest     - The location to return the IPv6 address.
  *
  * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
+ *   Zero (OK) on success; ERROR on failure.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
Also wget state is now allocated in order to conserve stack space.