### PR TITLE
netutils/usrsock_rpmsg:  Fix build failures

### DIFF
--- a/netutils/usrsock_rpmsg/Make.defs
+++ b/netutils/usrsock_rpmsg/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/system/usrsock_rpmsg/Make.defs
+# apps/netutils/usrsock_rpmsg/Make.defs
 #
 #   Copyright (C) 2018 Pinecone Inc. All rights reserved.
 #   Author: Pinecone <pinecone@pinecone.net>
@@ -34,5 +34,5 @@
 ############################################################################
 
 ifeq ($(CONFIG_NETUTILS_USRSOCK_RPMSG),y)
-CONFIGURED_APPS += $(APPDIR)/system/usrsock_rpmsg
+CONFIGURED_APPS += $(APPDIR)/netutils/usrsock_rpmsg
 endif

--- a/netutils/usrsock_rpmsg/Makefile
+++ b/netutils/usrsock_rpmsg/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/system/usrsock_rpmsg/Makefile
+# apps/netutils/usrsock_rpmsg/Makefile
 #
 #   Copyright (C) 2018 Pinecone Inc. All rights reserved.
 #   Author: Pinecone <pinecone@pinecone.net>


### PR DESCRIPTION
## Summary

Not all files were correctly modified when usrsock_rpmsg was moved from apps/system to apps/netutils.  Changes were overlooked in the Makefile and Make.defs file.

## Impact

Should correct the PR check system which is failing on this problem.

## Testing

