### PR TITLE
PTY: add option to wait on serial device

### DIFF
--- a/examples/pty_test/Kconfig
+++ b/examples/pty_test/Kconfig
@@ -40,4 +40,12 @@ config EXAMPLES_PTYTEST_DAEMONPRIO
 	int "PTY_Test daemon task priority"
 	default 100
 
+config EXAMPLES_PTYTEST_WAIT_CONNECTED
+  bool "Keep retrying open serial device"
+  ---help---
+     For USB based serial devices, open will fail
+     if the other end is not connected (USB cable unplugged).
+     Enabling this option will retry the open() call every second
+     until connected.
+
 endif

--- a/examples/pty_test/pty_test.c
+++ b/examples/pty_test/pty_test.c
@@ -394,7 +394,7 @@ int main(int argc, FAR char *argv[])
     {
       /* Nothing to do, then sleep to avoid eating all cpu time */
 
-      usleep(10000);
+      pause();
     }
 
   return EXIT_SUCCESS;

--- a/examples/pty_test/pty_test.c
+++ b/examples/pty_test/pty_test.c
@@ -115,7 +115,7 @@ static void serial_in(struct term_pair_s *tp)
 
   /* Run forever */
 
-  for (;;)
+  while (true)
     {
 #ifdef CONFIG_EXAMPLES_PTYTEST_POLL
       ret = poll((struct pollfd *)&fdp, 1, POLL_TIMEOUT);
@@ -194,7 +194,7 @@ static void serial_out(struct term_pair_s *tp)
 
   /* Run forever */
 
-  for (;;)
+  while (true)
     {
 #ifdef CONFIG_EXAMPLES_PTYTEST_POLL
       ret = poll((struct pollfd *)&fdp, 1, POLL_TIMEOUT);
@@ -320,7 +320,8 @@ int main(int argc, FAR char *argv[])
 
       if (errno == ENOTCONN)
         {
-          fprintf(stderr, "ERROR: device not connected, will continue trying\n");
+          fprintf(stderr, "ERROR: device not connected, will continue"
+                          " trying\n");
         }
 
       while (termpair.fd_uart < 0 && errno == ENOTCONN)
@@ -382,7 +383,8 @@ int main(int argc, FAR char *argv[])
   /* Create a new console using this /dev/pts/N */
 
   pid = task_create("NSH Console", CONFIG_EXAMPLES_PTYTEST_DAEMONPRIO,
-                    CONFIG_EXAMPLES_PTYTEST_STACKSIZE, nsh_consolemain, NULL);
+                    CONFIG_EXAMPLES_PTYTEST_STACKSIZE, nsh_consolemain,
+                    NULL);
   if (pid < 0)
     {
       /* Can't do output because stdout and stderr are redirected */
@@ -416,7 +418,7 @@ int main(int argc, FAR char *argv[])
 
   /* Stay here to keep the threads running */
 
-  for (;;)
+  while (true)
     {
       /* Nothing to do, then sleep to avoid eating all cpu time */
 


### PR DESCRIPTION
## Summary
This change allows the pty app to wait on the underlying serial device to appear. This is useful for the case where this device is actually a USB serial device emulator which may be opened only when the USB cable is plugged. This allows for maintaining the serial console on the hard serial device but to open another console on a USB device on boot (using a boot script which runs "pts").

## Impact
Adds an optional feature.

## Testing
Tested with CDCACM device and an NSH init script calling "conn" (connect composite device) and "pts". With the feature enabled, once the cable is connected the console can be used.
