### PR TITLE
bmp180: enable use for BMP280 as well

### DIFF
--- a/examples/bmp180/Kconfig
+++ b/examples/bmp180/Kconfig
@@ -4,11 +4,11 @@
 #
 
 config EXAMPLES_BMP180
-	tristate "BMP180 Barometer sensor example"
+	tristate "BMP180/280 Barometer sensor example"
 	default n
-	depends on SENSORS_BMP180
+	depends on SENSORS_BMP180 || SENSORS_BMP280
 	---help---
-		Enable the BMP180 example
+		Enable the BMP180/BMP280 example
 
 if EXAMPLES_BMP180
 

--- a/examples/bmp180/bmp180_main.c
+++ b/examples/bmp180/bmp180_main.c
@@ -56,12 +56,13 @@ int main(int argc, FAR char *argv[])
   int ret;
   uint32_t sample;
 
-  fd = open("/dev/press0", O_RDWR);
+  fd = open("/dev/press0", O_RDONLY);
   while (1)
     {
       ret = read(fd, &sample, sizeof(uint32_t));
       if (ret != sizeof(sample))
         {
+          perror("Could not read");
           break;
         }
 


### PR DESCRIPTION
## Summary
Added support for BMP280 sensor to bmp180 app. Probably this app should be named differently eventually. 

## Impact
Only extends support to existing app

## Testing
Using BMP280 sensor on custom board.
