### PR TITLE
 make/clean: clean the OBJ directly if declare in subdirectory 

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -231,6 +231,7 @@ endif
 depend:: .depend
 
 clean::
+	$(Q) rm -f $(OBJS)
 	$(call DELFILE, .built)
 	$(call CLEAN)
 


### PR DESCRIPTION
## Summary
 make/clean: clean the OBJ directly if declare in subdirectory 

## Impact
Depends on https://github.com/apache/incubator-nuttx/pull/1297

## Testing
make clean

