### PR TITLE
Testing for UTF8 support for FAT Filesystem.

### DIFF
--- a/testing/fatutf8/Kconfig
+++ b/testing/fatutf8/Kconfig
@@ -1,0 +1,32 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config TESTING_FATUTF8
+	tristate "FAT UTF8 test"
+	default n
+	---help---
+		Enable FAT UTF8 test
+
+		For the tests to be successful, you need to enable
+		CONFIG_FAT_LFN, CONFIG_FAT_LFN_UTF8.
+
+if TESTING_FATUTF8
+
+config TESTING_FATUTF8_PROGNAME
+	string "Program name"
+	default "fatutf8"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config TESTING_FATUTF8_PRIORITY
+	int "FAT UTF8 test task priority"
+	default 100
+
+config TESTING_FATUTF8_STACKSIZE
+	int "FAT UTF8 test stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/testing/fatutf8/Make.defs
+++ b/testing/fatutf8/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/testing/fatutf8/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_TESTING_FATUTF8),)
+CONFIGURED_APPS += $(APPDIR)/testing/fatutf8
+endif

--- a/testing/fatutf8/Makefile
+++ b/testing/fatutf8/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/testing/fatutf8/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# fatutf8 test built-in application info
+
+PROGNAME  = $(CONFIG_TESTING_FATUTF8_PROGNAME)
+PRIORITY  = $(CONFIG_TESTING_FATUTF8_PRIORITY)
+STACKSIZE = $(CONFIG_TESTING_FATUTF8_STACKSIZE)
+MODULE    = $(CONFIG_TESTING_FATUTF8)
+
+# fatutf8 test files
+
+MAINSRC = fatutf8_main.c
+
+include $(APPDIR)/Application.mk

--- a/testing/fatutf8/fatutf8_main.c
+++ b/testing/fatutf8/fatutf8_main.c
@@ -1,0 +1,165 @@
+/****************************************************************************
+ * apps/testing/fatutf8/fatutf8_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void show_usage(FAR const char *progname,
+                       int exitcode) noreturn_function;
+static void show_usage(FAR const char *progname, int exitcode)
+{
+  printf("USAGE: %s [<basepath>]\n", progname);
+  printf("       %s --help\n", progname);
+  exit(exitcode);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#define BASEPATH "/mnt/sdcard"
+#define FOLDER_NAME "/ÄÖÜ 测试文件夹 Test Folder"
+#define FILE_NAME "/ÄÖÜ 测试文件 Test File"
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+  int ret;
+  int len;
+
+  char buf[128];
+  char path[256];
+
+  char *basepath = NULL;
+
+  if (argc == 2 && strcmp(argv[1], "--help") == 0)
+    {
+      show_usage("fatutf8", EXIT_SUCCESS);
+    }
+  else if (argc >= 2)
+    {
+      basepath = argv[1];
+
+      len = strlen(basepath);
+      if (basepath[len - 1] == '/')
+        {
+          basepath[--len] = '\0';
+        }
+    }
+
+  if (basepath == NULL)
+    {
+      len = snprintf(path, sizeof(path), BASEPATH FOLDER_NAME);
+    }
+  else
+    {
+      len = snprintf(path, sizeof(path), "%s"FOLDER_NAME, basepath);
+    }
+
+  if (len + sizeof(FILE_NAME) >= sizeof(path))
+    {
+      printf("Error: Resulting Path too long.");
+      return EXIT_FAILURE;
+    }
+
+  printf("mkdir(%s)\n", path);
+  ret = mkdir(path, 0777);
+  if (ret != 0)
+    {
+      printf("mkdir failed: %d\n", errno);
+    }
+  else
+    {
+      printf("mkdir successful\n");
+    }
+
+  printf("\n");
+
+  strcat(path, FILE_NAME);
+
+  printf("open(%s)\n", path);
+  fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0777);
+  if (fd >= 0)
+    {
+      printf("open successful\n");
+      printf("write(\"This is a test file in a test folder.\")\n");
+
+      len = write(fd, "This is a test file in a test folder.", 37);
+      if (len == 37)
+        {
+          printf("write successful\n");
+        }
+      else
+        {
+          printf("write failed: %d\n", errno);
+        }
+
+      fsync(fd);
+      close(fd);
+    }
+  else
+    {
+      printf("open failed: %d\n", errno);
+    }
+
+  printf("\n");
+
+  printf("open(%s)\n", path);
+  fd = open(path, O_RDONLY);
+  if (fd >= 0)
+    {
+      printf("open successful\n");
+
+      len = read(fd, buf, sizeof(buf));
+      buf[len] = '\0';
+
+      if (len)
+        {
+          printf("read(\"%s\") successful\n", buf);
+        }
+      else
+        {
+          printf("read failed: %d\n", errno);
+        }
+
+      close(fd);
+    }
+  else
+    {
+      printf("open failed: %d\n", errno);
+    }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
Testing for CONFIG_FAT_LFN_UTF8, because nsh doesn't accept characters outside 0x7f
## Impact
--
## Testing
--
