### PR TITLE
Rename CONFIG_NPTHREAD_KEYS to CONFIG_TLS_NELEM

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -80,7 +80,7 @@ CSRCS += cancel.c cond.c mutex.c timedmutex.c sem.c semtimed.c barrier.c
 CSRCS += timedwait.c
 CSRCS += pthread_rwlock.c pthread_rwlock_cancel.c
 
-ifneq ($(CONFIG_NPTHREAD_KEYS),0)
+ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += specific.c
 endif
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -363,7 +363,7 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
-#if !defined(CONFIG_DISABLE_PTHREAD) && CONFIG_NPTHREAD_KEYS > 0
+#if !defined(CONFIG_DISABLE_PTHREAD) && CONFIG_TLS_NELEM > 0
       /* Verify pthread-specific data */
 
       printf("\nuser_main: pthread-specific data test\n");


### PR DESCRIPTION
## Summary

After the redesign of pthread-specific data, CONFIG_NPTHREAD_KEYS is removed and replaced with CONFIG_TLS_NELEM
