### PR TITLE
testing/cxxtest: Fix the compiler warning

### DIFF
--- a/testing/cxxtest/cxxtest_main.cxx
+++ b/testing/cxxtest/cxxtest_main.cxx
@@ -56,7 +56,8 @@ using namespace std;
 class Base
 {
 public:
-  virtual void printBase(void) {};
+  virtual void printBase(void) {}
+  virtual ~Base() {}
 };
 
 class Extend : public Base


### PR DESCRIPTION
## Summary
cxxtest_main.cxx: In function ‘void test_rtti()’:
cxxtest_main.cxx:199:3: warning: deleting object of polymorphic class type ‘Base’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
  199 |   delete a;
      |   ^~~~~~~~
cxxtest_main.cxx:200:3: warning: deleting object of polymorphic class type ‘Base’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
  200 |   delete b;

## Impact
No.

## Testing

