### PR TITLE
net/sockopt: change the socket option style from Linux to BSD

### DIFF
--- a/examples/mld/mld_main.c
+++ b/examples/mld/mld_main.c
@@ -189,7 +189,7 @@ void mld_catfile(FAR const char *filepath, FAR char **iobuffer)
 
   /* And just dump it byte for byte into stdout */
 
-  for (;;)
+  for (; ; )
     {
       ssize_t nbytesread = read(fd, *iobuffer, IOBUFFERSIZE);
 
@@ -332,7 +332,8 @@ int main(int argc, FAR char *argv[])
   printf("Join group...\n");
   mld_dumpstats(&iobuffer);
 
-  memcpy(mrec.ipv6mr_multiaddr.s6_addr16, g_grp_addr, sizeof(struct in6_addr));
+  memcpy(mrec.ipv6mr_multiaddr.s6_addr16,
+         g_grp_addr, sizeof(struct in6_addr));
   mrec.ipv6mr_interface = if_nametoindex("eth0");
 
   ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_JOIN_GROUP, (FAR void *)&mrec,
@@ -411,7 +412,8 @@ int main(int argc, FAR char *argv[])
       /* Send a garbage packet */
 
       ret = sendto(sockfd, g_garbage, sizeof(g_garbage), 0,
-                   (FAR struct sockaddr *)&target, sizeof(struct sockaddr_in6));
+                   (FAR struct sockaddr *)&target,
+                   sizeof(struct sockaddr_in6));
       if (ret < 0)
         {
           fprintf(stderr, "ERROR: sendto() failed: %d\n", errno);

--- a/examples/mld/mld_main.c
+++ b/examples/mld/mld_main.c
@@ -335,7 +335,7 @@ int main(int argc, FAR char *argv[])
   memcpy(mrec.ipv6mr_multiaddr.s6_addr16, g_grp_addr, sizeof(struct in6_addr));
   mrec.ipv6mr_interface = if_nametoindex("eth0");
 
-  ret = setsockopt(sockfd, SOL_IPV6, IPV6_JOIN_GROUP, (FAR void *)&mrec,
+  ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_JOIN_GROUP, (FAR void *)&mrec,
                    sizeof(struct ipv6_mreq));
   if (ret < 0)
     {
@@ -438,7 +438,7 @@ int main(int argc, FAR char *argv[])
   /* Leave the group */
 
   printf("Leave group...\n");
-  ret = setsockopt(sockfd, SOL_IPV6, IPV6_LEAVE_GROUP, (FAR void *)&mrec,
+  ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (FAR void *)&mrec,
                    sizeof(struct ipv6_mreq));
   if (ret < 0)
     {

--- a/examples/netloop/lo_main.c
+++ b/examples/netloop/lo_main.c
@@ -114,7 +114,7 @@ static int lo_client(void)
   tv.tv_sec  = 5;
   tv.tv_usec = 0;
 
-  ret = setsockopt(sockfd, SOL_TCP, TCP_KEEPIDLE, &tv, sizeof(struct timeval));
+  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE, &tv, sizeof(struct timeval));
   if (ret < 0)
     {
       ret = -errno;
@@ -125,7 +125,7 @@ static int lo_client(void)
   tv.tv_sec  = 1;
   tv.tv_usec = 0;
 
-  ret = setsockopt(sockfd, SOL_TCP, TCP_KEEPINTVL, &tv, sizeof(struct timeval));
+  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL, &tv, sizeof(struct timeval));
   if (ret < 0)
     {
       ret = -errno;
@@ -134,7 +134,7 @@ static int lo_client(void)
     }
 
   value = 3;
-  ret = setsockopt(sockfd, SOL_TCP, TCP_KEEPCNT, &value, sizeof(int));
+  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPCNT, &value, sizeof(int));
   if (ret < 0)
     {
       ret = -errno;

--- a/examples/netloop/lo_main.c
+++ b/examples/netloop/lo_main.c
@@ -114,7 +114,8 @@ static int lo_client(void)
   tv.tv_sec  = 5;
   tv.tv_usec = 0;
 
-  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE, &tv, sizeof(struct timeval));
+  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
+                   &tv, sizeof(struct timeval));
   if (ret < 0)
     {
       ret = -errno;
@@ -125,7 +126,8 @@ static int lo_client(void)
   tv.tv_sec  = 1;
   tv.tv_usec = 0;
 
-  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL, &tv, sizeof(struct timeval));
+  ret = setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
+                   &tv, sizeof(struct timeval));
   if (ret < 0)
     {
       ret = -errno;
@@ -149,8 +151,10 @@ static int lo_client(void)
   myaddr.sin_port        = htons(LISTENER_PORT);
   myaddr.sin_addr.s_addr = htonl(LO_ADDRESS);
 
-  printf("lo_client: Connecting to %08x:%d...\n", LO_ADDRESS, LISTENER_PORT);
-  if (connect( sockfd, (struct sockaddr*)&myaddr, sizeof(struct sockaddr_in)) < 0)
+  printf("lo_client: Connecting to %08x:%d...\n",
+         LO_ADDRESS, LISTENER_PORT);
+  if (connect(sockfd,
+              (struct sockaddr *)&myaddr, sizeof(struct sockaddr_in)) < 0)
     {
       ret = -errno;
       printf("lo_client: connect failure: %d\n", ret);
@@ -179,7 +183,8 @@ static int lo_client(void)
       else if (nbytessent != len)
         {
           ret = -EINVAL;
-          printf("lo_client: Bad send length: %d Expected: %d\n", nbytessent, len);
+          printf("lo_client: Bad send length: %d Expected: %d\n",
+                 nbytessent, len);
           goto errout_with_socket;
         }
 
@@ -205,7 +210,8 @@ static int lo_client(void)
       if (nbytesrecvd != len)
         {
           ret = -EINVAL;
-          printf("lo_client: Bad recv length: %d Expected: %d\n", nbytesrecvd, len);
+          printf("lo_client: Bad recv length: %d Expected: %d\n",
+                 nbytesrecvd, len);
           goto errout_with_socket;
         }
       else if (memcmp(inbuf, outbuf, len) != 0)
@@ -216,7 +222,8 @@ static int lo_client(void)
         }
 
 #ifdef CONFIG_EXAMPLES_NETLOOP_KEEPALIVE
-      /* Send four messages, then wait a longer amount of time ... longer than
+      /* Send four messages, then wait a longer amount of time ...
+       * longer than:
        * TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT = 5 + 3 * 1 = 8 seconds.
        */
 

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -467,7 +467,7 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
        * by definition and purpose of DHCP, undefined yet).
        */
 
-      ret = setsockopt(pdhcpc->sockfd, SOL_UDP, UDP_BINDTODEVICE,
+      ret = setsockopt(pdhcpc->sockfd, IPPROTO_UDP, UDP_BINDTODEVICE,
                        pdhcpc->interface, strlen(pdhcpc->interface));
       if (ret < 0)
         {


### PR DESCRIPTION
## Summary

net/sockopt: change the socket option style from Linux to BSD

```
Linux Programmer's Manual
...
IP(7)
...
NOTES
...
    Using the SOL_IP socket options level isn't portable;
    BSD-based stacks use the IPPROTO_IP level.
```

## Impact

## Testing
CI check is enough.
