### PR TITLE
 apps/makefile/implicit rules: completion the obj path

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -129,9 +129,9 @@ $(CXXOBJS): %$(SUFFIX)$(OBJEXT): %$(CXXEXT)
 
 .built: $(OBJS)
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-	$(call ARLOCK, "${shell cygpath -w $(BIN)}", $(OBJS))
+	$(call ARLOCK, "${shell cygpath -w $(BIN)}", $^)
 else
-	$(call ARLOCK, $(BIN), $(OBJS))
+	$(call ARLOCK, $(BIN), $^)
 endif
 	$(Q) touch $@
 


### PR DESCRIPTION
## Summary
apps/makefile/implicit rules: completion the obj path

## Impact
Depends  on https://github.com/apache/incubator-nuttx/pull/1290

## Testing
```
./tools/configure.sh arty_a7/nsh
make -j16
```

