### PR TITLE
build: Remove some duplicated definitions

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -79,19 +79,6 @@ else
   MKKCONFIG ?= $(APPDIR)$(DELIM)tools$(DELIM)mkkconfig.sh
 endif
 
-# Invoke make
-
-define MAKE_template
-	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
-
-endef
-
-define SDIR_template
-$(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
-
-endef
-
 # Builtin Registration
 
 BUILTIN_REGISTRY = $(APPDIR)$(DELIM)builtin$(DELIM)registry


### PR DESCRIPTION
## Summary
Remove the duplicated MAKE_template and SDIR_template definitions since they go into nuttx/tools/Config.mk in https://github.com/apache/incubator-nuttx/pull/1102. 

## Impact

## Testing
Rerun check jobs once https://github.com/apache/incubator-nuttx/pull/1102 merged.
