### PR TITLE
netutils/dhcpd: correct the option header check

### DIFF
--- a/netutils/dhcpd/Kconfig
+++ b/netutils/dhcpd/Kconfig
@@ -18,7 +18,7 @@ config NETUTILS_DHCPD_HOST
 	depends on EXPERIMENTAL
 	---help---
 		DHCPD supports a host based build for testing on a PC.  It is
-		enabled by this configuration, however, ti cannot really be used
+		enabled by this configuration, however, it cannot really be used
 		in the context to the NuttX build as it currently stands.
 
 config NETUTILS_DHCPD_IGNOREBROADCAST

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -595,7 +595,7 @@ static inline bool dhcpd_parseoptions(void)
 #ifndef CONFIG_NET_DHCP_LIGHT
           case DHCP_OPTION_OVERLOAD:
             optlen = ptr[DHCPD_OPTION_LENGTH] + 2;
-            if (optlen >= 1 && optlen < remaining)
+            if (optlen >= 3 && optlen < remaining)
               {
                 overloaded = ptr[DHCPD_OPTION_DATA];
               }
@@ -629,7 +629,7 @@ static inline bool dhcpd_parseoptions(void)
 
           case DHCP_OPTION_REQ_IPADDR: /* Requested IP Address */
             optlen = ptr[DHCPD_OPTION_LENGTH] + 2;
-            if (optlen >= 4 && optlen < remaining)
+            if (optlen >= 6 && optlen < remaining)
               {
                 memcpy(&tmp, &ptr[DHCPD_OPTION_DATA], 4);
                 g_state.ds_optreqip = (in_addr_t)ntohl(tmp);
@@ -638,7 +638,7 @@ static inline bool dhcpd_parseoptions(void)
 
           case DHCP_OPTION_LEASE_TIME: /* IP address lease time */
              optlen = ptr[DHCPD_OPTION_LENGTH] + 2;
-            if (optlen >= 4 && optlen < remaining)
+            if (optlen >= 6 && optlen < remaining)
               {
                 memcpy(&tmp, &ptr[DHCPD_OPTION_DATA], 4);
                 g_state.ds_optleasetime = (time_t)ntohl(tmp);
@@ -647,7 +647,7 @@ static inline bool dhcpd_parseoptions(void)
 
          case DHCP_OPTION_MSG_TYPE: /* DHCP message type */
             optlen = ptr[DHCPD_OPTION_LENGTH] + 2;
-            if (optlen >= 1 && optlen < remaining)
+            if (optlen >= 3 && optlen < remaining)
               {
                 g_state.ds_optmsgtype = ptr[DHCPD_OPTION_DATA];
               }
@@ -655,7 +655,7 @@ static inline bool dhcpd_parseoptions(void)
 
           case DHCP_OPTION_SERVER_ID: /* Server identifier */
             optlen = ptr[DHCPD_OPTION_LENGTH] + 2;
-            if (optlen >= 4 && optlen < remaining)
+            if (optlen >= 6 && optlen < remaining)
               {
                 memcpy(&tmp, &ptr[DHCPD_OPTION_DATA], 4);
                 g_state.ds_optserverip = (in_addr_t)ntohl(tmp);
@@ -943,12 +943,6 @@ static void dhcpd_initpacket(uint8_t mtype)
     {
       g_state.ds_outpacket.flags  = g_state.ds_inpacket.flags;
     }
-  else
-    {
-      g_state.ds_outpacket.flags  = 0;
-    }
-
-  memset(g_state.ds_outpacket.giaddr, 0, 4);
 
   /* Add the generic options */
 

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -814,7 +814,7 @@ static int dhcpd_addoption32(uint8_t code, uint32_t value)
  * Name: dhcp_addoption32p
  ****************************************************************************/
 
-#ifdef HAVE_DSNIP
+#ifdef HAVE_DNSIP
 static int dhcp_addoption32p(uint8_t code, FAR uint8_t *value)
 {
   uint8_t option[6];
@@ -832,7 +832,7 @@ static int dhcp_addoption32p(uint8_t code, FAR uint8_t *value)
 #endif
 
 /****************************************************************************
- * Name: dhcpd_soclet
+ * Name: dhcpd_socket
  ****************************************************************************/
 
 static inline int dhcpd_socket(void)
@@ -1061,7 +1061,7 @@ static int dhcpd_sendpacket(int bbroadcast)
 static inline int dhcpd_sendoffer(in_addr_t ipaddr, uint32_t leasetime)
 {
   in_addr_t netaddr;
-#ifdef HAVE_DSNIP
+#ifdef HAVE_DNSIP
   uint32_t dnsaddr;
   dnsaddr = htonl(CONFIG_NETUTILS_DHCPD_DNSIP);
 #endif
@@ -1089,7 +1089,7 @@ static inline int dhcpd_sendoffer(in_addr_t ipaddr, uint32_t leasetime)
   dhcpd_addoption32(DHCP_OPTION_ROUTER,
                     htonl(CONFIG_NETUTILS_DHCPD_ROUTERIP));
 #endif
-#ifdef HAVE_DSNIP
+#ifdef HAVE_DNSIP
   dhcp_addoption32p(DHCP_OPTION_DNS_SERVER, (FAR uint8_t *)&dnsaddr);
 #endif
 
@@ -1123,7 +1123,7 @@ int dhcpd_sendack(in_addr_t ipaddr)
 {
   uint32_t leasetime = CONFIG_NETUTILS_DHCPD_LEASETIME;
   in_addr_t netaddr;
-#ifdef HAVE_DSNIP
+#ifdef HAVE_DNSIP
   uint32_t dnsaddr;
   dnsaddr = htonl(CONFIG_NETUTILS_DHCPD_DNSIP);
 #endif
@@ -1153,7 +1153,7 @@ int dhcpd_sendack(in_addr_t ipaddr)
   dhcpd_addoption32(DHCP_OPTION_ROUTER,
                     htonl(CONFIG_NETUTILS_DHCPD_ROUTERIP));
 #endif
-#ifdef HAVE_DSNIP
+#ifdef HAVE_DNSIP
   dhcp_addoption32p(DHCP_OPTION_DNS_SERVER, (FAR uint8_t *)&dnsaddr);
 #endif
 


### PR DESCRIPTION
## Summary
netutils/dhcpd: correct the option header check
netutils/dhcpd: Fix the minor typo error
