### PR TITLE
Fix errors from DEFAULT_TASK_SIZE change

### DIFF
--- a/examples/mount/Kconfig
+++ b/examples/mount/Kconfig
@@ -35,7 +35,7 @@ if !EXAMPLES_MOUNT_BLOCKDEVICE
 
 config EXAMPLES_MOUNT_NSECTORS
 	int "RAM disk number of sectors"
-	default DEFAULT_TASK_STACKSIZE
+	default 2048
 	---help---
 		The number of "sectors" in the RAM disk used when
 		EXAMPLES_MOUNT_BLOCKDEVICE is not selected.

--- a/netutils/libcurl4nx/Kconfig
+++ b/netutils/libcurl4nx/Kconfig
@@ -44,6 +44,6 @@ config LIBCURL4NX_MINRXBUFLEN
 
 config LIBCURL4NX_MAXRXBUFLEN
 	int "Maximum RX buffer size for CURL4NXOPT_BUFFERSIZE"
-	default DEFAULT_TASK_STACKSIZE
+	default 2048
 
 endif


### PR DESCRIPTION
There were several places where default sector and buffer sizes of 2048 were changed to DEFAULT_TASK_STACKSIZE.  This is not correct.  This was noted by Xiao Xiang.