### PR TITLE
netutils: netclient: Introduce CONFIG_NETUTILS_NTPCLIENT_WITH_AUTH

### DIFF
--- a/netutils/ntpclient/Kconfig
+++ b/netutils/ntpclient/Kconfig
@@ -42,4 +42,8 @@ config NETUTILS_NTPCLIENT_SIGWAKEUP
 	int "NTP client wakeup signal number"
 	default 18
 
+config NETUTILS_NTPCLIENT_WITH_AUTH
+	bool "NTP client with authentication"
+	default n
+
 endif # NETUTILS_NTPCLIENT

--- a/netutils/ntpclient/ntpv3.h
+++ b/netutils/ntpclient/ntpv3.h
@@ -197,11 +197,13 @@ struct ntp_datagram_s
   uint8_t origtimestamp[8];  /* Originate Timestamp */
   uint8_t recvtimestamp[8];  /* Receive Timestamp */
   uint8_t xmittimestamp[8];  /* Transmit Timestamp */
+#ifdef CONFIG_NETUTILS_NTPCLIENT_WITH_AUTH
   uint8_t keyid[4];          /* Authenticator data */
   uint8_t digest1[4];
   uint8_t digest2[4];
   uint8_t digest3[4];
   uint8_t digest4[4];
+#endif
 };
 
 #endif /* __APPS_NETUTILS_NTPCLIENT_NTPV3_H */


### PR DESCRIPTION
## Summary

- I found that some NTP servers did not respond with ntpclient
- Finally, I found that authentication headers in NTP packet are not implemented correctly, so some NTP servers could not send a response.
- This PR introduces to CONFIG_NETUTILS_NTPCLIENT_WITH_AUTH to implement authentication in the future. (the current default value is false)

## Impact

- This PR affects ntpclient.

## Testing

- I tested this PR with CONFIG_NETUTILS_NTPCLIENT_SERVER="162.159.200.1" 
