### PR TITLE
examples/pca9635/pca9635_main.c: Change the brightness sturct's name.

### DIFF
--- a/examples/pca9635/pca9635_main.c
+++ b/examples/pca9635/pca9635_main.c
@@ -68,7 +68,7 @@
 
 int main(int argc, FAR char *argv[])
 {
-  struct pca9635pw_setled_brightness_arg_s ledbright;
+  struct pca9635pw_brightness_s ledbright;
   int led;
   int bright;
   int fd;
@@ -91,10 +91,12 @@ int main(int argc, FAR char *argv[])
               ledbright.led = led;
               ledbright.brightness = bright;
 
-              ret = ioctl(fd, PWMIOC_SETLED_BRIGHTNESS, (unsigned long)&ledbright);
+              ret = ioctl(fd, PWMIOC_SETLED_BRIGHTNESS,
+                          (unsigned long)&ledbright);
               if (ret < 0)
                 {
-                  _err("ERROR: ioctl(PWMIOC_SETLED_BRIGHTNESS) failed: %d\n", errno);
+                  _err("ERROR: ioctl(PWMIOC_SETLED_BRIGHTNESS) failed: %d\n",
+                        errno);
                 }
             }
 


### PR DESCRIPTION
##Summary
The brightness struct name was changed in the OS driver, thus this example needs to follow suit.

## Impact
This impacts only the pca9635 example.

## Testing

