### PR TITLE
Don't preconfig, clean or distclean when it's not necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *~
 .built
 .depend
+.kconfig
 /*.lock
 /bin
 /boot_romfsimg.h

--- a/Application.mk
+++ b/Application.mk
@@ -96,7 +96,7 @@ VPATH += :.
 # Targets follow
 
 all:: .built
-.PHONY: clean preconfig depend distclean
+.PHONY: clean depend distclean
 .PRECIOUS: $(BIN)
 
 define ELFASSEMBLE
@@ -194,8 +194,6 @@ endif
 install::
 
 endif # BUILD_MODULE
-
-preconfig::
 
 ifeq ($(CONFIG_NSH_BUILTIN_APPS),y)
 ifneq ($(PROGNAME),)

--- a/Directory.mk
+++ b/Directory.mk
@@ -35,38 +35,38 @@
 
 include $(APPDIR)/Make.defs
 
-# Sub-directories
+# Sub-directories that have been built or configured.
 
-SUBDIRS = $(dir $(wildcard */Makefile))
+SUBDIRS       := $(dir $(wildcard *$(DELIM)Makefile))
+CONFIGSUBDIRS := $(filter-out $(dir $(wildcard *$(DELIM)Kconfig)),$(SUBDIRS))
+CLEANSUBDIRS  := $(dir $(wildcard *$(DELIM).built))
+CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).depend))
+CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).kconfig))
 
 all: nothing
 
-.PHONY: nothing context depend clean distclean
+.PHONY: nothing clean distclean
 
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),context)))
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),depend)))
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
-$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+$(foreach SDIR, $(CONFIGSUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))
+$(foreach SDIR, $(CLEANSUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
+$(foreach SDIR, $(CLEANSUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
 nothing:
 
 install:
 
-preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+preconfig: $(foreach SDIR, $(CONFIGSUBDIRS), $(SDIR)_preconfig)
 ifneq ($(MENUDESC),)
 	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) touch .kconfig
 endif
 
-context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
+clean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_clean)
 
-depend: $(foreach SDIR, $(SUBDIRS), $(SDIR)_depend)
-
-clean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_clean)
-
-distclean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_distclean)
+distclean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_distclean)
 ifneq ($(MENUDESC),)
 	$(call DELFILE, Kconfig)
+	$(call DELFILE, .kconfig)
 endif
 
 -include Make.dep

--- a/Make.defs
+++ b/Make.defs
@@ -53,9 +53,11 @@ endif
 # CLEANDIRS is the list of all top-level directories containing Makefiles.
 #   It is used only for cleaning.
 
-BUILDIRS  := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Make.defs))
-BUILDIRS  := $(filter-out $(APPDIR)$(DELIM)import$(DELIM),$(BUILDIRS))
-CLEANDIRS := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
+BUILDIRS   := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Make.defs))
+BUILDIRS   := $(filter-out $(APPDIR)$(DELIM)import$(DELIM),$(BUILDIRS))
+CONFIGDIRS := $(filter-out $(APPDIR)$(DELIM)builtin$(DELIM),$(BUILDIRS))
+CONFIGDIRS := $(filter-out $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Kconfig)),$(CONFIGDIRS))
+CLEANDIRS  := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
 
 # CONFIGURED_APPS is the application directories that should be built in
 #   the current configuration.

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ context_serialize:
 context: context_serialize
 
 Kconfig:
-	$(foreach SDIR, $(BUILDIRS), $(call MAKE_template,$(SDIR),preconfig))
+	$(foreach SDIR, $(CONFIGDIRS), $(call MAKE_template,$(SDIR),preconfig))
 	$(Q) $(MKKCONFIG)
 
 preconfig: Kconfig


### PR DESCRIPTION
## Summary
This PR has 2 main commits.  The first one related to #340.  It prevents the `preconfig` target from executing in application directories that don't actually need any pre-configuration.
The second one limits the execution scope of `clean` and `distclean` to the folder that we know we have built, instead of recursively going through every sub-directory.

## Impact
The `preconfig` commit reduces configuration time.
The `clean` and `distclean` commit reduces cleaning time.
Both remove a bunch of unnecessary output.
The whole `./tools/configure.sh make make distclean` procedure shall be faster.
## Testing
A bunch of configurations with different examples, hello, helloxx, ostest, etc.
