### PR TITLE
Remove the unnecessary BUILD_FLAT dependence from Kconfig

### DIFF
--- a/examples/timer/Kconfig
+++ b/examples/timer/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_TIMER
 	tristate "Timer example"
 	default n
-	depends on TIMER && BUILD_FLAT
+	depends on TIMER
 	---help---
 		Enable the timer example
 

--- a/system/readline/Kconfig
+++ b/system/readline/Kconfig
@@ -29,7 +29,7 @@ if READLINE_ECHO
 config READLINE_TABCOMPLETION
 	bool "Tab completion"
 	default n
-	depends on (BUILD_FLAT && BUILTIN) || READLINE_HAVE_EXTMATCH
+	depends on BUILTIN || READLINE_HAVE_EXTMATCH
 	---help---
 		Build in support for Unix-style tab completion.  This feature was
 		originally provided by Nghia Ho.


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>