### PR TITLE
Remove CONFIG_TLS

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -63,7 +63,7 @@ ifneq ($(CONFIG_STDIO_DISABLE_BUFFERING),y)
 CSRCS += setvbuf.c
 endif
 
-ifeq ($(CONFIG_TLS),y)
+ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += tls.c
 endif
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -284,7 +284,7 @@ static int user_main(int argc, char *argv[])
   check_test_memory_usage();
 #endif
 
-#ifdef CONFIG_TLS
+#if CONFIG_TLS_NELEM > 0
   /* Test TLS */
 
   tls_test();

--- a/testing/ostest/tls.c
+++ b/testing/ostest/tls.c
@@ -48,7 +48,7 @@
 
 #include "ostest.h"
 
-#ifdef CONFIG_TLS
+#if CONFIG_TLS_NELEM > 0
 
 #include <arch/tls.h>
 
@@ -126,4 +126,4 @@ void tls_test(void)
   put_tls_info(&g_save_info);
 }
 
-#endif /* CONFIG_TLS */
+#endif /* CONFIG_TLS_NELEM > 0 */


### PR DESCRIPTION
## Summary

A first step in implementing the user-space error is force TLS to be enabled at all times. It is no longer optional.

## Impact

Risky all architectures are affected.

## Testing

Not yet.


