### PR TITLE
example/thttpd: update Makefile and mksymtab.sh etc to fix build breaks

### DIFF
--- a/examples/thttpd/content/Makefile.nxflat
+++ b/examples/thttpd/content/Makefile.nxflat
@@ -33,6 +33,8 @@
 #
 ############################################################################
 
+include $(TOPDIR)/Make.defs
+
 SUBDIRS = hello tasks
 INSTALL_FILES = index.html style.css
 
@@ -76,7 +78,7 @@ $(ROMFS_SRC): $(ROMFS_IMG)
 # Create the exported symbol table list from the derived *-thunk.S files
 
 $(SYMTAB_SRC): install
-	$(Q) $(APPDIR)$(DELIM)tools$(DELIM)mksymtab.sh $(CONTENT_DIR) g_thttpd >$@.tmp
+	$(Q) $(APPDIR)/tools/mksymtab.sh $(CONTENT_DIR) g_thttpd >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Nothing special needs to be done during the context phase

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -183,7 +183,7 @@ int                         g_thttpdnsymbols;
 extern const unsigned char romfs_img[];
 extern const unsigned int romfs_img_len;
 
-#ifdef CONFIG_THTTPD_FLAT
+#ifdef CONFIG_THTTPD_NXFLAT
 extern const struct symtab_s g_thttpd_exports[];
 extern const int g_thttpd_nexports;
 #endif

--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -72,7 +72,8 @@ echo "#include <nuttx/compiler.h>"
 echo "#include <nuttx/symtab.h>"
 echo ""
 
-for var in $varlist; do
+for string in $varlist; do
+  var=`echo $string | sed -e "s/\"//g"`
   echo "extern void *${var};"
 done
 
@@ -90,7 +91,8 @@ else
 fi
 echo "{"
 
-for var in $varlist; do
+for string in $varlist; do
+  var=`echo $string | sed -e "s/\"//g"`
   echo "  {\"${var}\", &${var}},"
 done
 


### PR DESCRIPTION
## Summary
Update thttpd example Makefile and tools/mksymtab.sh etc to fix build breaks

## Impact

## Testing
Using eagle100:thttpd config which needs buildroot tools to test.
