### PR TITLE
Revert "CI: use 'git diff $commits' as a whole patchset to do checkpatch"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,4 +38,5 @@ jobs:
         cd apps
         commits=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
         git log --oneline $commits
-        git diff $commits | ../nuttx/tools/checkpatch.sh -
+        echo "../nuttx/tools/checkpatch.sh -g $commits"
+        ../nuttx/tools/checkpatch.sh -g $commits


### PR DESCRIPTION
## Summary
This reverts commit 9c4cdc5331c1989b9a82e392255e516b16a5a47b.

If one PR is on a former master code base, using 'git diff $commits' would result in
abnormal checkpatch report sometimes. So revert it anyway.

## Impact

## Testing

