### PR TITLE
make import: enhance make import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	$(Q) echo "CP: nuttx.bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary nuttx$(EXEEXT) nuttx.bin
 endif
+	$(call POSTBUILD, $(APPDIR))
 
 import: $(IMPORT_TOOLS)
 	$(Q) $(MAKE) context TOPDIR="$(APPDIR)$(DELIM)import"

--- a/import/Make.defs
+++ b/import/Make.defs
@@ -35,6 +35,7 @@
 
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
+-include $(TOPDIR)/scripts/Config.mk
 include $(TOPDIR)/scripts/Make.defs
 
 # Tool related definitions

--- a/import/Makefile
+++ b/import/Makefile
@@ -43,25 +43,7 @@ FILES   = .config System.map User.map
 all:
 .PHONY: context depend clean distclean
 
-APPDIR = $(realpath $(CURDIR)$(DELIM)..)
-HEAD_OBJ += $(wildcard $(TOPDIR)$(DELIM)startup$(DELIM)*$(OBJEXT))
-HEAD_OBJ += $(wildcard $(APPDIR)$(DELIM)builtin$(DELIM)*$(OBJEXT))
-
-$(APPDIR)$(DELIM)nuttx$(EXEEXT): $(wildcard $(APPDIR)$(DELIM)*$(LIBEXT))
-	$(Q) echo "LD: nuttx"
-	$(Q) $(LD) --entry=__start $(LDFLAGS) -T$(LDSCRIPT) $(LIBPATHS) \
-	  $(LDLIBPATH) -L$(CURDIR)$(DELIM)scripts -o $@ $(HEAD_OBJ) \
-	  $(EXTRA_OBJS) $(LDSTARTGROUP) $^ $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
-ifeq ($(CONFIG_INTELHEX_BINARY),y)
-	$(Q) echo "CP: nuttx.hex"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $@ nuttx.hex
-endif
-ifeq ($(CONFIG_RAW_BINARY),y)
-	$(Q) echo "CP: nuttx.bin"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $@ nuttx.bin
-endif
-
-install: $(APPDIR)$(DELIM)nuttx$(EXEEXT)
+install:
 
 context:
 

--- a/tools/mkimport.sh
+++ b/tools/mkimport.sh
@@ -95,6 +95,7 @@ fi
 
 WD=${PWD}
 IMPORTDIR=${WD}/import
+BUILTINDIR=${WD}/builtin
 DARCHDIR=${IMPORTDIR}/arch
 DINCDIR=${IMPORTDIR}/include
 DLIBDIR=${IMPORTDIR}/libs
@@ -144,6 +145,7 @@ SLIBDIR=${EXPORTDIR}/libs
 SSCRIPTSDIR=${EXPORTDIR}/scripts
 SSTARTDIR=${EXPORTDIR}/startup
 STOOLSDIR=${EXPORTDIR}/tools
+REGISTERSDIR=${EXPORTDIR}/registry
 
 unset SALLDIRS
 if [ -d ${SARCHDIR} ]; then
@@ -169,6 +171,9 @@ fi
 
 mv ${SALLDIRS} ${IMPORTDIR}/. || \
 	{ echo "ERROR: Failed to move ${SALLDIRS} to ${IMPORTDIR}"; exit 1; }
+
+cp -rf ${REGISTERSDIR} ${BUILTINDIR}/. || \
+	{ echo "ERROR: Failed to move ${REGISTERSDIR} to ${BUILTINDIR}"; exit 1; }
 
 # Move the .config file in place in the import directory
 

--- a/tools/mkimport.sh
+++ b/tools/mkimport.sh
@@ -114,18 +114,18 @@ rm -rf ${DALLDIRS}
 mkdir ${TMPDIR} || \
 	{ echo "ERROR: Failed to create ${TMPDIR}"; exit 1; }
 
+if [ "X${TGZ}" == "Xy" ]; then
+	tar zxf ${EXPORT} -C ${TMPDIR} || \
+		{ echo "ERROR: tar zxf ${EXPORT} failed"; exit 1; }
+else
+	unzip ${EXPORT} -d ${TMPDIR} || \
+		{ echo "ERROR: unzip ${EXPORT} failed"; exit 1; }
+fi
+
 # Unpack the export package into the temporary directory
 
 cd ${TMPDIR} || \
 	{ echo "ERROR: Failed to cd to ${TMPDIR}"; exit 1; }
-
-if [ "X${TGZ}" == "Xy" ]; then
-	tar zxf ${EXPORT} || \
-		{ echo "ERROR: tar zxf ${EXPORT} failed"; exit 1; }
-else
-	unzip ${EXPORT} || \
-		{ echo "ERROR: unzip ${EXPORT} failed"; exit 1; }
-fi
 
 EXPORTDIR=`ls`
 


### PR DESCRIPTION
## Summary

1. make/import: support import zip use relative path

```
mkimport.sh failure if using relative path:

$ ./tools/mkimport.sh -x ../incubator-nuttx/nuttx-export-9.1.0.zip
unzip:  cannot find or open ../incubator-nuttx/nuttx-export-9.1.0.zip, ../incubator-nuttx/nuttx-export-9.1.0.zip.zip or ../incubator-nuttx/nuttx-export-9.1.0.zip.ZIP.
ERROR: unzip ../incubator-nuttx/nuttx-export-9.1.0.zip failed
```

2. make/import: copy the exported buildin registers

`copy the exported buildin registers to avoid symbols dropping on import build`


3. make/import: add post build support

`support post processing after binary install`



4. make/import: move the binary install to the top Makefile

`move the binary install to the main Makefile to support link extra libraries`


## Impact
make import

Depends on: https://github.com/apache/incubator-nuttx/pull/1345

## Testing

```
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12
$ cd ../apps
$ ./tools/mkimport.sh -x ../incubator-nuttx/nuttx-export-9.1.0.zip
$ make import -j12
....
echo "CP: nuttx.hex"
CP: nuttx.hex
arm-none-eabi-objcopy  -O ihex nuttx nuttx.hex
echo "CP: nuttx.bin"
CP: nuttx.bin
arm-none-eabi-objcopy  -O binary nuttx nuttx.bin
make[1]: Leaving directory '/home/archer/code/apps'
```

