### PR TITLE
webclient: Fix http -> https redirection

### DIFF
--- a/netutils/webclient/Kconfig
+++ b/netutils/webclient/Kconfig
@@ -9,6 +9,7 @@ config NETUTILS_WEBCLIENT
 	depends on NET_TCP
 	select LIBC_NETDB
 	select NET_SOCKOPTS
+	select NETUTILS_NETLIB_GENERICURLPARSER
 	---help---
 		Enable support for the uIP web client.
 


### PR DESCRIPTION
http -> https redirection is rather common. The old code was
just broken in that case.

Also, this commit is a step towards https support.

* Switch to netlib_parseurl
* Fix error propagation in wget_parseheaders
* Bail out on a redirect to a URL with unsupported scheme

## Summary

## Impact

## Testing

