### PR TITLE
example/helloxx: Remove EXAMPLES_HELLOXX_NOSTACKCONST

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -540,8 +540,6 @@ examples/helloxx
 
     CONFIG_NSH_BUILTIN_APPS -- Build the helloxx example as a
       "built-in"  that can be executed from the NSH command line.
-    CONFIG_EXAMPLES_HELLOXX_NOSTACKCONST - Set if the system does not
-      support construction of objects on the stack.
 
   Also needed:
 

--- a/examples/helloxx/helloxx_main.cxx
+++ b/examples/helloxx/helloxx_main.cxx
@@ -128,12 +128,10 @@ extern "C"
 
     // Exercise an C++ object instantiated on the stack
 
-#ifndef CONFIG_EXAMPLES_HELLOXX_NOSTACKCONST
     CHelloWorld HelloWorld;
 
     printf("helloxx_main: Saying hello from the instance constructed on the stack\n");
     HelloWorld.HelloWorld();
-#endif
 
     // Exercise an statically constructed C++ object
 


### PR DESCRIPTION

## Summary
since this config doesn't appear inside examples/helloxx/Kconfig anymore and
there is any c++ compiler can't construct the stack object as far as I know

## Impact
No, since the related code path never activate.

## Testing

