### PR TITLE
Make programs under apps/bin executable to generate symtab file rightly

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -158,6 +158,7 @@ ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
 else
 	$(call ELFLD,$(firstword $(PROGOBJ)),$(firstword $(PROGLIST)))
 endif
+	$(Q) chmod +x $(firstword $(PROGLIST))
 ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
 	$(Q) $(STRIP) $(firstword $(PROGLIST))
 endif


### PR DESCRIPTION
## Summary
Make programs under apps/bin executable since tools/mksymtab.sh called with
'find $dir -type f -perm -a=x 2>/dev/null'. So generate symtab file rightly.

## Impact

## Testing
Verify with sim:loadable config. Or running nuttx with sim loadable config got stuck.
