### PR TITLE
apps: Make c++ examples/testing work with both uClibc++ and libcxx

### DIFF
--- a/examples/elf/Kconfig
+++ b/examples/elf/Kconfig
@@ -120,12 +120,12 @@ config EXAMPLES_ELF_LIBC
 		program greatly increasing the total code size.  This option is
 		primarily intended only for testing.
 
-config EXAMPLES_ELF_UCLIBCXX
-	bool "uClibc++ is installed"
+config EXAMPLES_ELF_CXX
+	bool "uClibc++/libcxx is installed"
 	default n
-	depends on UCLIBCXX
+	depends on UCLIBCXX || LIBCXX
 	---help---
-		By default, uClibc++ is not installed and configured. If the
+		By default, uClibc++/libcxx is not installed and configured. If the
 		user installs and configures the C++ standard library, this
 		example will compile the demos using it.
 

--- a/examples/elf/tests/helloxx/Makefile
+++ b/examples/elf/tests/helloxx/Makefile
@@ -66,7 +66,7 @@ ALL_BIN += $(FSIMG_DIR)/$(BIN2)
 ifeq ($(CONFIG_HAVE_CXXINITIALIZE),y)
 BIN3 = hello++3
 ALL_BIN += $(FSIMG_DIR)/$(BIN3)
-ifeq ($(CONFIG_EXAMPLES_ELF_UCLIBCXX),y)
+ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
 BIN4 = hello++4
 ALL_BIN += $(FSIMG_DIR)/$(BIN4)
 BIN5 = hello++5
@@ -83,7 +83,7 @@ OBJS2 = $(SRCS2:.c=$(OBJEXT))
 ifeq ($(CONFIG_HAVE_CXXINITIALIZE),y)
 SRCS3 = $(BIN3).c
 OBJS3 = $(SRCS3:.c=$(OBJEXT))
-ifeq ($(CONFIG_EXAMPLES_ELF_UCLIBCXX),y)
+ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
 SRCS4 = $(BIN4).c
 OBJS4 = $(SRCS4:.c=$(OBJEXT))
 SRCS5 = $(BIN5).c
@@ -134,7 +134,7 @@ $(BIN3): $(OBJS3)
 #
 # NOTE:  libstdc++ is not available for NuttX as of this writing
 #
-ifeq ($(CONFIG_EXAMPLES_ELF_UCLIBCXX),y)
+ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
 $(BIN4): $(OBJS4)
 	@echo "LD: $<"
 	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $@ $(ARCHCRT0OBJ) $^ $(LDLIBS)
@@ -166,7 +166,7 @@ ifneq ($(CONFIG_DEBUG_SYMBOLS),y)
 	$(Q) $(STRIP) $(FSIMG_DIR)/$(BIN3)
 endif
 
-ifeq ($(CONFIG_EXAMPLES_ELF_UCLIBCXX),y)
+ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
 $(FSIMG_DIR)/$(BIN4): $(BIN4)
 	$(Q) mkdir -p $(FSIMG_DIR)
 	$(Q) install $(BIN4) $(FSIMG_DIR)/$(BIN4)

--- a/testing/README.txt
+++ b/testing/README.txt
@@ -35,9 +35,9 @@ testing/cxxtest
 
     CONFIG_HAVE_CXX=y
     CONFIG_HAVE_CXXINITIALIZE=y
-    CONFIG_UCLIBCXX=y
+    CONFIG_UCLIBCXX=y or CONFIG_LIBCXX=y
 
-  Additional uClibc++ settings may be required in your build environment.
+  Additional uClibc++/libcxx settings may be required in your build environment.
 
 testing/fstest
 ==============

--- a/testing/cxxtest/README.txt
+++ b/testing/cxxtest/README.txt
@@ -23,6 +23,6 @@ README
 
     CONFIG_HAVE_CXX=y
     CONFIG_HAVE_CXXINITIALIZE=y
-    CONFIG_UCLIBCXX=y
+    CONFIG_UCLIBCXX=y or CONFIG_LIBCXX=y
 
-  Additional uClibc++ settings may be required in your build environment.
+  Additional uClibc++/libcxx settings may be required in your build environment.


### PR DESCRIPTION
## Summary
Only Kconfig change.
 
## Impact

## Testing

