### PR TITLE
Move usrsock_rpmsg from system to netutils folder

### DIFF
--- a/netutils/usrsock_rpmsg/Kconfig
+++ b/netutils/usrsock_rpmsg/Kconfig
@@ -3,25 +3,25 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config SYSTEM_USRSOCK_RPMSG
+config NETUTILS_USRSOCK_RPMSG
 	tristate "RPMSG usrsock"
 	default n
 	depends on NET && OPENAMP
 	---help---
 		Enable usrsock through rpmsg channel.
 
-if SYSTEM_USRSOCK_RPMSG
+if NETUTILS_USRSOCK_RPMSG
 
-config SYSTEM_USRSOCK_RPMSG_PRIORITY
+config NETUTILS_USRSOCK_RPMSG_PRIORITY
 	int "usrsock task priority"
 	default 80
 	---help---
 		The priority for usrsock task.
 
-config SYSTEM_USRSOCK_RPMSG_STACKSIZE
+config NETUTILS_USRSOCK_RPMSG_STACKSIZE
 	int "usrsock task stack size"
 	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stack size allocated for the usrsock task.
 
-endif # SYSTEM_USRSOCK_RPMSG
+endif # NETUTILS_USRSOCK_RPMSG

--- a/netutils/usrsock_rpmsg/Make.defs
+++ b/netutils/usrsock_rpmsg/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/system/usrsock_rpmsg/Makefile
+# apps/system/usrsock_rpmsg/Make.defs
 #
 #   Copyright (C) 2018 Pinecone Inc. All rights reserved.
 #   Author: Pinecone <pinecone@pinecone.net>
@@ -33,17 +33,6 @@
 #
 ############################################################################
 
--include $(TOPDIR)/Make.defs
-
-PROGNAME = usrsock
-PRIORITY = CONFIG_SYSTEM_USRSOCK_RPMSG_PRIORITY
-STACKSIZE = CONFIG_SYSTEM_USRSOCK_RPMSG_STACKSIZE
-
-ifeq ($(CONFIG_NET_USRSOCK),y)
-MAINSRC := usrsock_rpmsg_client.c
-else
-MAINSRC := usrsock_rpmsg_server.c
+ifeq ($(CONFIG_NETUTILS_USRSOCK_RPMSG),y)
+CONFIGURED_APPS += $(APPDIR)/system/usrsock_rpmsg
 endif
-MODULE = $(CONFIG_SYSTEM_USRSOCK_RPMSG)
-
-include $(APPDIR)/Application.mk

--- a/netutils/usrsock_rpmsg/Makefile
+++ b/netutils/usrsock_rpmsg/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/system/usrsock_rpmsg/Make.defs
+# apps/system/usrsock_rpmsg/Makefile
 #
 #   Copyright (C) 2018 Pinecone Inc. All rights reserved.
 #   Author: Pinecone <pinecone@pinecone.net>
@@ -33,6 +33,17 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_USRSOCK_RPMSG),y)
-CONFIGURED_APPS += $(APPDIR)/system/usrsock_rpmsg
+-include $(TOPDIR)/Make.defs
+
+PROGNAME = usrsock
+PRIORITY = CONFIG_NETUTILS_USRSOCK_RPMSG_PRIORITY
+STACKSIZE = CONFIG_NETUTILS_USRSOCK_RPMSG_STACKSIZE
+
+ifeq ($(CONFIG_NET_USRSOCK),y)
+MAINSRC := usrsock_rpmsg_client.c
+else
+MAINSRC := usrsock_rpmsg_server.c
 endif
+MODULE = $(CONFIG_NETUTILS_USRSOCK_RPMSG)
+
+include $(APPDIR)/Application.mk

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg.h
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/usrsock_rpmsg/usrsock_rpmsg.h
+ * apps/netutils/usrsock_rpmsg/usrsock_rpmsg.h
  *
  *   Copyright (C) 2018 Pinecone Inc. All rights reserved.
  *   Author: Jianli Dong <dongjianli@pinecone.net>
@@ -33,8 +33,8 @@
  *
  ****************************************************************************/
 
-#ifndef __SYSTEM_USRSOCK_RPMSG_H
-#define __SYSTEM_USRSOCK_RPMSG_H
+#ifndef __NETUTILS_USRSOCK_RPMSG_H
+#define __NETUTILS_USRSOCK_RPMSG_H
 
 /****************************************************************************
  * Included Files
@@ -63,4 +63,4 @@ begin_packed_struct struct usrsock_rpmsg_dns_event_s
   uint16_t addrlen;
 } end_packed_struct;
 
-#endif /* __SYSTEM_USRSOCK_RPMSG_H */
+#endif /* __NETUTILS_USRSOCK_RPMSG_H */

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/usrsock_rpmsg/usrsock_rpmsg_client.c
+ * apps/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
  * usrsock rpmsg client
  *
  *   Copyright (C) 2018 Pinecone Inc. All rights reserved.

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/usrsock_rpmsg/usrsock_rpmsg_server.c
+ * apps/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
  * usrsock rpmsg server
  *
  *   Copyright (C) 2018 Pinecone Inc. All rights reserved.


### PR DESCRIPTION
This is a more suitable location

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary
need work with https://github.com/apache/incubator-nuttx-apps/pull/234

## Impact

## Testing

