### PR TITLE
system: nxrecorder: Add O_TRUNC when creating a file

### DIFF
--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -847,7 +847,7 @@ int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
 
   /* Test that the specified file exists */
 
-  if ((precorder->fd = open(pfilename, O_WRONLY | O_CREAT)) == -1)
+  if ((precorder->fd = open(pfilename, O_WRONLY | O_CREAT | O_TRUNC)) == -1)
     {
       /* File not found.  Test if its in the mediadir */
 


### PR DESCRIPTION
## Summary

- This PR lets nxrecorder create a new file with O_TUNC option.

## Impact

- This PR affects nxrecorder only.

## Testing

- I tested this PR with spresense:wifi configuration.

```
nsh> nxrecorder
nxrecorder> device /dev/audio/pcm_in1
nxrecorder> recordraw /mnt/sd0/rec0001.raw
nxrecorder> stop
```
