### PR TITLE
Update make dependency for elf/module/nxflat/posix_spawn/sotest/thttpd

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -219,7 +219,7 @@ else
 context::
 endif
 
-.depend: Makefile $(SRCS)
+.depend: Makefile $(wildcard $(SRCS))
 ifeq ($(filter %$(CXXEXT),$(SRCS)),)
 	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(filter-out Makefile,$^) >Make.dep
 else

--- a/examples/elf/Makefile
+++ b/examples/elf/Makefile
@@ -37,7 +37,14 @@
 
 # ELF Example
 
-CSRCS = symtab.c
+ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
+CSRCS = romfs.c
+endif
+ifeq ($(CONFIG_EXAMPLES_ELF_CROMFS),y)
+CSRCS = cromfs.c
+endif
+CSRCS += dirlist.c
+CSRCS += symtab.c
 MAINSRC = elf_main.c
 
 PROGNAME = elf
@@ -51,7 +58,13 @@ ROOTDEPPATH := --dep-path tests
 
 VPATH += :tests
 
-elf_main.c: build
+ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
+tests/romfs.c: build
+endif
+ifeq ($(CONFIG_EXAMPLES_ELF_CROMFS),y)
+tests/cromfs.c: build
+endif
+tests/dirlist.c: build
 tests/symtab.c: build
 
 .PHONY: build

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -42,16 +42,6 @@
 
 #include "platform/cxxinitialize.h"
 
-#if defined(CONFIG_EXAMPLES_ELF_ROMFS)
-#  include "tests/romfs.h"
-#elif defined(CONFIG_EXAMPLES_ELF_CROMFS)
-#  include "tests/cromfs.h"
-#elif !defined(CONFIG_EXAMPLES_ELF_EXTERN)
-#  error "No file system selected"
-#endif
-
-#include "tests/dirlist.h"
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -134,6 +124,15 @@ static char fullpath[128];
 /****************************************************************************
  * Symbols from Auto-Generated Code
  ****************************************************************************/
+
+#if defined(CONFIG_EXAMPLES_ELF_ROMFS) || defined(CONFIG_EXAMPLES_ELF_CROMFS)
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+#elif !defined(CONFIG_EXAMPLES_ELF_EXTERN)
+#  error "No file system selected"
+#endif
+
+extern const char *dirlist[];
 
 extern const struct symtab_s g_elf_exports[];
 extern const int g_elf_nexports;

--- a/examples/elf/tests/.gitignore
+++ b/examples/elf/tests/.gitignore
@@ -1,8 +1,8 @@
 /romfs
-/romfs.h
+/romfs.c
 /romfs.img
 /cromfs
-/cromfs.h
-/dirlist.h
+/cromfs.c
+/dirlist.c
 /symtab.c
 /varlist.tmp

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -56,14 +56,14 @@ endif
 
 ELF_DIR = $(APPDIR)/examples/elf
 TESTS_DIR = $(ELF_DIR)/tests
-DIRLIST_HDR = $(TESTS_DIR)/dirlist.h
+DIRLIST_SRC = $(TESTS_DIR)/dirlist.c
 SYMTAB_SRC = $(TESTS_DIR)/symtab.c
 
 ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
   FSIMG_SUBDIR = romfs
   FSIMG_DIR = $(TESTS_DIR)/$(FSIMG_SUBDIR)
   ROMFS_IMG = $(TESTS_DIR)/romfs.img
-  FSIMG_HDR = $(TESTS_DIR)/romfs.h
+  FSIMG_SRC = $(TESTS_DIR)/romfs.c
 else
   NXTOOLDIR = $(TOPDIR)/tools
   GENCROMFSSRC = gencromfs.c
@@ -71,7 +71,7 @@ else
 
   FSIMG_SUBDIR = cromfs
   FSIMG_DIR = $(TESTS_DIR)/$(FSIMG_SUBDIR)
-  FSIMG_HDR = $(TESTS_DIR)/cromfs.h
+  FSIMG_SRC = $(TESTS_DIR)/cromfs.c
 endif
 
 define DIR_template
@@ -79,7 +79,7 @@ $(1)_$(2):
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSIMG_DIR="$(FSIMG_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(FSIMG_HDR) $(DIRLIST_HDR) $(SYMTAB_SRC)
+all: $(FSIMG_SRC) $(DIRLIST_SRC) $(SYMTAB_SRC)
 .PHONY: all clean install
 
 $(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
@@ -96,10 +96,10 @@ $(ROMFS_IMG): install
 	$(Q) genromfs -f $@.tmp -d $(FSIMG_DIR) -V "ELFTEST"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(FSIMG_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(FSIMG_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
 else
 # Make sure that the NuttX gencromfs tool has been built
@@ -109,7 +109,7 @@ $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
 
 # Create the cromfs.h header file from the populated cromfs directory
 
-$(FSIMG_HDR): install $(NXTOOLDIR)/$(GENCROMFSEXE)
+$(FSIMG_SRC): install $(NXTOOLDIR)/$(GENCROMFSEXE)
 	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
@@ -117,7 +117,7 @@ endif
 
 # Create the dirlist.h header file from the file system image directory
 
-$(DIRLIST_HDR): install
+$(DIRLIST_SRC): install
 	$(Q) $(TESTS_DIR)/mkdirlist.sh $(FSIMG_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
@@ -130,5 +130,5 @@ $(SYMTAB_SRC): install
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(ALL_SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(FSIMG_HDR) $(DIRLIST_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(FSIMG_SRC) $(DIRLIST_SRC) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(FSIMG_DIR)

--- a/examples/elf/tests/mkdirlist.sh
+++ b/examples/elf/tests/mkdirlist.sh
@@ -17,10 +17,9 @@ if [ ! -d "$dir" ]; then
 	exit 1
 fi
 
-echo "#ifndef __EXAMPLES_ELF_TESTS_DIRLIST_H"
-echo "#define __EXAMPLES_ELF_TESTS_DIRLIST_H"
+echo "#include <stddef.h>"
 echo ""
-echo "static const char *dirlist[] ="
+echo "const char *dirlist[] ="
 echo "{"
 
 for file in `ls $dir`; do
@@ -29,5 +28,3 @@ done
 
 echo "  NULL"
 echo "};"
-echo ""
-echo "#endif /* __EXAMPLES_ELF_TESTS_DIRLIST_H */"

--- a/examples/module/Makefile
+++ b/examples/module/Makefile
@@ -44,21 +44,27 @@ MODULE = $(CONFIG_EXAMPLES_MODULE)
 
 # Module Example
 
-MAINSRC = module_main.c
-
-ifeq ($(CONFIG_BUILD_FLAT),y)
-CSRCS += mod_symtab.c
+ifeq ($(CONFIG_EXAMPLES_MODULE_ROMFS),y)
+CSRCS = romfs.c
 endif
+ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
+CSRCS = cromfs.c
+endif
+CSRCS += mod_symtab.c
+MAINSRC = module_main.c
 
 VPATH += drivers
 ROOTDEPPATH += --dep-path drivers
 
 # Build targets
 
-module_main.c: build
-ifeq ($(CONFIG_BUILD_FLAT),y)
-drivers/mod_symtab.c: build
+ifeq ($(CONFIG_EXAMPLES_MODULE_ROMFS),y)
+drivers/romfs.c: build
 endif
+ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
+drivers/cromfs.c: build
+endif
+drivers/mod_symtab.c: build
 
 .PHONY: build
 build:

--- a/examples/module/drivers/.gitignore
+++ b/examples/module/drivers/.gitignore
@@ -1,5 +1,5 @@
 /fsroot
-/romfs.h
-/cromfs.h
+/romfs.c
+/cromfs.c
 /romfs.img
 /mod_symtab.c

--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -51,13 +51,13 @@ endif
 ifeq ($(CONFIG_EXAMPLES_MODULE_BUILTINFS),y)
 ifeq ($(CONFIG_EXAMPLES_MODULE_ROMFS),y)
   ROMFS_IMG = $(DRIVER_DIR)/romfs.img
-  FSIMG_HDR = $(DRIVER_DIR)/romfs.h
+  FSIMG_SRC = $(DRIVER_DIR)/romfs.c
 else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
   NXTOOLDIR = $(TOPDIR)/tools
   GENCROMFSSRC = gencromfs.c
   GENCROMFSEXE = gencromfs$(EXEEXT)
 
-  FSIMG_HDR = $(DRIVER_DIR)/cromfs.h
+  FSIMG_SRC = $(DRIVER_DIR)/cromfs.c
 endif
 endif
 
@@ -66,7 +66,7 @@ $(1)_$(2):
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(FSIMG_HDR) $(SYMTAB_SRC) $(PASS1_SYMTAB)
+all: $(FSIMG_SRC) $(SYMTAB_SRC) $(PASS1_SYMTAB)
 .PHONY: all clean install
 
 $(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
@@ -84,10 +84,10 @@ $(ROMFS_IMG): install
 	$(Q) genromfs -f $@.tmp -d $(FSROOT_DIR) -V "MODULETEST"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(FSIMG_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(DRIVER_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(FSIMG_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(DRIVER_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
 else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
 # Make sure that the NuttX gencromfs tool has been built
@@ -95,9 +95,9 @@ else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
 $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
 	$(Q) $(MAKE) -C $(NXTOOLDIR) -f Makefile.host $(GENCROMFSEXE)
 
-# Create the cromfs.h header file from the populated cromfs directory
+# Create the cromfs.c file from the populated cromfs directory
 
-$(FSIMG_HDR): install $(NXTOOLDIR)/$(GENCROMFSEXE)
+$(FSIMG_SRC): install $(NXTOOLDIR)/$(GENCROMFSEXE)
 	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
@@ -120,5 +120,5 @@ endif
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(ALL_SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(FSIMG_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(FSIMG_SRC) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(FSROOT_DIR)

--- a/examples/module/module_main.c
+++ b/examples/module/module_main.c
@@ -122,7 +122,7 @@
  * Private data
  ****************************************************************************/
 
-static const char g_write_string[] = "Hi there, installed driver\n";
+static const char g_write_string[] = "Hi there installed driver\n";
 
 /****************************************************************************
  * Symbols from Auto-Generated Code
@@ -196,7 +196,9 @@ int main(int argc, FAR char *argv[])
                          NSECTORS(romfs_img_len), SECTORSIZE);
   if (ret < 0)
     {
-      /* This will happen naturally if we registered the ROM disk previously. */
+      /* This will happen naturally if we registered the ROM disk
+       * previously.
+       */
 
       if (ret != -EEXIST)
         {

--- a/examples/module/module_main.c
+++ b/examples/module/module_main.c
@@ -59,9 +59,6 @@
 
 #if  defined(CONFIG_EXAMPLES_MODULE_ROMFS)
 #  include <nuttx/drivers/ramdisk.h>
-#  include "drivers/romfs.h"
-#elif defined(CONFIG_EXAMPLES_MODULE_CROMFS)
-#  include "drivers/cromfs.h"
 #endif
 
 /****************************************************************************
@@ -130,6 +127,11 @@ static const char g_write_string[] = "Hi there, installed driver\n";
 /****************************************************************************
  * Symbols from Auto-Generated Code
  ****************************************************************************/
+
+#if defined(CONFIG_EXAMPLES_MODULE_ROMFS) || defined(CONFIG_EXAMPLES_MODULE_CROMFS)
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+#endif
 
 #ifdef CONFIG_BUILD_FLAT
 extern const struct symtab_s g_mod_exports[];

--- a/examples/nxflat/Makefile
+++ b/examples/nxflat/Makefile
@@ -37,6 +37,9 @@
 
 # NXFLAT Example
 
+CSRCS = romfs.c
+CSRCS += dirlist.c
+CSRCS += symtab.c
 MAINSRC = nxflat_main.c
 
 PROGNAME = nxflat
@@ -44,7 +47,9 @@ PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
 MODULE = $(CONFIG_EXAMPLES_NXFLAT)
 
-nxflat_main.c: build
+tests/romfs.c: build
+tests/dirlist.c: build
+tests/symtab.c: build
 
 .PHONY: build
 build:

--- a/examples/nxflat/nxflat_main.c
+++ b/examples/nxflat/nxflat_main.c
@@ -53,10 +53,6 @@
 #include <nuttx/drivers/ramdisk.h>
 #include <nuttx/binfmt/binfmt.h>
 
-#include "tests/romfs.h"
-#include "tests/dirlist.h"
-#include "tests/symtab.h"
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -118,6 +114,18 @@ static const char delimiter[] =
 #ifndef CONFIG_LIB_ENVPATH
 static char fullpath[128];
 #endif
+
+/****************************************************************************
+ * Symbols from Auto-Generated Code
+ ****************************************************************************/
+
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+
+extern const char *dirlist[];
+
+extern const struct symtab_s g_nxflat_exports[];
+extern const int g_nxflat_nexports;
 
 /****************************************************************************
  * Private Functions
@@ -213,7 +221,7 @@ int main(int argc, FAR char *argv[])
        */
 
       args[0] = NULL;
-      ret = exec(filename, args, g_nxflat_exports, NEXPORTS);
+      ret = exec(filename, args, g_nxflat_exports, g_nxflat_nexports);
       if (ret < 0)
         {
           errmsg("ERROR: exec(%s) failed: %d\n", dirlist[i], errno);

--- a/examples/nxflat/tests/.gitignore
+++ b/examples/nxflat/tests/.gitignore
@@ -1,5 +1,5 @@
 /romfs
-/romfs.h
+/romfs.c
 /romfs.img
-/dirlist.h
-/symtab.h
+/dirlist.c
+/symtab.c

--- a/examples/nxflat/tests/Makefile
+++ b/examples/nxflat/tests/Makefile
@@ -49,16 +49,16 @@ NXFLAT_DIR	= $(APPDIR)/examples/nxflat
 TESTS_DIR	= $(NXFLAT_DIR)/tests
 ROMFS_DIR	= $(TESTS_DIR)/romfs
 ROMFS_IMG	= $(TESTS_DIR)/romfs.img
-ROMFS_HDR	= $(TESTS_DIR)/romfs.h
-ROMFS_DIRLIST	= $(TESTS_DIR)/dirlist.h
-SYMTAB		= $(TESTS_DIR)/symtab.h
+ROMFS_SRC	= $(TESTS_DIR)/romfs.c
+DIRLIST_SRC	= $(TESTS_DIR)/dirlist.h
+SYMTAB_SRC	= $(TESTS_DIR)/symtab.c
 
 define DIR_template
 $(1)_$(2):
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(ROMFS_HDR) $(ROMFS_DIRLIST) $(SYMTAB)
+all: $(ROMFS_SRC) $(DIRLIST_SRC) $(SYMTAB_SRC)
 .PHONY: all clean install
 
 $(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
@@ -74,25 +74,25 @@ $(ROMFS_IMG): install
 	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "NXFLATTEST"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(ROMFS_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
 # Create the dirlist.h header file from the romfs directory
 
-$(ROMFS_DIRLIST): install
+$(DIRLIST_SRC): install
 	$(Q) $(TESTS_DIR)/mkdirlist.sh $(ROMFS_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Create the exported symbol table list from the derived *-thunk.S files
 
-$(SYMTAB): install
+$(SYMTAB_SRC): install
 	$(Q) $(TESTS_DIR)/mksymtab.sh $(ROMFS_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(ROMFS_HDR) $(ROMFS_DIRLIST) $(ROMFS_IMG) $(SYMTAB)
+	$(Q) rm -f $(ROMFS_SRC) $(DIRLIST_SRC) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(ROMFS_DIR)

--- a/examples/nxflat/tests/mkdirlist.sh
+++ b/examples/nxflat/tests/mkdirlist.sh
@@ -17,8 +17,7 @@ if [ ! -d "$dir" ]; then
 	exit 1
 fi
 
-echo "#ifndef __EXAMPLES_NXFLAT_TESTS_DIRLIST_H"
-echo "#define __EXAMPLES_NXFLAT_TESTS_DIRLIST_H"
+echo "#include <stddef.h>"
 echo ""
 echo "static const char *dirlist[] ="
 echo "{"
@@ -29,5 +28,3 @@ done
 
 echo "  NULL"
 echo "};"
-echo ""
-echo "#endif /* __EXAMPLES_NXFLAT_TESTS_DIRLIST_H */"

--- a/examples/nxflat/tests/mksymtab.sh
+++ b/examples/nxflat/tests/mksymtab.sh
@@ -19,12 +19,21 @@ fi
 
 varlist=`find $dir -name "*-thunk.S"| xargs grep -h asciz | cut -f3 | sort | uniq`
 
-echo "#ifndef __EXAMPLES_NXFLAT_TESTS_SYMTAB_H"
-echo "#define __EXAMPLES_NXFLAT_TESTS_SYMTAB_H"
-echo ""
+# Now output the symbol table as a structure in a C source file.  All
+# undefined symbols are declared as void* types.  If the toolchain does
+# any kind of checking for function vs. data objects, then this could
+# failed
+
+echo "#include <nuttx/compiler.h>"
 echo "#include <nuttx/symtab.h>"
 echo ""
-echo "static const struct symtab_s g_nxflat_exports[] = "
+
+for var in $varlist; do
+	echo "extern void *${var};"
+done
+
+echo ""
+echo "const struct symtab_s g_nxflat_exports[] = "
 echo "{"
 
 for string in $varlist; do
@@ -33,6 +42,5 @@ for string in $varlist; do
 done
 
 echo "};"
-echo "#define NEXPORTS (sizeof(g_nxflat_exports)/sizeof(struct symtab_s))"
 echo ""
-echo "#endif /* __EXAMPLES_NXFLAT_TESTS_SYMTAB_H */"
+echo "const int g_nxflat_nexports = sizeof(g_nxflat_exports) / sizeof(struct symtab_s);"

--- a/examples/posix_spawn/Makefile
+++ b/examples/posix_spawn/Makefile
@@ -37,7 +37,8 @@
 
 # ELF Example
 
-CSRCS = symtab.c
+CSRCS = romfs.c
+CSRCS += symtab.c
 MAINSRC = spawn_main.c
 
 PROGNAME = posix_spawn
@@ -51,7 +52,7 @@ ROOTDEPPATH	+= --dep-path filesystem
 
 VPATH += filesystem
 
-spawn_main.c: build
+filesystem/romfs.c: build
 filesystem/symtab.c: build
 
 .PHONY: build

--- a/examples/posix_spawn/filesystem/.gitignore
+++ b/examples/posix_spawn/filesystem/.gitignore
@@ -1,4 +1,4 @@
 /romfs
-/romfs.h
+/romfs.c
 /romfs.img
 /symtab.c

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -39,10 +39,10 @@ SPAWN_DIR = $(APPDIR)$(DELIM)examples$(DELIM)posix_spawn
 FILESYSTEM_DIR = $(SPAWN_DIR)$(DELIM)filesystem
 ROMFS_DIR = $(FILESYSTEM_DIR)$(DELIM)romfs
 ROMFS_IMG = $(FILESYSTEM_DIR)$(DELIM)romfs.img
-ROMFS_HDR = $(FILESYSTEM_DIR)$(DELIM)romfs.h
+ROMFS_SRC = $(FILESYSTEM_DIR)$(DELIM)romfs.c
 SYMTAB_SRC = $(FILESYSTEM_DIR)$(DELIM)symtab.c
 
-all: $(ROMFS_HDR) $(SYMTAB_SRC)
+all: $(ROMFS_SRC) $(SYMTAB_SRC)
 .PHONY: all hello/hello redirect/redirect clean
 
 # Build the hello test program
@@ -65,10 +65,10 @@ $(ROMFS_IMG): hello/hello redirect/redirect testdata.txt
 	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "POSIXSPAWN"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(ROMFS_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(FILESYSTEM_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(FILESYSTEM_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
 # Create the exported symbol table
 
@@ -81,5 +81,5 @@ $(SYMTAB_SRC): $(ROMFS_IMG)
 clean:
 	$(Q) $(MAKE) -C hello clean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)"
 	$(Q) $(MAKE) -C redirect clean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" ROMFS_DIR="$(ROMFS_DIR)"
-	$(Q) rm -f $(ROMFS_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(ROMFS_SRC) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(ROMFS_DIR)

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -40,8 +40,6 @@
 #include <nuttx/drivers/ramdisk.h>
 #include <nuttx/symtab.h>
 
-#include "filesystem/romfs.h"
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -132,6 +130,9 @@ static char * const g_argv[4] =
 /****************************************************************************
  * Symbols from Auto-Generated Code
  ****************************************************************************/
+
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
 
 extern const struct symtab_s g_spawn_exports[];
 extern const int g_spawn_nexports;

--- a/examples/sotest/Makefile
+++ b/examples/sotest/Makefile
@@ -47,7 +47,10 @@ MODULE = $(CONFIG_EXAMPLES_SOTEST)
 
 # Shared Library Example
 
-CSRCS = sot_symtab.c
+ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
+CSRCS = romfs.c
+endif
+CSRCS += sot_symtab.c
 MAINSRC = sotest_main.c
 
 ROOTDEPPATH += --dep-path lib
@@ -56,7 +59,9 @@ ROOTDEPPATH += --dep-path lib
 
 VPATH = lib
 
-sotest_main.c: build
+ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
+lib/romfs.c: build
+endif
 lib/sot_symtab.c: build
 
 .PHONY: build

--- a/examples/sotest/lib/.gitignore
+++ b/examples/sotest/lib/.gitignore
@@ -1,4 +1,4 @@
 /fsroot
-/romfs.h
+/romfs.c
 /romfs.img
 /sot_symtab.c

--- a/examples/sotest/lib/Makefile
+++ b/examples/sotest/lib/Makefile
@@ -50,7 +50,7 @@ SYMTAB_SRC = $(LIB_DIR)/sot_symtab.c
 
 ifeq ($(CONFIG_EXAMPLES_SOTEST_BUILTINFS),y)
   ROMFS_IMG = $(LIB_DIR)/romfs.img
-  ROMFS_HDR = $(LIB_DIR)/romfs.h
+  ROMFS_SRC = $(LIB_DIR)/romfs.c
 endif
 
 define DIR_template
@@ -58,7 +58,7 @@ $(1)_$(2):
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" FSROOT_DIR="$(FSROOT_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: $(ROMFS_HDR) $(SYMTAB_SRC)
+all: $(ROMFS_SRC) $(SYMTAB_SRC)
 .PHONY: all clean install
 
 $(foreach DIR, $(ALL_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
@@ -75,10 +75,10 @@ $(ROMFS_IMG): install
 	$(Q) genromfs -f $@.tmp -d $(FSROOT_DIR) -V "SOTESTTEST"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(ROMFS_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(LIB_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(LIB_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 endif
 
 # Create the exported symbol table
@@ -90,5 +90,5 @@ $(SYMTAB_SRC): install
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(ALL_SUBDIRS), $(DIR)_clean)
-	$(Q) rm -f $(ROMFS_HDR) $(ROMFS_IMG) $(SYMTAB_SRC)
+	$(Q) rm -f $(ROMFS_SRC) $(ROMFS_IMG) $(SYMTAB_SRC)
 	$(Q) rm -rf $(FSROOT_DIR)

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -55,7 +55,6 @@
 
 #ifdef CONFIG_EXAMPLES_SOTEST_BUILTINFS
 #  include <nuttx/drivers/ramdisk.h>
-#  include "lib/romfs.h"
 #endif
 
 /****************************************************************************
@@ -99,6 +98,11 @@
 /****************************************************************************
  * Symbols from Auto-Generated Code
  ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_SOTEST_BUILTINFS
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+#endif
 
 extern const struct symtab_s g_sot_exports[];
 extern const int g_sot_nexports;

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -145,7 +145,9 @@ int main(int argc, FAR char *argv[])
                          NSECTORS(romfs_img_len), SECTORSIZE);
   if (ret < 0)
     {
-      /* This will happen naturally if we registered the ROM disk previously. */
+      /* This will happen naturally if we registered the ROM disk
+       * previously.
+       */
 
       if (ret != -EEXIST)
         {
@@ -257,7 +259,9 @@ int main(int argc, FAR char *argv[])
   testfunc(msg);
 
 #if CONFIG_MODLIB_MAXDEPEND > 0
-  /* This should fail because the second shared library depends on the first. */
+  /* This should fail because the second shared library depends on
+   * the first.
+   */
 
   ret = dlclose(handle1);
   if (ret == 0)

--- a/examples/thttpd/Makefile
+++ b/examples/thttpd/Makefile
@@ -37,6 +37,7 @@
 
 # THTTPD Web Server Example
 
+CSRCS = romfs.c
 MAINSRC = thttpd_main.c
 
 CONTENT_MAKE = $(MAKE) -C content
@@ -44,6 +45,7 @@ ifeq ($(CONFIG_THTTPD_BINFS),y)
   CONTENT_MAKE += -f Makefile.binfs
 else
   CONTENT_MAKE += -f Makefile.nxflat
+  CSRCS += symtab.c
 endif
 
 PROGNAME = thttp
@@ -51,7 +53,13 @@ PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
 MODULE = $(CONFIG_EXAMPLES_THTTPD)
 
-thttpd_main.c: build
+VPATH += content
+ROOTDEPPATH += --dep-path content
+
+content/romfs.c: build
+ifeq ($(CONFIG_THTTPD_NXFLAT),y)
+content/symtab.c: build
+endif
 
 .PHONY: build
 build:

--- a/examples/thttpd/content/.gitignore
+++ b/examples/thttpd/content/.gitignore
@@ -10,6 +10,6 @@
 /*.lib
 /*.src
 /romfs
-/romfs.h
+/romfs.c
 /romfs.img
-/symtab.h
+/symtab.c

--- a/examples/thttpd/content/Makefile.binfs
+++ b/examples/thttpd/content/Makefile.binfs
@@ -50,7 +50,7 @@ THTTPD_DIR = $(APPDIR)/examples/thttpd
 CONTENT_DIR = $(THTTPD_DIR)/content
 ROMFS_DIR = $(CONTENT_DIR)/romfs
 ROMFS_IMG = $(CONTENT_DIR)/romfs.img
-ROMFS_HDR = $(CONTENT_DIR)/romfs.h
+ROMFS_SRC = $(CONTENT_DIR)/romfs.c
 
 # Populate the romfs directory
 
@@ -67,14 +67,14 @@ $(ROMFS_DIR)/style.css : $(CONTENT_DIR)/style.css
 $(ROMFS_IMG): $(ROMFS_DIR)/index.html $(ROMFS_DIR)/style.css
 	$(Q) genromfs -f $@ -d $(ROMFS_DIR) -V "THTTPDTEST"
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(ROMFS_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
-all:: $(ROMFS_HDR)
+all:: $(ROMFS_SRC)
 
 clean::
-	$(call DELFILE, $(ROMFS_HDR))
+	$(call DELFILE, $(ROMFS_SRC))
 	$(call DELFILE, $(ROMFS_IMG))
 	$(Q) rm -rf $(ROMFS_DIR)

--- a/examples/thttpd/content/Makefile.nxflat
+++ b/examples/thttpd/content/Makefile.nxflat
@@ -40,16 +40,16 @@ THTTPD_DIR = $(APPDIR)/examples/thttpd
 CONTENT_DIR = $(THTTPD_DIR)/content
 ROMFS_DIR = $(CONTENT_DIR)/romfs
 ROMFS_IMG = $(CONTENT_DIR)/romfs.img
-ROMFS_HDR = $(CONTENT_DIR)/romfs.h
+ROMFS_SRC = $(CONTENT_DIR)/romfs.c
 ROMFSCGI_DIR = $(ROMFS_DIR)/cgi-bin
-SYMTAB = $(CONTENT_DIR)/symtab.h
+SYMTAB_SRC = $(CONTENT_DIR)/symtab.c
 
 define DIR_template
 $(1)_$(2):
 	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV) CGI_DIR="$(ROMFSCGI_DIR)"
 endef
 
-all: $(ROMFS_HDR) $(SYMTAB)
+all: $(ROMFS_SRC) $(SYMTAB_SRC)
 .PHONY: all clean distclean install context depend
 
 $(foreach DIR, $(SUBDIRS), $(eval $(call DIR_template,$(DIR),clean)))
@@ -68,14 +68,14 @@ $(ROMFS_IMG): install
 	$(Q) genromfs -f $@.tmp -d $(ROMFS_DIR) -V "THTTPDTEST"
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
-# Create the romfs.h header file from the romfs.img file
+# Create the romfs.c file from the romfs.img file
 
-$(ROMFS_HDR): $(ROMFS_IMG)
-	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/static const unsigned/g" >$@)
+$(ROMFS_SRC): $(ROMFS_IMG)
+	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
 
 # Create the exported symbol table list from the derived *-thunk.S files
 
-$(SYMTAB): install
+$(SYMTAB_SRC): install
 	$(Q) $(CONTENT_DIR)/mksymtab.sh $(CONTENT_DIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
@@ -86,9 +86,9 @@ context:
 # Clean each subdirectory
 
 clean: $(foreach DIR, $(SUBDIRS), $(DIR)_clean)
-	$(call DELFILE, $(ROMFS_HDR))
+	$(call DELFILE, $(ROMFS_SRC))
 	$(call DELFILE, $(ROMFS_IMG))
-	$(call DELFILE, $(SYMTAB))
+	$(call DELFILE, $(SYMTAB_SRC))
 	$(Q) rm -rf $(ROMFS_DIR)
 
 distclean: clean

--- a/examples/thttpd/content/mksymtab.sh
+++ b/examples/thttpd/content/mksymtab.sh
@@ -19,12 +19,21 @@ fi
 
 varlist=`find $dir -name "*-thunk.S"| xargs grep -h asciz | cut -f3 | sort | uniq`
 
-echo "#ifndef __EXAMPLES_NXFLAT_TESTS_SYMTAB_H"
-echo "#define __EXAMPLES_NXFLAT_TESTS_SYMTAB_H"
-echo ""
+# Now output the symbol table as a structure in a C source file.  All
+# undefined symbols are declared as void* types.  If the toolchain does
+# any kind of checking for function vs. data objects, then this could
+# failed
+
+echo "#include <nuttx/compiler.h>"
 echo "#include <nuttx/symtab.h>"
 echo ""
-echo "static const struct symtab_s g_thttpd_exports[] = "
+
+for var in $varlist; do
+	echo "extern void *${var};"
+done
+
+echo ""
+echo "const struct symtab_s g_thttpd_exports[] = "
 echo "{"
 
 for string in $varlist; do
@@ -33,6 +42,4 @@ for string in $varlist; do
 done
 
 echo "};"
-echo "#define NEXPORTS (sizeof(g_thttpd_exports)/sizeof(struct symtab_s))"
-echo ""
-echo "#endif /* __EXAMPLES_NXFLAT_TESTS_SYMTAB_H */"
+echo "const int g_thttpd_nexports = sizeof(g_thttpd_exports) / sizeof(struct symtab_s);"

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -67,12 +67,6 @@
 #  include <nuttx/net/net.h>
 #endif
 
-#include "content/romfs.h"
-
-#ifdef CONFIG_THTTPD_NXFLAT
-#  include "content/symtab.h"
-#endif
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -180,6 +174,18 @@
 
 FAR const struct symtab_s *g_thttpdsymtab;
 int                         g_thttpdnsymbols;
+#endif
+
+/****************************************************************************
+ * Symbols from Auto-Generated Code
+ ****************************************************************************/
+
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+
+#ifdef CONFIG_THTTPD_FLAT
+extern const struct symtab_s g_thttpd_exports[];
+extern const int g_thttpd_nexports;
 #endif
 
 /****************************************************************************
@@ -296,7 +302,7 @@ int main(int argc, FAR char *argv[])
 
 #ifdef CONFIG_THTTPD_NXFLAT
   g_thttpdsymtab   = g_thttpd_exports;
-  g_thttpdnsymbols = NEXPORTS;
+  g_thttpdnsymbols = g_thttpd_nexports;
 #endif
 
   printf("Starting THTTPD\n");

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -110,13 +110,13 @@
 /* Ethernet specific configuration */
 
 #ifdef CONFIG_NET_ETHERNET
-   /* Use the standard Ethernet device name */
+/* Use the standard Ethernet device name */
 
 #  define NET_DEVNAME "eth0"
 
 #else
 
-   /* No Ethernet -> No MAC address operations */
+/* No Ethernet -> No MAC address operations */
 
 #  undef CONFIG_EXAMPLES_THTTPD_NOMAC
 #endif
@@ -125,7 +125,7 @@
 
 #ifdef CONFIG_NET_SLIP
 
-   /* TTY device to use */
+/* TTY device to use */
 
 #  ifndef CONFIG_NET_SLIPTTY
 #    define CONFIG_NET_SLIPTTY "/dev/ttyS1"
@@ -216,7 +216,7 @@ int main(int argc, FAR char *argv[])
     }
 #endif
 
-/* Many embedded network interfaces must have a software assigned MAC */
+  /* Many embedded network interfaces must have a software assigned MAC */
 
 #ifdef CONFIG_EXAMPLES_THTTPD_NOMAC
   printf("Assigning MAC\n");
@@ -256,7 +256,8 @@ int main(int argc, FAR char *argv[])
 
   printf("Registering romdisk\n");
 
-  ret = romdisk_register(0, (uint8_t*)romfs_img, NSECTORS(romfs_img_len), SECTORSIZE);
+  ret = romdisk_register(0, (uint8_t *)romfs_img, NSECTORS(romfs_img_len),
+                         SECTORSIZE);
   if (ret < 0)
     {
       printf("ERROR: romdisk_register failed: %d\n", ret);
@@ -283,22 +284,26 @@ int main(int argc, FAR char *argv[])
   ret = mount(NULL, BINFS_MOUNTPT, "binfs", MS_RDONLY, NULL);
   if (ret < 0)
     {
-      printf("ERROR: mount(NULL,%s,binfs) failed: %d\n", BINFS_MOUNTPT, errno);
+      printf("ERROR: mount(NULL,%s,binfs) failed: %d\n",
+             BINFS_MOUNTPT, errno);
     }
 
   /* Now create and mount the union file system */
 
   printf("Creating UNIONFS filesystem at %s\n", UNIONFS_MOUNTPT);
 
-  ret = unionfs_mount(ROMFS_MOUNTPT, ROMFS_PREFIX, BINFS_MOUNTPT, BINFS_PREFIX,
-                      UNIONFS_MOUNTPT);
+  ret = unionfs_mount(ROMFS_MOUNTPT, ROMFS_PREFIX, BINFS_MOUNTPT,
+                      BINFS_PREFIX, UNIONFS_MOUNTPT);
   if (ret < 0)
     {
-      printf("ERROR: Failed to create the union file system at %s: %d\n", UNIONFS_MOUNTPT, ret);
+      printf("ERROR: Failed to create the union file system at %s: %d\n",
+             UNIONFS_MOUNTPT, ret);
     }
 #endif
 
-  /* Start THTTPD.  At present, symbol table info is passed via global variables */
+  /* Start THTTPD.  At present, symbol table info is passed via
+   * global variables.
+   */
 
 #ifdef CONFIG_THTTPD_NXFLAT
   g_thttpdsymtab   = g_thttpd_exports;


### PR DESCRIPTION
## Summary
Update make dependency for elf/module/nxflat/posix_spawn/sotest/thttpd examples which make use of mksymtab.sh. This could avoid them built twice in 'make depend' and 'make all' which would result in file truncated build break. Now only build once by 'make all'.

## Impact

## Testing
Pass local nightly build

