### PR TITLE
Revert "build.yml: Remove -G from cibuild.sh command line"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         run: |
           cd testing
-          ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -x -G testlist/${{matrix.boards}}.dat
 
   macOS:
     runs-on: macos-10.15
@@ -119,4 +119,4 @@ jobs:
     - name: Run builds
       run: |
         cd testing
-        ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat
+        ./cibuild.sh -i -x -G testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
Until the code base restore to the origin state after "make distclean" 