### PR TITLE
Directory.mk: The subdirectories' clean and distclean targets need to be unique.

### DIFF
--- a/Directory.mk
+++ b/Directory.mk
@@ -42,6 +42,7 @@ CONFIGSUBDIRS := $(filter-out $(dir $(wildcard *$(DELIM)Kconfig)),$(SUBDIRS))
 CLEANSUBDIRS  := $(dir $(wildcard *$(DELIM).built))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).depend))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).kconfig))
+CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))
 
 all: nothing
 


### PR DESCRIPTION
## Summary
The subdirectories' clean and distclean targets need to be unique to avoid the "overriding recipe for target" warning.

## Impact

## Testing

