### PR TITLE
nsh/parse: Try FILE_APPS first in the case of builtin

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -182,17 +182,12 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
     }
 
 #ifdef CONFIG_LIBC_EXECFUNCS
-  /* A NULL entry point implies that the task is a loadable application */
+  /* Load and execute the application. */
 
-  if (builtin->main == NULL)
-    {
-      /* Load and execute the application. */
+  ret = posix_spawn(&pid, builtin->name, &file_actions, &attr,
+                    (argv) ? &argv[1] : (FAR char * const *)NULL, NULL);
 
-      ret = posix_spawn(&pid, builtin->name, &file_actions,
-                        &attr, (argv) ? &argv[1] : (FAR char * const *)NULL,
-                        NULL);
-    }
-  else
+  if (ret != 0 && builtin->main != NULL)
 #endif
     {
       /* Start the built-in */

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -507,48 +507,11 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
    * 4. If not, report that the command was not found.
    */
 
-  /* Does this command correspond to an application filename?
-   * nsh_fileapp() returns:
-   *
-   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could
-   *               not be started (possibly because it does not exist).
-   *    0 (OK)     if the application task corresponding to 'argv[0]' was
-   *               and successfully started.  If CONFIG_SCHED_WAITPID is
-   *               defined, this return value also indicates that the
-   *               application returned successful status (EXIT_SUCCESS)
-   *    1          If CONFIG_SCHED_WAITPID is defined, then this return value
-   *               indicates that the application task was spawned
-   *               successfully but returned failure exit status.
-   *
-   * Note the priority is not effected by nice-ness.
-   */
-
-#ifdef CONFIG_NSH_FILE_APPS
-  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile, oflags);
-  if (ret >= 0)
-    {
-      /* nsh_fileapp() returned 0 or 1.  This means that the built-in
-       * command was successfully started (although it may not have ran
-       * successfully).  So certainly it is not an NSH command.
-       */
-
-      /* Save the result:  success if 0; failure if 1 */
-
-      return nsh_saveresult(vtbl, ret != OK);
-    }
-
-  /* No, not a file name command (or, at least, we were unable to start a
-   * program of that name).  Maybe it is a built-in application or an NSH
-   * command.
-   */
-
-#endif
-
   /* Does this command correspond to a built-in command?
    * nsh_builtin() returns:
    *
    *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could
-   *               not be started (possibly because it doesn not exist).
+   *               not be started (possibly because it does not exist).
    *    0 (OK)     if the application task corresponding to 'argv[0]' was
    *               and successfully started.  If CONFIG_SCHED_WAITPID is
    *               defined, this return value also indicates that the
@@ -579,7 +542,44 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     }
 
   /* No, not a built in command (or, at least, we were unable to start a
-   * built-in command of that name).  Treat it like an NSH command.
+   * built-in command of that name). Maybe it is a built-in application
+   * or an NSH command.
+   */
+
+#endif
+
+  /* Does this command correspond to an application filename?
+   * nsh_fileapp() returns:
+   *
+   *   -1 (ERROR)  if the application task corresponding to 'argv[0]' could
+   *               not be started (possibly because it doesn not exist).
+   *    0 (OK)     if the application task corresponding to 'argv[0]' was
+   *               and successfully started.  If CONFIG_SCHED_WAITPID is
+   *               defined, this return value also indicates that the
+   *               application returned successful status (EXIT_SUCCESS)
+   *    1          If CONFIG_SCHED_WAITPID is defined, then this return value
+   *               indicates that the application task was spawned
+   *               successfully but returned failure exit status.
+   *
+   * Note the priority is not effected by nice-ness.
+   */
+
+#ifdef CONFIG_NSH_FILE_APPS
+  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile, oflags);
+  if (ret >= 0)
+    {
+      /* nsh_fileapp() returned 0 or 1.  This means that the built-in
+       * command was successfully started (although it may not have ran
+       * successfully).  So certainly it is not an NSH command.
+       */
+
+      /* Save the result:  success if 0; failure if 1 */
+
+      return nsh_saveresult(vtbl, ret != OK);
+    }
+
+  /* No, not a file name command (or, at least, we were unable to start a
+   * program of that name). Treat it like an NSH command.
    */
 
 #endif


### PR DESCRIPTION
## Summary
nsh/parse: Try FILE_APPS first in the case of builtin
Bring back the BUILTIN_APPS / FILE_APPS calling sequence

