### PR TITLE
webclient: include string.h for strlen

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -60,6 +60,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <string.h>
 #include <strings.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
Instead of relying on indirect namespace pollutions.

## Summary

## Impact

## Testing

