### PR TITLE
make/import: add incdir into import build 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 $(MKDEP): $(TOPDIR)/tools/mkdeps.c
 	$(HOSTCC) $(HOSTINCLUDES) $(HOSTCFLAGS) $< -o $@
 
+$(INCDIR): $(TOPDIR)/tools/incdir.c
+	$(HOSTCC) $(HOSTINCLUDES) $(HOSTCFLAGS) $< -o $@
+
+IMPORT_TOOLS = $(MKDEP) $(INCDIR)
+
 # In the KERNEL build, we must build and install all of the modules.  No
 # symbol table is needed
 
@@ -81,7 +86,8 @@ install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 .import: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) $(MAKE) install TOPDIR="$(TOPDIR)"
 
-import: $(MKDEP) context
+import: $(IMPORT_TOOLS)
+	$(Q) $(MAKE) context TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) depend TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) .import TOPDIR="$(APPDIR)$(DELIM)import"
 
@@ -117,7 +123,8 @@ install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
 .import: $(BIN) install
 
-import: $(MKDEP) context
+import: $(IMPORT_TOOLS)
+	$(Q) $(MAKE) context TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) depend TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) .import TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) -C import install TOPDIR="$(APPDIR)$(DELIM)import"


### PR DESCRIPTION
## Summary

make/import: add incdir into import build 

export build break by commit https://github.com/apache/incubator-nuttx/commit/5555070fc3320d91876391bc24f0a7283d31841c

## Impact

make export

Depends on: https://github.com/apache/incubator-nuttx/pull/1332

## Testing

Before patch:

```
$ cd $(NUTTX_DIR)
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12

$ cd $(APPS_DIR)
$ ./tools/mkimport.sh -x $(NUTTX_DIR)/nuttx-export-9.1.0.zip
$ make import -j12
...
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
```
After patch:

```
$ cd $(NUTTX_DIR)
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12

$ cd $(APPS_DIR)
$ ./tools/mkimport.sh -x $(NUTTX_DIR)/nuttx-export-9.1.0.zip
$ make import -j12
...
LD: nuttx
make[1]: Leaving directory '/home/archer/code/apps/import'
```
