### PR TITLE
Application.mk: update .depend dependency for SRCS with VPATH

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -220,11 +220,11 @@ else
 context::
 endif
 
-.depend: Makefile $(SRCS)
+.depend: Makefile $(wildcard $(foreach SRC, $(SRCS), $(addsuffix /$(SRC), $(subst :, ,$(VPATH)))))
 ifeq ($(filter %$(CXXEXT),$(SRCS)),)
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(filter-out Makefile,$(wildcard $^)) >Make.dep
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(filter-out Makefile,$^) >Make.dep
 else
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(filter-out Makefile,$(wildcard $^)) >Make.dep
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(filter-out Makefile,$^) >Make.dep
 endif
 	$(Q) touch $@
 


### PR DESCRIPTION
## Summary
Update .depend dependency for SRCS with VPATH to avoid the generated symtab.c etc trigger built in make depend.

## Impact

## Testing

