### PR TITLE
fsutils/mkfatfs: use DMA memory for mkfatfs when needed

### DIFF
--- a/fsutils/mkfatfs/mkfatfs.c
+++ b/fsutils/mkfatfs/mkfatfs.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/fs/fat.h>
 
 #include "fsutils/mkfatfs.h"
 #include "fat32.h"
@@ -337,7 +338,11 @@ int mkfatfs(FAR const char *pathname, FAR struct fat_format_s *fmt)
 
   /* Allocate a buffer that will be working sector memory */
 
+#ifdef CONFIG_FAT_DMAMEMORY
+  var.fv_sect = (FAR uint8_t *)fat_dma_alloc(var.fv_sectorsize);
+#else
   var.fv_sect = (FAR uint8_t *)malloc(var.fv_sectorsize);
+#endif
   if (!var.fv_sect)
     {
       ferr("ERROR: Failed to allocate working buffers\n");
@@ -360,7 +365,11 @@ errout:
 
   if (var.fv_sect)
     {
+#ifdef CONFIG_FAT_DMAMEMORY
+      fat_dma_free(var.fv_sect, var.fv_sectorsize);
+#else
       free(var.fv_sect);
+#endif
     }
 
   /* Return any reported errors */


### PR DESCRIPTION
this makes mkfatfs use fat_dma_alloc() when CONFIG_FAT_DMAMEMORY is
set. This is needed to ensure mkfatfs operates with boards that use
DMA for microSD

From nuttx b3dd424

## Summary

Reimport the change that was made originally in nuttx tree:
https://github.com/apache/incubator-nuttx/commit/b3dd424

When the mkfatfs tool was migrated to apps/, it seems this change has been lost.

## Impact

## Testing

Tested with:
./boards/arm/stm32h7/stm32h747i-disco/src/stm32_dma_alloc.c

CONFIG_GRAN=y
CONFIG_FAT_DMAMEMORY=y

Test to format a microSD card with FAT:
mkfatfs -F 32 /dev/mmcsd0
mount -t vfat /dev/mmcsd0 /mnt
