### PR TITLE
ostest: fix assert when open CONFIG_SIG_DEFAULT

### DIFF
--- a/testing/ostest/mqueue.c
+++ b/testing/ostest/mqueue.c
@@ -359,7 +359,7 @@ void mqueue_test(void)
   /* Wake up the receiver thread with a signal */
 
   printf("mqueue_test: Killing receiver\n");
-  pthread_kill(receiver, 9);
+  pthread_kill(receiver, SIGUSR1);
 
   /* Wait a bit to see if the thread exits on its own */
 


### PR DESCRIPTION
## Summary
SIGKILL was captured and call nxsig_abnormal_termination,
which kills the children when SIGCHLD was set. 
Solution: change SIGKILL to SIGUSR1.
## Impact

## Testing

