### PR TITLE
dhcpc: Don't use an uninitialized variable

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -529,7 +529,9 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
       newaddr.s_addr = INADDR_ANY;
       netlib_set_ipv4addr(pdhcpc->interface, &newaddr);
 
-      /* Loop sending the DISCOVER up to CONFIG_NETUTILS_DHCPC_RETRIES times */
+      /* Loop sending the DISCOVER up to CONFIG_NETUTILS_DHCPC_RETRIES
+       * times
+       */
 
       retries = 0;
 

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -424,7 +424,7 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
       pdhcpc->sockfd = socket(PF_INET, SOCK_DGRAM, 0);
       if (pdhcpc->sockfd < 0)
         {
-          ninfo("socket handle %d\n", ret);
+          ninfo("socket handle %d\n", pdhcpc->sockfd);
           free(pdhcpc);
           return NULL;
         }


### PR DESCRIPTION
## Summary
dhcpc: Don't use an uninitialized variable
## Impact

## Testing

