### PR TITLE
cxxtest: Check CONFIG_CXX_EXCEPTION instead of CONFIG_UCLIBCXX_EXCEPTION

### DIFF
--- a/testing/cxxtest/cxxtest_main.cxx
+++ b/testing/cxxtest/cxxtest_main.cxx
@@ -219,7 +219,7 @@ static void test_rtti(void)
 // Name: test_exception
 //***************************************************************************/
 
-#ifdef CONFIG_UCLIBCXX_EXCEPTION
+#ifdef CONFIG_CXX_EXCEPTION
 static void test_exception(void)
 {
   std::cout << "test exception==========================" << std::endl;
@@ -258,7 +258,7 @@ extern "C"
     test_iostream();
     test_stl();
     test_rtti();
-#ifdef CONFIG_UCLIBCXX_EXCEPTION
+#ifdef CONFIG_CXX_EXCEPTION
     test_exception();
 #endif
 


### PR DESCRIPTION

## Summary

cxxtest: Check CONFIG_CXX_EXCEPTION instead of CONFIG_UCLIBCXX_EXCEPTION because the user may use libcxx which just define CONFIG_LIBCXX_EXCEPTION

## Impact
No functionality change.

## Testing

