### PR TITLE
CI: use 'git diff $commits' as a whole patchset to do checkpatch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,5 +38,4 @@ jobs:
         cd apps
         commits=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
         git log --oneline $commits
-        echo "../nuttx/tools/checkpatch.sh -g $commits"
-        ../nuttx/tools/checkpatch.sh -g $commits
+        git diff $commits | ../nuttx/tools/checkpatch.sh -


### PR DESCRIPTION
## Summary
Use 'git diff $commits' as a whole patchset instead of 'git show $commits' to avoid checkpatch with duplicate error/warning logs sometimes and rename file not opened issue.

## Impact

## Testing

