### PR TITLE
nshlib: Call symlink if user pass -s for ln command

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1050,7 +1050,15 @@ int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
       goto errout_with_tgtpath;
     }
 
-  ret = link(tgtpath, linkpath);
+  if (ndx == 1)
+    {
+      ret = link(tgtpath, linkpath);
+    }
+  else
+    {
+      ret = symlink(tgtpath, linkpath);
+    }
+
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, argv[0], "link", NSH_ERRNO);


### PR DESCRIPTION
## Summary
since NuttX kernel support really support symlink not link.
Note: link equal symlink now because the hard link doesn't support yet

## Impact
No, since link equal symlink in the current implementation

## Testing

