### PR TITLE
examples/unionfs: Remove [a|b]testdir.h in distclean

### DIFF
--- a/examples/unionfs/Makefile
+++ b/examples/unionfs/Makefile
@@ -72,5 +72,7 @@ context:: romfs_atestdir.h romfs_btestdir.h
 distclean::
 	$(call DELFILE, atestdir.img)
 	$(call DELFILE, btestdir.img)
+	$(call DELFILE, atestdir.h)
+	$(call DELFILE, btestdir.h)
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>