### PR TITLE
wireless: gs2200m: Fix to receive a big packet

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -865,7 +865,9 @@ static int recvfrom_request(int fd, FAR struct gs2200m_s *priv,
     }
 
   memset(&rmsg, 0, sizeof(rmsg));
-  rmsg.buf = calloc(1, 1500);
+  rmsg.buf = calloc(1, req->max_buflen);
+  ASSERT(rmsg.buf);
+
   rmsg.cid = usock->cid;
   rmsg.reqlen = req->max_buflen;
   rmsg.is_tcp = (usock->type == SOCK_STREAM) ? true : false;


### PR DESCRIPTION
## Summary

- This PR fixes hardfault when read()/recvfrom() are called with length which is greater than 1500.
- Now it allocates a memory with requested size.

## Impact

- This PR only affects gs2200m daemon. More specifically read()/recvfrom() are called from application.

## Testing

- I tested this PR with wget on spresense:wifi by changing read size from 512 to 4096 in nsh_netcmds.c
