### PR TITLE
nshlib: Introduce CONFIG_NSH_WGET_BUFF_SIZE

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -1121,6 +1121,14 @@ config NSH_NETINIT
 	---help---
 		This option enables/disables all network initialization in NSH.
 
+if !NSH_DISABLE_WGET
+config NSH_WGET_BUFF_SIZE
+	int "wget buffer size"
+	default 512
+	---help---
+		Buffer size for wget command
+endif # NSH_DISABLE_WGET
+
 endmenu # Networking Configuration"
 
 menu "Telnet Configuration"

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -1345,7 +1345,7 @@ int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   /* Allocate an I/O buffer */
 
-  buffer = malloc(512);
+  buffer = malloc(CONFIG_NSH_WGET_BUFF_SIZE);
   if (buffer == NULL)
     {
       fmt = g_fmtcmdoutofmemory;
@@ -1354,7 +1354,8 @@ int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   /* And perform the wget */
 
-  ret = wget(url, buffer, 512, wget_callback, (FAR void *)((intptr_t)fd));
+  ret = wget(url, buffer, CONFIG_NSH_WGET_BUFF_SIZE,
+             wget_callback, (FAR void *)((intptr_t)fd));
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, argv[0], "wget", NSH_ERRNO);


### PR DESCRIPTION
##Summary

- This PR introduces CONFIG_NSH_WGET_BUFF_SIZE to customize the buffer size for wget command.

## Impact

- This PR only affects wget command for nsh.

## Testing

- I tested this PR with spresense:wifi

