### PR TITLE
build: Replace $(TOPDIR)/Make.defs with $(APPDIR)/Make.defs

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -35,8 +35,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
 # If this is an executable program (with MAINSRC), we must build it as a
 # loadable module for the KERNEL build (always) or if the tristate module
 # has the value "m"
@@ -59,6 +57,12 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 CWD = $(strip ${shell echo %CD% | cut -d: -f2})
 else
 CWD = $(CURDIR)
+endif
+
+ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
+  LDLIBS += "${shell cygpath -w $(BIN)}"
+else
+  LDLIBS += $(BIN)
 endif
 
 SUFFIX = $(subst $(DELIM),.,$(CWD))

--- a/Directory.mk
+++ b/Directory.mk
@@ -33,7 +33,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
 # Sub-directories

--- a/Make.defs
+++ b/Make.defs
@@ -34,6 +34,19 @@
 #
 ############################################################################
 
+TOPDIR ?= $(APPDIR)/import
+include $(TOPDIR)/Make.defs
+
+# The GNU make CURDIR will always be a POSIX-like path with forward slashes
+# as path segment separators.  This is fine for the above inclusions but
+# will cause problems later for the native build.  If we know that this is
+# a native build, then we need to fix up the APPDIR path for subsequent
+# use
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+APPDIR := ${shell echo %CD%}
+endif
+
 # Application Directories
 
 # BUILDIRS is the list of top-level directories containing Make.defs files
@@ -103,7 +116,7 @@ CFLAGS   += ${shell $(INCDIR) "$(CC)" "$(APPDIR)$(DELIM)include"}
 CXXFLAGS += ${shell $(INCDIR) "$(CC)" "$(APPDIR)$(DELIM)include"}
 
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-  LDLIBS ?= "${shell cygpath -w $(BIN)}"
+  NUTTXLIB ?= "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
 else
-  LDLIBS ?= $(BIN)
+  NUTTXLIB ?= "$(TOPDIR)$(DELIM)staging"
 endif

--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,7 @@
 ############################################################################
 
 APPDIR = $(CURDIR)
-TOPDIR ?= $(APPDIR)/import
-include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
-
-# The GNU make CURDIR will always be a POSIX-like path with forward slashes
-# as path segment separators.  This is fine for the above inclusions but
-# will cause problems later for the native build.  If we know that this is
-# a native build, then we need to fix up the APPDIR path for subsequent
-# use
-
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-APPDIR := ${shell echo %CD%}
-endif
 
 # Symbol table for loadable apps.
 

--- a/builtin/Makefile
+++ b/builtin/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Source and object files
 

--- a/canutils/candump/Makefile
+++ b/canutils/candump/Makefile
@@ -18,7 +18,7 @@
 #
 ############################################################################/
 
--include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SocketCAN userspace utilities and tools candump tool
 # https://github.com/linux-can/can-utils/blob/master/candump.c

--- a/canutils/canlib/Makefile
+++ b/canutils/canlib/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CAN utility library
 

--- a/canutils/cansend/Makefile
+++ b/canutils/cansend/Makefile
@@ -18,7 +18,7 @@
 #
 ############################################################################/
 
--include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SocketCAN userspace utilities and tools cansend tool
 # https://github.com/linux-can/can-utils/blob/master/cansend.c

--- a/canutils/libcanard/Makefile
+++ b/canutils/libcanard/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 WGET = wget
 UNPACK = unzip

--- a/canutils/libcanutils/Makefile
+++ b/canutils/libcanutils/Makefile
@@ -18,7 +18,7 @@
 #
 ############################################################################/
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SocketCAN userspace utilities and tools library
 # https://github.com/linux-can/can-utils

--- a/canutils/libobd2/Makefile
+++ b/canutils/libobd2/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CAN utility library
 

--- a/examples/abntcodi/Makefile
+++ b/examples/abntcodi/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ABNTCODI built-in application info
 

--- a/examples/adc/Makefile
+++ b/examples/adc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ADC example
 

--- a/examples/adxl372_test/Makefile
+++ b/examples/adxl372_test/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = $(CONFIG_EXAMPLES_ADXL372_TEST_PROGNAME)
 PRIORITY = $(CONFIG_EXAMPLES_ADXL372_TEST_PRIORITY)

--- a/examples/ajoystick/Makefile
+++ b/examples/ajoystick/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! Example
 

--- a/examples/alarm/Makefile
+++ b/examples/alarm/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # RTC driver alarm test built-in application info
 

--- a/examples/apa102/Makefile
+++ b/examples/apa102/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # APA102 built-in application info
 

--- a/examples/apds9960/Makefile
+++ b/examples/apds9960/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/audio_rttl/Makefile
+++ b/examples/audio_rttl/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 -include $(SDKDIR)/Make.defs
 
 # Audio application info

--- a/examples/bastest/Makefile
+++ b/examples/bastest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # BAS test volume mounter
 

--- a/examples/battery/Makefile
+++ b/examples/battery/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Battery built-in application info
 

--- a/examples/bmi160/Makefile
+++ b/examples/bmi160/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 -include $(SDKDIR)/Make.defs
 
 # sixaxis built-in application info

--- a/examples/bmp180/Makefile
+++ b/examples/bmp180/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # BMP180 Barometer sensor example built-in application info
 

--- a/examples/bridge/Makefile
+++ b/examples/bridge/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Discover built-in application info
 

--- a/examples/buttons/Makefile
+++ b/examples/buttons/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LED driver test built-in application info
 

--- a/examples/calib_udelay/Makefile
+++ b/examples/calib_udelay/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # built-in application info
 

--- a/examples/camera/Makefile
+++ b/examples/camera/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # camera built-in application info
 

--- a/examples/can/Makefile
+++ b/examples/can/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/canard/Makefile
+++ b/examples/canard/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = canard
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/examples/cctype/Makefile
+++ b/examples/cctype/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # cctype verification
 

--- a/examples/charger/Makefile
+++ b/examples/charger/Makefile
@@ -1,5 +1,5 @@
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 -include $(SDKDIR)/Make.defs
 
 PROGNAME = $(CONFIG_EXAMPLES_CHARGER_PROGNAME)

--- a/examples/chat/Makefile
+++ b/examples/chat/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 MAINSRC = chat_main.c
 

--- a/examples/chrono/Makefile
+++ b/examples/chrono/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Chronometer built-in application info
 

--- a/examples/configdata/Makefile
+++ b/examples/configdata/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CONFIGDATA Unit Test
 

--- a/examples/cpuhog/Makefile
+++ b/examples/cpuhog/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # do nothing loop to use up cpu time
 

--- a/examples/cromfs/Makefile
+++ b/examples/cromfs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CROMFS Example
 

--- a/examples/dac/Makefile
+++ b/examples/dac/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DAC tool
 

--- a/examples/dhcpd/Makefile
+++ b/examples/dhcpd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DHCP Daemon Example
 

--- a/examples/dhcpd/Makefile.host
+++ b/examples/dhcpd/Makefile.host
@@ -35,7 +35,7 @@
 
 # TOPDIR must be defined on the make command line
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 OBJS		= host.hobj dhcpd.hobj
 BIN		= dhcpd

--- a/examples/dhtxx/Makefile
+++ b/examples/dhtxx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Dhtxx, World! built-in application info
 

--- a/examples/discover/Makefile
+++ b/examples/discover/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Discover built-in application info
 

--- a/examples/djoystick/Makefile
+++ b/examples/djoystick/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! Example
 

--- a/examples/dsptest/Makefile
+++ b/examples/dsptest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # dsptest built-in application info
 

--- a/examples/elf/Makefile
+++ b/examples/elf/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ELF Example
 

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = errno hello helloxx longjmp mutex pthread signal task struct
 BUILD_SUBDIRS = errno hello struct signal

--- a/examples/elf/tests/errno/Makefile
+++ b/examples/elf/tests/errno/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/hello/Makefile
+++ b/examples/elf/tests/hello/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/helloxx/Makefile
+++ b/examples/elf/tests/helloxx/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/longjmp/Makefile
+++ b/examples/elf/tests/longjmp/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/mutex/Makefile
+++ b/examples/elf/tests/mutex/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/pthread/Makefile
+++ b/examples/elf/tests/pthread/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/signal/Makefile
+++ b/examples/elf/tests/signal/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/struct/Makefile
+++ b/examples/elf/tests/struct/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/elf/tests/task/Makefile
+++ b/examples/elf/tests/task/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_EXAMPLES_ELF_SYSCALL),y)
 LDELFFLAGS += -Bstatic

--- a/examples/embedlog/Makefile
+++ b/examples/embedlog/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # embedlog example built-in application info
 

--- a/examples/fb/Makefile
+++ b/examples/fb/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FB, World! built-in application info
 

--- a/examples/fboverlay/Makefile
+++ b/examples/fboverlay/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # fboverlay built-in application info
 

--- a/examples/flash_test/Makefile
+++ b/examples/flash_test/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SMART FLASH block device test
 

--- a/examples/flowc/Makefile
+++ b/examples/flowc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FLOWC Test
 

--- a/examples/ft80x/Makefile
+++ b/examples/ft80x/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FT80X example built-in application info
 

--- a/examples/ftpc/Makefile
+++ b/examples/ftpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FTPC Client Application
 

--- a/examples/ftpd/Makefile
+++ b/examples/ftpd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 MAINSRC = ftpd_main.c
 

--- a/examples/gpio/Makefile
+++ b/examples/gpio/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # GPIO, World! built-in application info
 

--- a/examples/gps/Makefile
+++ b/examples/gps/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # GPS built-in application info
 

--- a/examples/hdc1008_demo/Makefile
+++ b/examples/hdc1008_demo/Makefile
@@ -18,7 +18,7 @@
 #
 ############################################################################/
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # hdc1008 example built-in application info
 

--- a/examples/hello/Makefile
+++ b/examples/hello/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/helloxx/Makefile
+++ b/examples/helloxx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! C++ Example
 

--- a/examples/hidkbd/Makefile
+++ b/examples/hidkbd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # USB Host HID keyboard Example
 

--- a/examples/hts221_reader/Makefile
+++ b/examples/hts221_reader/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # hts221_reader example
 

--- a/examples/i2schar/Makefile
+++ b/examples/i2schar/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # I2S character driver test
 

--- a/examples/i2sloop/Makefile
+++ b/examples/i2sloop/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # I2S character driver test
 

--- a/examples/igmp/Makefile
+++ b/examples/igmp/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = igmp
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/examples/ina219/Makefile
+++ b/examples/ina219/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/ina226/Makefile
+++ b/examples/ina226/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # INA226 built-in application info
 

--- a/examples/ini_dumper/Makefile
+++ b/examples/ini_dumper/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ini_dumper example built-in application info
 

--- a/examples/ipforward/Makefile
+++ b/examples/ipforward/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/json/Makefile
+++ b/examples/json/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # cJSON built-in application info
 

--- a/examples/leds/Makefile
+++ b/examples/leds/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LED driver test built-in application info
 

--- a/examples/lis3dsh_reader/Makefile
+++ b/examples/lis3dsh_reader/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = $(CONFIG_EXAMPLES_LIS3DSH_READER_PROGNAME)
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/examples/lsm303_reader/Makefile
+++ b/examples/lsm303_reader/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # lsm303_reader example
 

--- a/examples/lsm330spi_test/Makefile
+++ b/examples/lsm330spi_test/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = $(CONFIG_EXAMPLES_LSM330SPI_TEST_PROGNAME)
 PRIORITY = $(CONFIG_EXAMPLES_LSM330SPI_TEST_PRIORITY)

--- a/examples/lsm6dsl_reader/Makefile
+++ b/examples/lsm6dsl_reader/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # lsm6dsl_reader example
 

--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LittleVGL demo built-in application info
 

--- a/examples/max31855/Makefile
+++ b/examples/max31855/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # max31855 built-in application info
 

--- a/examples/media/Makefile
+++ b/examples/media/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Media test application info
 

--- a/examples/mld/Makefile
+++ b/examples/mld/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # MLD Networking Example
 

--- a/examples/mlx90614/Makefile
+++ b/examples/mlx90614/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # MLX90614 built-in application info
 

--- a/examples/modbus/Makefile
+++ b/examples/modbus/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FreeModBus demo built-in application info
 

--- a/examples/modbusmaster/Makefile
+++ b/examples/modbusmaster/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Modbus Master built-in application info
 

--- a/examples/module/Makefile
+++ b/examples/module/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Module example built-in application info
 

--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = chardev
 BUILD_SUBDIRS = chardev

--- a/examples/module/drivers/chardev/Makefile
+++ b/examples/module/drivers/chardev/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 CMODULEFLAGS += $(KDEFINE)
 

--- a/examples/mount/Makefile
+++ b/examples/mount/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # mount() test
 

--- a/examples/mtdpart/Makefile
+++ b/examples/mtdpart/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # MTD Partition Example
 

--- a/examples/mtdrwb/Makefile
+++ b/examples/mtdrwb/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # MTD R/W buffer test Example
 

--- a/examples/netlink_route/Makefile
+++ b/examples/netlink_route/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Netlink NETLINK_ROUTE built-in application info
 

--- a/examples/netloop/Makefile
+++ b/examples/netloop/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Network loopback Example
 

--- a/examples/netpkt/Makefile
+++ b/examples/netpkt/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Network packet socket example
 

--- a/examples/nettest/Makefile
+++ b/examples/nettest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic TCP networking test
 

--- a/examples/nrf24l01_term/Makefile
+++ b/examples/nrf24l01_term/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic nRF24L01+ terminal demonstration
 

--- a/examples/null/Makefile
+++ b/examples/null/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # The NULL example built-in application info
 

--- a/examples/nunchuck/Makefile
+++ b/examples/nunchuck/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Nunchuck Example
 

--- a/examples/nx/Makefile
+++ b/examples/nx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/nxdemo/Makefile
+++ b/examples/nxdemo/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/nxflat/Makefile
+++ b/examples/nxflat/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NXFLAT Example
 

--- a/examples/nxflat/tests/Makefile
+++ b/examples/nxflat/tests/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Most of these do no build yet
 #SUBDIRS	= errno hello hello++ longjmp mutex pthread signal task struct

--- a/examples/nxflat/tests/errno/Makefile
+++ b/examples/nxflat/tests/errno/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= errno
 

--- a/examples/nxflat/tests/hello++/Makefile
+++ b/examples/nxflat/tests/hello++/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN1			= hello++1
 BIN2			= hello++2

--- a/examples/nxflat/tests/hello/Makefile
+++ b/examples/nxflat/tests/hello/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= hello
 

--- a/examples/nxflat/tests/longjmp/Makefile
+++ b/examples/nxflat/tests/longjmp/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= longjmp
 

--- a/examples/nxflat/tests/mutex/Makefile
+++ b/examples/nxflat/tests/mutex/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= mutex
 

--- a/examples/nxflat/tests/pthread/Makefile
+++ b/examples/nxflat/tests/pthread/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs	# Basic make _info
+include $(APPDIR)/Make.defs	# Basic make _info
 
 BIN			= pthread
 

--- a/examples/nxflat/tests/signal/Makefile
+++ b/examples/nxflat/tests/signal/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= signal
 

--- a/examples/nxflat/tests/struct/Makefile
+++ b/examples/nxflat/tests/struct/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= struct
 

--- a/examples/nxflat/tests/task/Makefile
+++ b/examples/nxflat/tests/task/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN			= task
 

--- a/examples/nxhello/Makefile
+++ b/examples/nxhello/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/nximage/Makefile
+++ b/examples/nximage/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/nxlines/Makefile
+++ b/examples/nxlines/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/nxterm/Makefile
+++ b/examples/nxterm/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Console Example.
 

--- a/examples/nxtext/Makefile
+++ b/examples/nxtext/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/obd2/Makefile
+++ b/examples/obd2/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # OBD2 application info
 

--- a/examples/oneshot/Makefile
+++ b/examples/oneshot/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Oneshot timer built-in application info
 

--- a/examples/pca9635/Makefile
+++ b/examples/pca9635/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # PCA9635 built-in application info
 

--- a/examples/pdcurses/Makefile
+++ b/examples/pdcurses/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # pdcurses demo programs
 

--- a/examples/pf_ieee802154/Makefile
+++ b/examples/pf_ieee802154/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # PF_IEEE802154 Socket Test
 

--- a/examples/pipe/Makefile
+++ b/examples/pipe/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Pipe Example
 

--- a/examples/poll/Makefile
+++ b/examples/poll/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CSRCS = poll_listener.c select_listener.c net_listener.c net_reader.c
 MAINSRC = poll_main.c

--- a/examples/poll/Makefile.host
+++ b/examples/poll/Makefile.host
@@ -35,7 +35,7 @@
 
 # TOPDIR must be defined on the make command line
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 SRC	= host.c
 BIN	= host

--- a/examples/popen/Makefile
+++ b/examples/popen/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # popen() built-in application info
 

--- a/examples/posix_spawn/Makefile
+++ b/examples/posix_spawn/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ELF Example
 

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 SPAWN_DIR = $(APPDIR)$(DELIM)examples$(DELIM)posix_spawn
 FILESYSTEM_DIR = $(SPAWN_DIR)$(DELIM)filesystem

--- a/examples/posix_spawn/filesystem/hello/Makefile
+++ b/examples/posix_spawn/filesystem/hello/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN = hello
 

--- a/examples/posix_spawn/filesystem/redirect/Makefile
+++ b/examples/posix_spawn/filesystem/redirect/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN = redirect
 

--- a/examples/powerled/Makefile
+++ b/examples/powerled/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Powerled Example
 

--- a/examples/powermonitor/Makefile
+++ b/examples/powermonitor/Makefile
@@ -32,7 +32,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = powermonitor
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/examples/pppd/Makefile
+++ b/examples/pppd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # pppd Example
 

--- a/examples/pty_test/Makefile
+++ b/examples/pty_test/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/pwfb/Makefile
+++ b/examples/pwfb/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX per-window frame buffer graphics example.
 

--- a/examples/pwlines/Makefile
+++ b/examples/pwlines/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/pwm/Makefile
+++ b/examples/pwm/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # PWM Example.
 

--- a/examples/qencoder/Makefile
+++ b/examples/qencoder/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/random/Makefile
+++ b/examples/random/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # /dev/random test
 

--- a/examples/relays/Makefile
+++ b/examples/relays/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # relays Example
 

--- a/examples/rfid_readuid/Makefile
+++ b/examples/rfid_readuid/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # RFID Read UID built-in application info
 

--- a/examples/rgbled/Makefile
+++ b/examples/rgbled/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # RGBLED built-in application info
 

--- a/examples/romfs/Makefile
+++ b/examples/romfs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ROMFS built-in application info
 

--- a/examples/sendmail/Makefile
+++ b/examples/sendmail/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Sendmail SMTP Example
 

--- a/examples/serialblaster/Makefile
+++ b/examples/serialblaster/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # For testing: Blast canned characters at a designated serial port
 

--- a/examples/serialrx/Makefile
+++ b/examples/serialrx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # For testing: Blast canned characters at a designated serial port
 

--- a/examples/serloop/Makefile
+++ b/examples/serloop/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Mindlessly simple console loopack test
 

--- a/examples/slcd/Makefile
+++ b/examples/slcd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 

--- a/examples/smps/Makefile
+++ b/examples/smps/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Smps Example
 

--- a/examples/sotest/Makefile
+++ b/examples/sotest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Shared library example built-in application info
 

--- a/examples/sotest/lib/Makefile
+++ b/examples/sotest/lib/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ALL_SUBDIRS = sotest
 BUILD_SUBDIRS = sotest

--- a/examples/sotest/lib/modprint/Makefile
+++ b/examples/sotest/lib/modprint/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 LDLIBPATH =
 LDLIBS =

--- a/examples/sotest/lib/sotest/Makefile
+++ b/examples/sotest/lib/sotest/Makefile
@@ -33,13 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-NUTTXLIB = "${shell cygpath -w $(TOPDIR)$(DELIM)staging}"
-else
-NUTTXLIB = "$(TOPDIR)$(DELIM)staging"
-endif
+include $(APPDIR)/Make.defs
 
 LDLIBPATH =
 LDLIBS =

--- a/examples/stat/Makefile
+++ b/examples/stat/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Stat built-in application info
 

--- a/examples/sx127x_demo/Makefile
+++ b/examples/sx127x_demo/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic sx127x+  demonstration
 

--- a/examples/system/Makefile
+++ b/examples/system/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # system() built-in application info
 

--- a/examples/tcpblaster/Makefile
+++ b/examples/tcpblaster/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic TCP networking test
 

--- a/examples/tcpecho/Makefile
+++ b/examples/tcpecho/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Discover built-in application info
 

--- a/examples/telnetd/Makefile
+++ b/examples/telnetd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Telnetd Example
 

--- a/examples/thttpd/Makefile
+++ b/examples/thttpd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # THTTPD Web Server Example
 

--- a/examples/thttpd/content/Makefile.binfs
+++ b/examples/thttpd/content/Makefile.binfs
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = hello tasks
 PRIORITY = $(CONFIG_THTTPD_CGI_PRIORITY)

--- a/examples/thttpd/content/Makefile.nxflat
+++ b/examples/thttpd/content/Makefile.nxflat
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 SUBDIRS = hello tasks
 INSTALL_FILES = index.html style.css

--- a/examples/thttpd/content/hello/Makefile
+++ b/examples/thttpd/content/hello/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN = hello
 

--- a/examples/thttpd/content/tasks/Makefile
+++ b/examples/thttpd/content/tasks/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 BIN = tasks
 

--- a/examples/tiff/Makefile
+++ b/examples/tiff/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # TIFF Unit Test
 

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Timer built-in application info
 

--- a/examples/touchscreen/Makefile
+++ b/examples/touchscreen/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX NX Graphics Example.
 

--- a/examples/udgram/Makefile
+++ b/examples/udgram/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic Unix domain networking test
 

--- a/examples/udp/Makefile
+++ b/examples/udp/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # UDP Test
 

--- a/examples/udpblaster/Makefile
+++ b/examples/udpblaster/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic TCP networking test
 

--- a/examples/uid/Makefile
+++ b/examples/uid/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # UID/GID built-in application info
 

--- a/examples/unionfs/Makefile
+++ b/examples/unionfs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # UNIONFS built-in application info
 

--- a/examples/usbserial/Makefile
+++ b/examples/usbserial/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # USB serial device example
 # Built-in application info

--- a/examples/usbserial/Makefile.host
+++ b/examples/usbserial/Makefile.host
@@ -35,7 +35,7 @@
 
 # TOPDIR must be defined on the make command line
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 SRC = host.c
 BIN = host$(HOSTEXEEXT)

--- a/examples/userfs/Makefile
+++ b/examples/userfs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # UserFS test application info
 

--- a/examples/usrsocktest/Makefile
+++ b/examples/usrsocktest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # USRSOCK Test built-in application info
 

--- a/examples/ustream/Makefile
+++ b/examples/ustream/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Basic Unix domain networking test
 

--- a/examples/veml6070/Makefile
+++ b/examples/veml6070/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # VEML6070 UltraViolet sensor example built-in application info
 

--- a/examples/watchdog/Makefile
+++ b/examples/watchdog/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Watchdog Timer Example.
 

--- a/examples/webserver/Makefile
+++ b/examples/webserver/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # uIP very tiny web server example
 

--- a/examples/wget/Makefile
+++ b/examples/wget/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # wget webclient example
 

--- a/examples/wgetjson/Makefile
+++ b/examples/wgetjson/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hello, World! Example
 

--- a/examples/xbc_test/Makefile
+++ b/examples/xbc_test/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # XBox controller driver test built-in application info
 

--- a/examples/xmlrpc/Makefile
+++ b/examples/xmlrpc/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # XML RPC built-in application info
 

--- a/examples/zerocross/Makefile
+++ b/examples/zerocross/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Zero Cross Example
 

--- a/fsutils/flash_eraseall/Makefile
+++ b/fsutils/flash_eraseall/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Password file access library
 

--- a/fsutils/inifile/Makefile
+++ b/fsutils/inifile/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # I2C tool
 CSRCS = inifile.c

--- a/fsutils/inih/Makefile
+++ b/fsutils/inih/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 WGET = wget
 CP = cp -R

--- a/fsutils/mkfatfs/Makefile
+++ b/fsutils/mkfatfs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # mkfatfs utility
 

--- a/fsutils/mksmartfs/Makefile
+++ b/fsutils/mksmartfs/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SmartFS file utility
 

--- a/fsutils/passwd/Makefile
+++ b/fsutils/passwd/Makefile
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Password file access library
 

--- a/gpsutils/minmea/Makefile
+++ b/gpsutils/minmea/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NSH Library
 

--- a/graphics/ft80x/Makefile
+++ b/graphics/ft80x/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FTDI/BridgeTek FT80x library
 CSRCS  = ft80x_dl.c ft80x_ramg.c ft80x_ramdl.c ft80x_ramcmd.c

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LVGL graphic library
 

--- a/graphics/nxglyphs/Makefile
+++ b/graphics/nxglyphs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_NXWIDGETS),y)
 # Glyphs used by NxWidgets

--- a/graphics/nxwidgets/Makefile
+++ b/graphics/nxwidgets/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Infrastructure
 

--- a/graphics/nxwidgets/UnitTests/CButton/Makefile
+++ b/graphics/nxwidgets/UnitTests/CButton/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CButton unit test
 

--- a/graphics/nxwidgets/UnitTests/CButtonArray/Makefile
+++ b/graphics/nxwidgets/UnitTests/CButtonArray/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CButtonArray unit test
 

--- a/graphics/nxwidgets/UnitTests/CCheckBox/Makefile
+++ b/graphics/nxwidgets/UnitTests/CCheckBox/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CCheckBox unit test
 

--- a/graphics/nxwidgets/UnitTests/CGlyphButton/Makefile
+++ b/graphics/nxwidgets/UnitTests/CGlyphButton/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CGlyphButton unit test
 

--- a/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/Makefile
+++ b/graphics/nxwidgets/UnitTests/CGlyphSliderHorizontal/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CGlyphSliderHorizontal unit test
 

--- a/graphics/nxwidgets/UnitTests/CImage/Makefile
+++ b/graphics/nxwidgets/UnitTests/CImage/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CImage unit test
 

--- a/graphics/nxwidgets/UnitTests/CKeypad/Makefile
+++ b/graphics/nxwidgets/UnitTests/CKeypad/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CKeyPad unit test
 

--- a/graphics/nxwidgets/UnitTests/CLabel/Makefile
+++ b/graphics/nxwidgets/UnitTests/CLabel/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CLabel unit test
 

--- a/graphics/nxwidgets/UnitTests/CLatchButton/Makefile
+++ b/graphics/nxwidgets/UnitTests/CLatchButton/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CLatchButton unit test
 

--- a/graphics/nxwidgets/UnitTests/CLatchButtonArray/Makefile
+++ b/graphics/nxwidgets/UnitTests/CLatchButtonArray/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CLatchButtonArray unit test
 

--- a/graphics/nxwidgets/UnitTests/CListBox/Makefile
+++ b/graphics/nxwidgets/UnitTests/CListBox/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CListBox unit test
 

--- a/graphics/nxwidgets/UnitTests/CProgressBar/Makefile
+++ b/graphics/nxwidgets/UnitTests/CProgressBar/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CProgressBar unit test
 

--- a/graphics/nxwidgets/UnitTests/CRadioButton/Makefile
+++ b/graphics/nxwidgets/UnitTests/CRadioButton/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CRadioButton unit test
 

--- a/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/Makefile
+++ b/graphics/nxwidgets/UnitTests/CScrollbarHorizontal/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CScrollbarHorizontal unit test
 

--- a/graphics/nxwidgets/UnitTests/CScrollbarVertical/Makefile
+++ b/graphics/nxwidgets/UnitTests/CScrollbarVertical/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CScrollbarVertical unit test
 

--- a/graphics/nxwidgets/UnitTests/CSliderHorizonal/Makefile
+++ b/graphics/nxwidgets/UnitTests/CSliderHorizonal/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CSliderHorizontal unit test
 

--- a/graphics/nxwidgets/UnitTests/CSliderVertical/Makefile
+++ b/graphics/nxwidgets/UnitTests/CSliderVertical/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CSliderVertical unit test
 

--- a/graphics/nxwidgets/UnitTests/CTextBox/Makefile
+++ b/graphics/nxwidgets/UnitTests/CTextBox/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CTextBox unit test
 

--- a/graphics/nxwm/Makefile
+++ b/graphics/nxwm/Makefile
@@ -33,7 +33,7 @@
 #
 #################################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = nxwm
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/graphics/pdcurs34/Makefile
+++ b/graphics/pdcurs34/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # pdcurses Text User Interface
 include pdcurses/Make.defs

--- a/graphics/screenshot/Makefile
+++ b/graphics/screenshot/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # TIFF Screenshot utility
 

--- a/graphics/slcd/Makefile
+++ b/graphics/slcd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SLcd
 

--- a/graphics/tiff/Makefile
+++ b/graphics/tiff/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttX TIFF Creation Tool
 CSRCS = tiff_addstrip.c tiff_finalize.c tiff_initialize.c tiff_utils.c

--- a/graphics/twm4nx/Makefile
+++ b/graphics/twm4nx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Add path to cursor images to CXXFLAGS
 

--- a/import/Makefile
+++ b/import/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Sub-directories from the NuttX export package
 

--- a/industry/abnt_codi/Makefile
+++ b/industry/abnt_codi/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NSH Library
 

--- a/interpreters/bas/Makefile
+++ b/interpreters/bas/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # BAS Library
 

--- a/interpreters/ficl/Makefile
+++ b/interpreters/ficl/Makefile
@@ -35,7 +35,7 @@
 
 BUILDDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Tools
 

--- a/interpreters/minibasic/Makefile
+++ b/interpreters/minibasic/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Mini Basic Library
 

--- a/modbus/Makefile
+++ b/modbus/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # FreeModBus Library
 

--- a/netutils/chat/Makefile
+++ b/netutils/chat/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CSRCS = chat.c
 

--- a/netutils/cjson/Makefile
+++ b/netutils/cjson/Makefile
@@ -35,7 +35,7 @@
 
 # Standard includes
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Set up build configuration and environment
 

--- a/netutils/codecs/Makefile
+++ b/netutils/codecs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CSRCS = urldecode.c base64.c md5.c
 

--- a/netutils/dhcpc/Makefile
+++ b/netutils/dhcpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DHCP Client Library
 

--- a/netutils/dhcpd/Makefile
+++ b/netutils/dhcpd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DHCP Daemn Library
 

--- a/netutils/discover/Makefile
+++ b/netutils/discover/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Telnet daemon
 

--- a/netutils/esp8266/Makefile
+++ b/netutils/esp8266/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ESP8266 Library
 CSRCS = esp8266.c

--- a/netutils/ftpc/Makefile
+++ b/netutils/ftpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DHCP Daemn Library
 

--- a/netutils/ftpd/Makefile
+++ b/netutils/ftpd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Telnet daemon
 

--- a/netutils/libcurl4nx/Makefile
+++ b/netutils/libcurl4nx/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Web client library
 

--- a/netutils/netinit/Makefile
+++ b/netutils/netinit/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CSRCS = netinit.c
 

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Network Library
 

--- a/netutils/ntpclient/Makefile
+++ b/netutils/ntpclient/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NTP client daemon Library
 

--- a/netutils/ping/Makefile
+++ b/netutils/ping/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_NETUTILS_PING),y)
   CSRCS += icmp_ping.c

--- a/netutils/pppd/Makefile
+++ b/netutils/pppd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CSRCS = pppd.c ppp.c ahdlc.c lcp.c ipcp.c
 ifeq ($(CONFIG_NETUTILS_PPPD_PAP),y)

--- a/netutils/smtp/Makefile
+++ b/netutils/smtp/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SMTP Library
 

--- a/netutils/telnetc/Makefile
+++ b/netutils/telnetc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Telnet daemon
 

--- a/netutils/telnetd/Makefile
+++ b/netutils/telnetd/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Telnet daemon
 

--- a/netutils/tftpc/Makefile
+++ b/netutils/tftpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # TFTP Client Library
 

--- a/netutils/thttpd/Makefile
+++ b/netutils/thttpd/Makefile
@@ -33,7 +33,7 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # THTTPD Library
 

--- a/netutils/thttpd/cgi-src/Makefile
+++ b/netutils/thttpd/cgi-src/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CFLAGS		+= ${shell $(INCDIR) "$(CC)" "$(APPDIR)$(DELIM)netutils$(DELIM)thttpd"}
 CGIBINDIR	= $(APPDIR)/netutils/thttpd/cgi-bin

--- a/netutils/usrsock_rpmsg/Makefile
+++ b/netutils/usrsock_rpmsg/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = usrsock
 PRIORITY = CONFIG_NETUTILS_USRSOCK_RPMSG_PRIORITY

--- a/netutils/webclient/Makefile
+++ b/netutils/webclient/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Web client library
 

--- a/netutils/webserver/Makefile
+++ b/netutils/webserver/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Web server library
 

--- a/netutils/xmlrpc/Makefile
+++ b/netutils/xmlrpc/Makefile
@@ -36,7 +36,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ifeq ($(CONFIG_NET_TCP),y)
 CSRCS = xmlparser.c response.c

--- a/nshlib/Makefile
+++ b/nshlib/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NSH Library
 

--- a/platform/Makefile
+++ b/platform/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 CONFIG_ARCH_BOARD ?= dummy
 

--- a/platform/bin/Makefile
+++ b/platform/bin/Makefile
@@ -33,7 +33,7 @@
 #
 ###########################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 all:
 .PHONY: clean distclean

--- a/system/cdcacm/Makefile
+++ b/system/cdcacm/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # USB CDC/ACM serial mass storage add-on
 

--- a/system/cfgdata/Makefile
+++ b/system/cfgdata/Makefile
@@ -38,7 +38,7 @@
 # TODO, this makefile should run make under the app dirs, instead of
 # sourcing the Make.defs!
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # config Application
 

--- a/system/cle/Makefile
+++ b/system/cle/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # EMACS-like Command Line Editor (CLE)
 CSRCS = cle.c

--- a/system/composite/Makefile
+++ b/system/composite/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # USB device mass storage add-on
 

--- a/system/critmon/Makefile
+++ b/system/critmon/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Stack Monitor Application
 

--- a/system/cu/Makefile
+++ b/system/cu/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 MAINSRC = cu_main.c
 

--- a/system/dhcpc/Makefile
+++ b/system/dhcpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # DHCPC address renewal built-in application info
 

--- a/system/embedlog/Makefile
+++ b/system/embedlog/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 WGET = wget
 CP = cp -R

--- a/system/flash_eraseall/Makefile
+++ b/system/flash_eraseall/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # flash_eraseall Application
 

--- a/system/hex2bin/Makefile
+++ b/system/hex2bin/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Hex2bin utility
 

--- a/system/hexed/Makefile
+++ b/system/hexed/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # hexed Application
 

--- a/system/i2c/Makefile
+++ b/system/i2c/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # I2C tool
 CSRCS   = i2c_bus.c i2c_common.c i2c_dev.c i2c_get.c i2c_set.c i2c_verf.c

--- a/system/lm75/Makefile
+++ b/system/lm75/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LM-75 Temperature Sensor Application
 

--- a/system/lzf/Makefile
+++ b/system/lzf/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LZF built-in application info
 

--- a/system/mdio/Makefile
+++ b/system/mdio/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # MDIO tool built-in application info
 

--- a/system/netdb/Makefile
+++ b/system/netdb/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # netdb Application
 

--- a/system/nsh/Makefile
+++ b/system/nsh/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NuttShell (NSH) Example
 

--- a/system/ntpc/Makefile
+++ b/system/ntpc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NTPC address renewal built-in application info
 

--- a/system/nxplayer/Makefile
+++ b/system/nxplayer/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NxPlayer Library
 

--- a/system/nxrecorder/Makefile
+++ b/system/nxrecorder/Makefile
@@ -32,7 +32,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NxRecorder Library
 

--- a/system/ping/Makefile
+++ b/system/ping/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ICMP ping command
 

--- a/system/ping6/Makefile
+++ b/system/ping6/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ICMP ping6 command
 

--- a/system/popen/Makefile
+++ b/system/popen/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # popen()/pclose functions
 

--- a/system/psmq/Makefile
+++ b/system/psmq/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 WGET = wget
 CP = cp -R

--- a/system/ramtest/Makefile
+++ b/system/ramtest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # RAM test
 

--- a/system/readline/Makefile
+++ b/system/readline/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # The Readline Library
 

--- a/system/sched_note/Makefile
+++ b/system/sched_note/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # LED driver test built-in application info
 

--- a/system/setlogmask/Makefile
+++ b/system/setlogmask/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # setlogmask command
 

--- a/system/spi/Makefile
+++ b/system/spi/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SPI tool
 

--- a/system/stackmonitor/Makefile
+++ b/system/stackmonitor/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Stack Monitor Application
 

--- a/system/system/Makefile
+++ b/system/system/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # system command
 

--- a/system/taskset/Makefile
+++ b/system/taskset/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # taskset command
 

--- a/system/tee/Makefile
+++ b/system/tee/Makefile
@@ -35,7 +35,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # tee command
 

--- a/system/telnet/Makefile
+++ b/system/telnet/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 ifneq ($(CONFIG_SYSTEM_TELNET_CHATD),)
 

--- a/system/termcurses/Makefile
+++ b/system/termcurses/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Termcurses terminal emulation library
 

--- a/system/ubloxmodem/Makefile
+++ b/system/ubloxmodem/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # u-blox modem tool
 

--- a/system/usbmsc/Makefile
+++ b/system/usbmsc/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = msconn msdis
 PRIORITY = $(CONFIG_SYSTEM_USBMSC_CMD_PRIORITY)

--- a/system/vi/Makefile
+++ b/system/vi/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # VI-Workalike Editor
 

--- a/system/zmodem/Makefile
+++ b/system/zmodem/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 PROGNAME = sz rz
 PRIORITY = $(CONFIG_SYSTEM_ZMODEM_PRIORITY)

--- a/system/zmodem/Makefile.host
+++ b/system/zmodem/Makefile.host
@@ -49,7 +49,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
 NUTTXINC = $(TOPDIR)/include

--- a/testing/cxxtest/Makefile
+++ b/testing/cxxtest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # CXX test program
 

--- a/testing/fstest/Makefile
+++ b/testing/fstest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Generic file system stress test application info
 

--- a/testing/getprime/Makefile
+++ b/testing/getprime/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # getprime built-in application info
 

--- a/testing/mm/Makefile
+++ b/testing/mm/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Memory Management Test
 

--- a/testing/nxffs/Makefile
+++ b/testing/nxffs/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # NXFFS file system example
 

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # ostest built-in application info
 

--- a/testing/scanftest/Makefile
+++ b/testing/scanftest/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # scanf() test built-in application info
 

--- a/testing/smart/Makefile
+++ b/testing/smart/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SMART file system stress test
 

--- a/testing/smart_test/Makefile
+++ b/testing/smart_test/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SMART filesystem test tool
 

--- a/testing/smp/Makefile
+++ b/testing/smp/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # SMP built-in application info
 

--- a/testing/unity/Makefile
+++ b/testing/unity/Makefile
@@ -35,7 +35,7 @@
 
 # Standard includes
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Set up build configuration and environment
 

--- a/wireless/bluetooth/btsak/Makefile
+++ b/wireless/bluetooth/btsak/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # Bluetooth SAK (swiss army knife )
 

--- a/wireless/gs2200m/Makefile
+++ b/wireless/gs2200m/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # gs2200m command
 

--- a/wireless/ieee802154/i8sak/Makefile
+++ b/wireless/ieee802154/i8sak/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # IEEE 802.15.4  SAK (swiss army knife )
 

--- a/wireless/ieee802154/i8shark/Makefile
+++ b/wireless/ieee802154/i8shark/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 MAINSRC = i8shark_main.c
 

--- a/wireless/ieee802154/libmac/Makefile
+++ b/wireless/ieee802154/libmac/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # libmac source files
 

--- a/wireless/ieee802154/libutils/Makefile
+++ b/wireless/ieee802154/libutils/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # libutils source files
 CSRCS += ieee802154_addrtostr.c

--- a/wireless/iwpan/Makefile
+++ b/wireless/iwpan/Makefile
@@ -34,7 +34,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # IEEE802.11 Wapi Application
 

--- a/wireless/wapi/Makefile
+++ b/wireless/wapi/Makefile
@@ -33,7 +33,7 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
 
 # IEEE802.11 Wapi Application
 


### PR DESCRIPTION
and move NUTTXLIB defintion to the common place

## Summary
So the common variables(e.g. NUTTXLIB) which is shared in apps can be put into a common place(apps/Make.defs).

## Impact
No.

## Testing

