### PR TITLE
wireless/bluetooth/btsak/btsak_security.c:  Fix newline character

### DIFF
--- a/wireless/bluetooth/btsak/btsak_security.c
+++ b/wireless/bluetooth/btsak/btsak_security.c
@@ -2,41 +2,27 @@
  * apps/wireless/bluetooth/btsak/btsak_security.c
  * Bluetooth Swiss Army Knife -- Security command
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author:  Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Based loosely on the i8sak IEEE 802.15.4 program by Anthony Merlino and
- * Sebastien Lorquet.  Commands inspired for btshell example in the
- * Intel/Zephyr Arduino 101 package (BSD license).
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
+
+/* Based loosely on the i8sak IEEE 802.15.4 program by Anthony Merlino and
+ * Sebastien Lorquet.  Commands inspired from btshell example in the
+ * Intel/Zephyr Arduino 101 package (BSD license).
+ */
 
 /****************************************************************************
  * Included Files
@@ -73,21 +59,27 @@ static void btsak_security_showusage(FAR const char *progname,
   fprintf(stderr, "%s:\tEnable security (encryption) for a connection:\n",
           cmd);
   fprintf(stderr,
-          "\tIf device is paired, key encryption will be enabled. If the link\n");
+          "\tIf device is paired, key encryption will be enabled. If the "
+          "link\n");
   fprintf(stderr,
-          "\tis already encrypted with sufficiently strong key this function\n");
+          "\tis already encrypted with sufficiently strong key this "
+          "function\n");
   fprintf(stderr,
           "\tdoes nothing.\n\n");
   fprintf(stderr,
-          "\tIf the device is not paired pairing will be initiated. If the device\n");
+          "\tIf the device is not paired pairing will be initiated. If the "
+          "device\n");
   fprintf(stderr,
-          "\tis paired and keys are too weak but input output capabilities allow\n");
+          "\tis paired and keys are too weak but input output capabilities "
+          "allow\n");
   fprintf(stderr,
           "\tfor strong enough keys pairing will be initiated.\n\n");
   fprintf(stderr,
-          "\tThis function may return error if required level of security is not\n");
+          "\tThis function may return error if required level of security "
+          "is not\n");
   fprintf(stderr,
-          "\tpossible to achieve due to local or remote device limitation (eg input\n");
+          "\tpossible to achieve due to local or remote device limitation "
+          "(eg input\n");
   fprintf(stderr,
           "\toutput capabilities).\n\n");
   fprintf(stderr, "Usage:\n\n");
@@ -106,7 +98,8 @@ static void btsak_security_showusage(FAR const char *progname,
   fprintf(stderr,
           "\t\thigh\t- Encryption and authentication (MITM)\n");
   fprintf(stderr,
-          "\t\tfips\t- Authenticated LE secure connections and encryption\n");
+          "\t\tfips\t- Authenticated LE secure connections and "
+          "encryption\n");
   exit(exitcode);
 }
 
@@ -122,7 +115,8 @@ static void btsak_security_showusage(FAR const char *progname,
  *
  ****************************************************************************/
 
-void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
+void btsak_cmd_security(FAR struct btsak_s *btsak, int argc,
+                        FAR char *argv[])
 {
   struct btreq_s btreq;
   int sockfd;
@@ -179,7 +173,8 @@ void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
   sockfd = btsak_socket(btsak);
   if (sockfd >= 0)
     {
-      ret = ioctl(sockfd, SIOCBTSECURITY, (unsigned long)((uintptr_t)&btreq));
+      ret = ioctl(sockfd, SIOCBTSECURITY,
+                  (unsigned long)((uintptr_t)&btreq));
       if (ret < 0)
         {
           fprintf(stderr, "ERROR:  ioctl(SIOCBTSECURITY) failed: %d\n",

--- a/wireless/bluetooth/btsak/btsak_security.c
+++ b/wireless/bluetooth/btsak/btsak_security.c
@@ -132,7 +132,7 @@ void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
 
   if (argc < 2)
     {
-      fprintf(stderr, "ERROR: Missing required arguments/n");
+      fprintf(stderr, "ERROR: Missing required arguments\n");
       btsak_security_showusage(btsak->progname, argv[0], EXIT_FAILURE);
     }
 
@@ -145,7 +145,7 @@ void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
 
   if (argc < 4)
     {
-      fprintf(stderr, "ERROR:  Missing required arguments/n");
+      fprintf(stderr, "ERROR:  Missing required arguments\n");
       btsak_security_showusage(btsak->progname, argv[0], EXIT_FAILURE);
     }
 
@@ -157,7 +157,7 @@ void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
   ret = btsak_str2addr(argv[1], btreq.btr_secaddr.val);
   if (ret < 0)
     {
-      fprintf(stderr, "ERROR:  Invalid address string: %s/n", argv[1]);
+      fprintf(stderr, "ERROR:  Invalid address string: %s\n", argv[1]);
       btsak_security_showusage(btsak->progname, argv[0], EXIT_FAILURE);
     }
 
@@ -166,7 +166,7 @@ void btsak_cmd_security(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
   ret = btsak_str2addrtype(argv[2], &btreq.btr_secaddr.type);
   if (ret < 0)
     {
-      fprintf(stderr, "ERROR:  Invalid address type: %s/n", argv[2]);
+      fprintf(stderr, "ERROR:  Invalid address type: %s\n", argv[2]);
       btsak_security_showusage(btsak->progname, argv[0], EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Inspired by Abdelatif's find, here are other cases where /n was used when \n ws intended