### PR TITLE
tools/mksymtab.sh: suppress 'find apps/bin' No such file or directory error msg

### DIFF
--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -63,7 +63,7 @@ rm -f $outfile
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
 
-execlist=`find ${dir} -type f`
+execlist=`find ${dir} -type f 2>/dev/null`
 if [ ! -z "${execlist}" ]; then
   for exec in ${execlist}; do
     nm $exec | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2  >>_tmplist


### PR DESCRIPTION
## Summary
Suppress apache nightly build find error msg as below:
find: '/home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/apps/bin': No such file or directory

## Impact

## Testing

