### PR TITLE
system: nxplayer: Introduce max host and file name for http url

### DIFF
--- a/system/nxplayer/Kconfig
+++ b/system/nxplayer/Kconfig
@@ -129,3 +129,15 @@ config NXPLAYER_HTTP_STREAMING_SUPPORT
 		audio streaming as well as local file playback.
 
 endif
+
+if NXPLAYER_HTTP_STREAMING_SUPPORT
+
+config NXPLAYER_HTTP_MAXHOSTNAME
+	int "Max host name in URL"
+	default 40
+
+config NXPLAYER_HTTP_MAXFILENAME
+	int "Max file name in URL"
+	default 100
+
+endif

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -171,8 +171,8 @@ static const int g_known_ext_count = sizeof(g_known_ext) /
 
 static int _open_with_http(const char *fullurl)
 {
-  char relurl[32];
-  char hostname[32];
+  char relurl[CONFIG_NXPLAYER_HTTP_MAXFILENAME];
+  char hostname[CONFIG_NXPLAYER_HTTP_MAXHOSTNAME];
   int  resp_chk = 0;
   char resp_msg[] = "\r\n\r\n";
   struct timeval tv;


### PR DESCRIPTION
## Summary

- This PR introduces max host and file name for http url in nxplayer.c
- The default values are brought from webclient.h

## Impact

- This PR only affects nxplayer. Specifically in case that http streaming is enabled.

## Testing

- I tested this PR with spresense:wifi 
