### PR TITLE
Remove the need to have CDCACM enabled for composite app

### DIFF
--- a/system/composite/composite.h
+++ b/system/composite/composite.h
@@ -57,14 +57,6 @@
 #  error "USB composite device support is not enabled (CONFIG_USBDEV_COMPOSITE)"
 #endif
 
-#ifndef CONFIG_CDCACM
-#  error "USB CDC/ACM serial device support is not enabled (CONFIG_CDCACM)"
-#endif
-
-#ifndef CONFIG_CDCACM_COMPOSITE
-#  error "USB CDC/ACM serial composite device support is not enabled (CONFIG_CDCACM_COMPOSITE)"
-#endif
-
 /* Trace initialization *****************************************************/
 
 #ifndef CONFIG_USBDEV_TRACE_INITIALIDSET

--- a/system/composite/composite.h
+++ b/system/composite/composite.h
@@ -46,7 +46,9 @@
 /****************************************************************************
  * Pre-Processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* OS/Driver configuration checks */
 
 #ifndef CONFIG_USBDEV
@@ -138,7 +140,7 @@ struct composite_state_s
 extern struct composite_state_s g_composite;
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 #endif /* __SYSTEM_COMPOSITE_COMPOSITE_H */


### PR DESCRIPTION
## Summary
Composite app does not really need CDCACM driver enabled, it is just the usual case.

## Impact
Extends functionality of composite app to more configurations 

## Testing
Using composite USBDEV different than CDCACM
