### PR TITLE
system/netdb/netdb_main.c: Eliminate a warning when CONFIG_NETDB_HOSTFILE is not set.

### DIFF
--- a/system/netdb/netdb_main.c
+++ b/system/netdb/netdb_main.c
@@ -78,7 +78,8 @@
  * Private Functions
  ****************************************************************************/
 
-static void show_usage(FAR const char *progname, int exitcode) noreturn_function;
+static void show_usage(FAR const char *progname,
+                       int exitcode) noreturn_function;
 static void show_usage(FAR const char *progname, int exitcode)
 {
   fprintf(stderr, "USAGE: %s --ipv4 <ipv4-addr>\n", progname);
@@ -99,7 +100,10 @@ int main(int argc, FAR char *argv[])
   FAR struct hostent *host;
   FAR const char *addrtype;
   char buffer[48];
+#ifdef HAVE_GETHOSTBYADDR
+  struct in_addr addr;
   int ret;
+#endif
 
   /* Handle: netdb --help */
 
@@ -108,7 +112,9 @@ int main(int argc, FAR char *argv[])
       show_usage(argv[0], EXIT_SUCCESS);
     }
 
-  /* Otherwise there must be exactly two arguments following the program name */
+  /* Otherwise there must be exactly two arguments following the program
+   * name
+   */
 
   else if (argc < 3)
     {
@@ -126,8 +132,6 @@ int main(int argc, FAR char *argv[])
 
   else if (strcmp(argv[1], "--ipv4") == 0)
     {
-      struct in_addr addr;
-
       /* Convert the address to binary */
 
       ret = inet_pton(AF_INET, argv[2], &addr);
@@ -152,8 +156,6 @@ int main(int argc, FAR char *argv[])
 
   else if (strcmp(argv[1], "--ipv6") == 0)
     {
-      struct in_addr addr;
-
       /* Convert the address to binary */
 
       ret = inet_pton(AF_INET6, argv[2], &addr);
@@ -203,6 +205,7 @@ int main(int argc, FAR char *argv[])
    */
 
   /* Convert the address to a string */
+
   /* Handle IPv4 addresses */
 
   if (host->h_addrtype == AF_INET)
@@ -237,9 +240,10 @@ int main(int argc, FAR char *argv[])
 
   else
     {
-       fprintf(stderr, "ERROR -- gethostbyname address type %d  not recognized.\n\n",
-               host->h_addrtype);
-       return EXIT_FAILURE;
+      fprintf(stderr,
+              "ERROR -- gethostbyname address type %d not recognized.\n\n",
+              host->h_addrtype);
+      return EXIT_FAILURE;
     }
 
   /* Print the host name / address mapping */


### PR DESCRIPTION
##  Summary
Eliminate a simple "variable unused" warning.

## Impact

## Testing

