### PR TITLE
[Backport-307] Revert "nshlib: remove the dependency of date on RTC"

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -259,8 +259,8 @@ config NSH_DISABLE_CMP
 
 config NSH_DISABLE_DATE
 	bool "Disable date"
-	default y if DEFAULT_SMALL
-	default n if !DEFAULT_SMALL
+	default n if RTC
+	default y if !RTC
 
 config NSH_DISABLE_DD
 	bool "Disable dd"


### PR DESCRIPTION
This is a bad change.  It has been show to cause an increase in size by around 2.3Kb in minimal configurations that cannot tolerate that massive size increase.

This is a backport of #307 

