### PR TITLE
Application.mk: fix generated empty Make.dep for SRCS with VPATH

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -220,11 +220,11 @@ else
 context::
 endif
 
-.depend: Makefile $(wildcard $(SRCS))
+.depend: Makefile $(SRCS)
 ifeq ($(filter %$(CXXEXT),$(SRCS)),)
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(filter-out Makefile,$^) >Make.dep
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(filter-out Makefile,$(wildcard $^)) >Make.dep
 else
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(filter-out Makefile,$^) >Make.dep
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(filter-out Makefile,$(wildcard $^)) >Make.dep
 endif
 	$(Q) touch $@
 


### PR DESCRIPTION
## Summary
https://github.com/apache/incubator-nuttx-apps/pull/250 resulted in generated empty
Make.dep for SRCS with VPATH.

## Impact

## Testing
Test with sim:nsh config for apps/platform with board VPATH
