### PR TITLE
examples: Remove the prefix of main from bmi160 and charger

### DIFF
--- a/examples/bmi160/sixaxis_main.c
+++ b/examples/bmi160/sixaxis_main.c
@@ -57,11 +57,7 @@
  * sixaxis_main
  ****************************************************************************/
 
-#ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
-#else
-int sixaxis_main(int argc, char *argv[])
-#endif
 {
   int fd;
   struct accel_gyro_st_s data;

--- a/examples/charger/charger_main.c
+++ b/examples/charger/charger_main.c
@@ -33,6 +33,10 @@
  *
  ****************************************************************************/
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 #include <nuttx/config.h>
 
 #include <sys/ioctl.h>
@@ -181,11 +185,7 @@ static int show_bat_status(int fd)
  * charger_main
  ****************************************************************************/
 
-#ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
-#else
-int charger_main(int argc, char *argv[])
-#endif
 {
   int fd;
   int current;


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>