### PR TITLE
CI: Remove -G from cibuild.sh command line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           run: |
             git -C sources/nuttx fetch --tags
             cd sources/testing
-            ./cibuild.sh -x -G testlist/${{matrix.boards}}.dat
+            ./cibuild.sh -x testlist/${{matrix.boards}}.dat
 
   macOS:
     runs-on: macos-10.15
@@ -211,4 +211,4 @@ jobs:
         run: |
           git -C sources/nuttx fetch --tags
           cd sources/testing
-          ./cibuild.sh -i -x -G testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
Use make distclean instead of git clean to do check build clean defaultly.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>