### PR TITLE
LICENSE:  Update with candump

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -374,7 +374,7 @@ apps/testing/scanftest/scanftest_main.c
     3. This notice may not be removed or altered from any source distribution.
 
 apps/webserver
-==================
+==============
 
   This has a license that is mostly compatible the NuttX 3-clause BSD license,
   but includes a fourth clause that required acknowledgement of Adam Dunkels
@@ -412,7 +412,8 @@ apps/webserver
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 apps/examples/lvgldemo
-========
+======================
+
   Derives from the lvgl Project which has an MIT license:
 
      Copyright (C) 2019 Gábor Kiss-Vámosi. All rights reserved.
@@ -440,3 +441,49 @@ apps/examples/lvgldemo
      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
      OTHER DEALINGS IN THE SOFTWARE.
+
+canutils/candump
+================
+
+  Includes five dual licensed third part files from Volkswagon with
+  licensing as follows (Copyright dates vary from file-to-file):
+  
+    SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+
+    Copyright (c) 2002-2009 Volkswagen Group Electronic Research
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Volkswagen nor the names of its contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    Alternatively, provided that this notice is retained in full, this
+    software may be distributed under the terms of the GNU General
+    Public License ("GPL") version 2, in which case the provisions of the
+    GPL apply INSTEAD OF those given above.
+
+    The provided data structures and external interfaces from this code
+    are not restricted to be used by modules with a GPL compatible license.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+
+    Send feedback to <linux-can@vger.kernel.org>


### PR DESCRIPTION
## Summary

apps/canutils/candump includes five third part files from VW that have a dual BSD-3/GPLv2 license.  This commits updates the LICENSE file to indicate this.

## Impact

No functional change

## Testing

N/A
