### PR TITLE
Add flags to usrsock daemons

### DIFF
--- a/examples/usrsocktest/usrsocktest_basic_connect.c
+++ b/examples/usrsocktest/usrsocktest_basic_connect.c
@@ -77,7 +77,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Setup
+ * Name: setup
  *
  * Description:
  *   Run before every testcase
@@ -93,7 +93,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Setup(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void setup(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   dconf->endpoint_addr = "127.0.0.1";
   dconf->endpoint_port = 255;
@@ -123,7 +123,7 @@ static void Setup(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Teardown(void)
+static void teardown(void)
 {
   int ret;
 
@@ -141,7 +141,7 @@ static void Teardown(void)
 }
 
 /****************************************************************************
- * Name: NotConnected
+ * Name: not_connected
  *
  * Description:
  *   Opened socket is not connected
@@ -157,13 +157,13 @@ static void Teardown(void)
  *
  ****************************************************************************/
 
-static void NotConnected(void)
+static void not_connected(void)
 {
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
 }
 
 /****************************************************************************
- * Name: Connect
+ * Name: basic_connect_connect
  *
  * Description:
  *   Open and connect the socket
@@ -179,7 +179,7 @@ static void NotConnected(void)
  *
  ****************************************************************************/
 
-static void Connect(void)
+static void basic_connect_connect(void)
 {
   int ret;
   struct sockaddr_in addr;
@@ -232,7 +232,7 @@ static void Connect(void)
 }
 
 /****************************************************************************
- * Name: WrongAF
+ * Name: wrong_af
  *
  * Description:
  *   Open and connect the socket with wrong AF
@@ -248,7 +248,7 @@ static void Connect(void)
  *
  ****************************************************************************/
 
-static void WrongAF(void)
+static void wrong_af(void)
 {
   int ret;
   struct sockaddr_in addr;
@@ -282,7 +282,7 @@ static void WrongAF(void)
 }
 
 /****************************************************************************
- * Name: WrongPort
+ * Name: wrong_port
  *
  * Description:
  *   Open and connect the socket with wrong port
@@ -298,7 +298,7 @@ static void WrongAF(void)
  *
  ****************************************************************************/
 
-static void WrongPort(void)
+static void wrong_port(void)
 {
   int ret;
   struct sockaddr_in addr;
@@ -332,7 +332,7 @@ static void WrongPort(void)
 }
 
 /****************************************************************************
- * Name: WrongEndpoint
+ * Name: wrong_endpoint
  *
  * Description:
  *   Open and connect the socket with wrong endpoint
@@ -348,7 +348,7 @@ static void WrongPort(void)
  *
  ****************************************************************************/
 
-static void WrongEndpoint(void)
+static void wrong_endpoint(void)
 {
   int ret;
   struct sockaddr_in addr;
@@ -391,97 +391,97 @@ static void WrongEndpoint(void)
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-TEST_SETUP(BasicConnect)
+TEST_SETUP(basic_connect)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Setup(&usrsocktest_daemon_config);
+  setup(&usrsocktest_daemon_config);
 }
 
-TEST_TEAR_DOWN(BasicConnect)
+TEST_TEAR_DOWN(basic_connect)
 {
-  Teardown();
+  teardown();
 }
 
-TEST(BasicConnect, NotConnected)
+TEST(basic_connect, not_connected)
 {
-  NotConnected();
+  not_connected();
 }
 
-TEST(BasicConnect, Connect)
+TEST(basic_connect, basic_connect_connect)
 {
-  Connect();
+  basic_connect_connect();
 }
 
-TEST(BasicConnect, WrongAF)
+TEST(basic_connect, wrong_af)
 {
-  WrongAF();
+  wrong_af();
 }
 
-TEST(BasicConnect, WrongPort)
+TEST(basic_connect, wrong_port)
 {
-  WrongPort();
+  wrong_port();
 }
 
-TEST(BasicConnect, WrongEndpoint)
+TEST(basic_connect, wrong_endpoint)
 {
-  WrongEndpoint();
+  wrong_endpoint();
 }
 
-TEST_SETUP(BasicConnectDelay)
+TEST_SETUP(basic_connect_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Setup(&usrsocktest_daemon_config);
+  setup(&usrsocktest_daemon_config);
 }
 
-TEST_TEAR_DOWN(BasicConnectDelay)
+TEST_TEAR_DOWN(basic_connect_delay)
 {
-  Teardown();
+  teardown();
 }
 
-TEST(BasicConnectDelay, NotConnected)
+TEST(basic_connect_delay, not_connected)
 {
-  NotConnected();
+  not_connected();
 }
 
-TEST(BasicConnectDelay, Connect)
+TEST(basic_connect_delay, basic_connect_connect)
 {
-  Connect();
+  basic_connect_connect();
 }
 
-TEST(BasicConnectDelay, WrongAF)
+TEST(basic_connect_delay, wrong_af)
 {
-  WrongAF();
+  wrong_af();
 }
 
-TEST(BasicConnectDelay, WrongPort)
+TEST(basic_connect_delay, wrong_port)
 {
-  WrongPort();
+  wrong_port();
 }
 
-TEST(BasicConnectDelay, WrongEndpoint)
+TEST(basic_connect_delay, wrong_endpoint)
 {
-  WrongEndpoint();
+  wrong_endpoint();
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicConnect)
+TEST_GROUP(basic_connect)
 {
-  RUN_TEST_CASE(BasicConnect, NotConnected);
-  RUN_TEST_CASE(BasicConnect, Connect);
-  RUN_TEST_CASE(BasicConnect, WrongAF);
-  RUN_TEST_CASE(BasicConnect, WrongPort);
-  RUN_TEST_CASE(BasicConnect, WrongEndpoint);
+  RUN_TEST_CASE(basic_connect, not_connected);
+  RUN_TEST_CASE(basic_connect, basic_connect_connect);
+  RUN_TEST_CASE(basic_connect, wrong_af);
+  RUN_TEST_CASE(basic_connect, wrong_port);
+  RUN_TEST_CASE(basic_connect, wrong_endpoint);
 }
 
-TEST_GROUP(BasicConnectDelay)
+TEST_GROUP(basic_connect_delay)
 {
-  RUN_TEST_CASE(BasicConnectDelay, NotConnected);
-  RUN_TEST_CASE(BasicConnectDelay, Connect);
-  RUN_TEST_CASE(BasicConnectDelay, WrongAF);
-  RUN_TEST_CASE(BasicConnectDelay, WrongPort);
-  RUN_TEST_CASE(BasicConnectDelay, WrongEndpoint);
+  RUN_TEST_CASE(basic_connect_delay, not_connected);
+  RUN_TEST_CASE(basic_connect_delay, basic_connect_connect);
+  RUN_TEST_CASE(basic_connect_delay, wrong_af);
+  RUN_TEST_CASE(basic_connect_delay, wrong_port);
+  RUN_TEST_CASE(basic_connect_delay, wrong_endpoint);
 }

--- a/examples/usrsocktest/usrsocktest_basic_daemon.c
+++ b/examples/usrsocktest/usrsocktest_basic_daemon.c
@@ -67,7 +67,9 @@
  ****************************************************************************/
 
 static bool started;
-static int sd, sd2, sd3;
+static int sd;
+static int sd2;
+static int sd3;
 
 /****************************************************************************
  * Public Data
@@ -78,7 +80,7 @@ static int sd, sd2, sd3;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: NoActiveSockets
+ * Name: no_active_sockets
  *
  * Description:
  *   Checks there is no active sockets on daemon startup
@@ -94,7 +96,7 @@ static int sd, sd2, sd3;
  *
  ****************************************************************************/
 
-static void NoActiveSockets(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void no_active_sockets(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(dconf));
   started = true;
@@ -103,7 +105,7 @@ static void NoActiveSockets(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: OpenClose
+ * Name: open_close
  *
  * Description:
  *   Open and close AF_INET socket, check active socket counter updates
@@ -119,7 +121,7 @@ static void NoActiveSockets(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void OpenClose(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void open_close(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(dconf));
   started = true;
@@ -139,7 +141,7 @@ static void OpenClose(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: UnsupportedType
+ * Name: unsupported_type
  *
  * Description:
  *   Try open socket for unsupported type
@@ -155,7 +157,7 @@ static void OpenClose(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void UnsupportedType(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void unsupported_type(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(dconf));
   started = true;
@@ -172,7 +174,7 @@ static void UnsupportedType(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: UnsupportedProto
+ * Name: unsupported_proto
  *
  * Description:
  *   Try open socket for unsupported protocol
@@ -188,7 +190,7 @@ static void UnsupportedType(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void UnsupportedProto(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void unsupported_proto(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(dconf));
   started = true;
@@ -205,7 +207,7 @@ static void UnsupportedProto(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: OpenThree
+ * Name: open_three
  *
  * Description:
  *   Open multiple sockets
@@ -221,7 +223,7 @@ static void UnsupportedProto(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void OpenThree(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void open_three(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
 
@@ -262,10 +264,10 @@ static void OpenThree(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Dup
+ * Name: basic_daemon_dup
  *
  * Description:
- *   Dup opened socket
+ *   basic_daemon_dup opened socket
  *
  * Input Parameters:
  *   None
@@ -278,7 +280,7 @@ static void OpenThree(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Dup(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void basic_daemon_dup(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
 
@@ -317,7 +319,7 @@ static void Dup(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Dup2
+ * Name: basic_daemon_dup2
  *
  * Description:
  *   Clone opened socket with dup2
@@ -333,7 +335,7 @@ static void Dup(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Dup2(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void basic_daemon_dup2(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
 
@@ -367,7 +369,7 @@ static void Dup2(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Stops
+ * Name: stops
  *
  * Description:
  *   Daemon stops unexpectedly
@@ -383,7 +385,7 @@ static void Dup2(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Stops(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void stops(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
 
@@ -404,7 +406,6 @@ static void Stops(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 
-
   TEST_ASSERT_EQUAL(0, close(sd));
   sd = -1;
   TEST_ASSERT_EQUAL(0, close(sd2));
@@ -412,7 +413,7 @@ static void Stops(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: StopsStarts
+ * Name: stops_starts
  *
  * Description:
  *   Daemon stops and restarts unexpectedly
@@ -428,7 +429,7 @@ static void Stops(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void StopsStarts(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void stops_starts(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
   struct sockaddr_in addr;
@@ -475,7 +476,7 @@ static void StopsStarts(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BasicDaemon test group setup
+ * Name: basic_daemon test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -491,7 +492,7 @@ static void StopsStarts(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BasicDaemon)
+TEST_SETUP(basic_daemon)
 {
   sd = -1;
   sd2 = -1;
@@ -500,7 +501,7 @@ TEST_SETUP(BasicDaemon)
 }
 
 /****************************************************************************
- * Name: BasicDaemon test group teardown
+ * Name: basic_daemon test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -516,7 +517,7 @@ TEST_SETUP(BasicDaemon)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BasicDaemon)
+TEST_TEAR_DOWN(basic_daemon)
 {
   int ret;
   if (sd >= 0)
@@ -524,16 +525,19 @@ TEST_TEAR_DOWN(BasicDaemon)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (sd2 >= 0)
     {
       ret = close(sd2);
       assert(ret >= 0);
     }
+
   if (sd3 >= 0)
     {
       ret = close(sd3);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -541,145 +545,145 @@ TEST_TEAR_DOWN(BasicDaemon)
     }
 }
 
-TEST(BasicDaemon, NoActiveSockets)
+TEST(basic_daemon, no_active_sockets)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  NoActiveSockets(&usrsocktest_daemon_config);
+  no_active_sockets(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, NoActiveSocketsDelay)
+TEST(basic_daemon, no_active_sockets_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  NoActiveSockets(&usrsocktest_daemon_config);
+  no_active_sockets(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, OpenClose)
+TEST(basic_daemon, open_close)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  OpenClose(&usrsocktest_daemon_config);
+  open_close(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, OpenCloseDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  OpenClose(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, UnsupportedType)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  UnsupportedType(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, UnsupportedTypeDelay)
+TEST(basic_daemon, open_close_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  UnsupportedType(&usrsocktest_daemon_config);
+  open_close(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, UnsupportedProto)
+TEST(basic_daemon, unsupported_type)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  UnsupportedProto(&usrsocktest_daemon_config);
+  unsupported_type(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, UnsupportedProtoDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  UnsupportedProto(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, OpenThree)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  OpenThree(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, OpenThreeDelay)
+TEST(basic_daemon, unsupported_type_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  OpenThree(&usrsocktest_daemon_config);
+  unsupported_type(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, Dup)
+TEST(basic_daemon, unsupported_proto)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Dup(&usrsocktest_daemon_config);
+  unsupported_proto(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, DupDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  Dup(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, Dup2)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Dup2(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, Dup2Delay)
+TEST(basic_daemon, unsupported_proto_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Dup2(&usrsocktest_daemon_config);
+  unsupported_proto(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, Stops)
+TEST(basic_daemon, open_three)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Stops(&usrsocktest_daemon_config);
+  open_three(&usrsocktest_daemon_config);
 }
 
-TEST(BasicDaemon, StopsDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  Stops(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, StopsStarts)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  StopsStarts(&usrsocktest_daemon_config);
-}
-
-TEST(BasicDaemon, StopsStartsDelay)
+TEST(basic_daemon, open_three_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  StopsStarts(&usrsocktest_daemon_config);
+  open_three(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, basic_daemon_dup)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  basic_daemon_dup(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, basic_daemon_dup_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  basic_daemon_dup(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, basic_daemon_dup2)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  basic_daemon_dup2(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, basic_daemon_dup2_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  basic_daemon_dup2(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, stops)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  stops(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, stops_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  stops(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, stops_starts)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  stops_starts(&usrsocktest_daemon_config);
+}
+
+TEST(basic_daemon, stops_starts_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  stops_starts(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicDaemon)
+TEST_GROUP(basic_daemon)
 {
-  RUN_TEST_CASE(BasicDaemon, NoActiveSockets);
-  RUN_TEST_CASE(BasicDaemon, NoActiveSocketsDelay);
-  RUN_TEST_CASE(BasicDaemon, OpenClose);
-  RUN_TEST_CASE(BasicDaemon, OpenCloseDelay);
-  RUN_TEST_CASE(BasicDaemon, UnsupportedType);
-  RUN_TEST_CASE(BasicDaemon, UnsupportedTypeDelay);
-  RUN_TEST_CASE(BasicDaemon, UnsupportedProto);
-  RUN_TEST_CASE(BasicDaemon, UnsupportedProtoDelay);
-  RUN_TEST_CASE(BasicDaemon, OpenThree);
-  RUN_TEST_CASE(BasicDaemon, OpenThreeDelay);
-  RUN_TEST_CASE(BasicDaemon, Dup);
-  RUN_TEST_CASE(BasicDaemon, DupDelay);
-  RUN_TEST_CASE(BasicDaemon, Dup2);
-  RUN_TEST_CASE(BasicDaemon, Dup2Delay);
-  RUN_TEST_CASE(BasicDaemon, Stops);
-  RUN_TEST_CASE(BasicDaemon, StopsDelay);
-  RUN_TEST_CASE(BasicDaemon, StopsStarts);
-  RUN_TEST_CASE(BasicDaemon, StopsStartsDelay);
+  RUN_TEST_CASE(basic_daemon, no_active_sockets);
+  RUN_TEST_CASE(basic_daemon, no_active_sockets_delay);
+  RUN_TEST_CASE(basic_daemon, open_close);
+  RUN_TEST_CASE(basic_daemon, open_close_delay);
+  RUN_TEST_CASE(basic_daemon, unsupported_type);
+  RUN_TEST_CASE(basic_daemon, unsupported_type_delay);
+  RUN_TEST_CASE(basic_daemon, unsupported_proto);
+  RUN_TEST_CASE(basic_daemon, unsupported_proto_delay);
+  RUN_TEST_CASE(basic_daemon, open_three);
+  RUN_TEST_CASE(basic_daemon, open_three_delay);
+  RUN_TEST_CASE(basic_daemon, basic_daemon_dup);
+  RUN_TEST_CASE(basic_daemon, basic_daemon_dup_delay);
+  RUN_TEST_CASE(basic_daemon, basic_daemon_dup2);
+  RUN_TEST_CASE(basic_daemon, basic_daemon_dup2_delay);
+  RUN_TEST_CASE(basic_daemon, stops);
+  RUN_TEST_CASE(basic_daemon, stops_delay);
+  RUN_TEST_CASE(basic_daemon, stops_starts);
+  RUN_TEST_CASE(basic_daemon, stops_starts_delay);
 }

--- a/examples/usrsocktest/usrsocktest_basic_getsockname.c
+++ b/examples/usrsocktest/usrsocktest_basic_getsockname.c
@@ -78,7 +78,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Open
+ * Name: basic_getsockname_open
  *
  * Description:
  *   Open and get socket options
@@ -94,7 +94,8 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
+static
+void basic_getsockname_open(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
   socklen_t addrlen;
@@ -209,7 +210,7 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BasicGetSockName test group setup
+ * Name: basic_getsockname test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -225,14 +226,14 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BasicGetSockName)
+TEST_SETUP(basic_getsockname)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BasicGetSockName test group teardown
+ * Name: basic_getsockname test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -248,7 +249,7 @@ TEST_SETUP(BasicGetSockName)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BasicGetSockName)
+TEST_TEAR_DOWN(basic_getsockname)
 {
   int ret;
   if (sd >= 0)
@@ -256,6 +257,7 @@ TEST_TEAR_DOWN(BasicGetSockName)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -263,25 +265,25 @@ TEST_TEAR_DOWN(BasicGetSockName)
     }
 }
 
-TEST(BasicGetSockName, Open)
+TEST(basic_getsockname, basic_getsockname_open)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Open(&usrsocktest_daemon_config);
+  basic_getsockname_open(&usrsocktest_daemon_config);
 }
 
-TEST(BasicGetSockName, OpenDelay)
+TEST(basic_getsockname, basic_getsockname_open_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Open(&usrsocktest_daemon_config);
+  basic_getsockname_open(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicGetSockName)
+TEST_GROUP(basic_getsockname)
 {
-  RUN_TEST_CASE(BasicGetSockName, Open);
-  RUN_TEST_CASE(BasicGetSockName, OpenDelay);
+  RUN_TEST_CASE(basic_getsockname, basic_getsockname_open);
+  RUN_TEST_CASE(basic_getsockname, basic_getsockname_open_delay);
 }

--- a/examples/usrsocktest/usrsocktest_basic_getsockopt.c
+++ b/examples/usrsocktest/usrsocktest_basic_getsockopt.c
@@ -75,7 +75,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Open
+ * Name: basic_getsockopt_open
  *
  * Description:
  *   Open and get socket options
@@ -91,7 +91,8 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
+static
+void basic_getsockopt_open(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
   int value;
@@ -188,7 +189,7 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BasicGetSockOpt test group setup
+ * Name: basic_getsockopt test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -204,14 +205,14 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BasicGetSockOpt)
+TEST_SETUP(basic_getsockopt)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BasicGetSockOpt test group teardown
+ * Name: basic_getsockopt test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -227,7 +228,7 @@ TEST_SETUP(BasicGetSockOpt)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BasicGetSockOpt)
+TEST_TEAR_DOWN(basic_getsockopt)
 {
   int ret;
   if (sd >= 0)
@@ -235,6 +236,7 @@ TEST_TEAR_DOWN(BasicGetSockOpt)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -242,25 +244,25 @@ TEST_TEAR_DOWN(BasicGetSockOpt)
     }
 }
 
-TEST(BasicGetSockOpt, Open)
+TEST(basic_getsockopt, basic_getsockopt_open)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Open(&usrsocktest_daemon_config);
+  basic_getsockopt_open(&usrsocktest_daemon_config);
 }
 
-TEST(BasicGetSockOpt, OpenDelay)
+TEST(basic_getsockopt, basic_getsockopt_open_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Open(&usrsocktest_daemon_config);
+  basic_getsockopt_open(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicGetSockOpt)
+TEST_GROUP(basic_getsockopt)
 {
-  RUN_TEST_CASE(BasicGetSockOpt, Open);
-  RUN_TEST_CASE(BasicGetSockOpt, OpenDelay);
+  RUN_TEST_CASE(basic_getsockopt, basic_getsockopt_open);
+  RUN_TEST_CASE(basic_getsockopt, basic_getsockopt_open_delay);
 }

--- a/examples/usrsocktest/usrsocktest_basic_send.c
+++ b/examples/usrsocktest/usrsocktest_basic_send.c
@@ -78,7 +78,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Send
+ * Name: basic_send_send
  *
  * Description:
  *   Open socket and send
@@ -94,7 +94,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Send(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void basic_send_send(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   struct sockaddr_in addr;
   ssize_t ret;
@@ -183,11 +183,10 @@ static void Send(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_send_bytes());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
-
 }
 
 /****************************************************************************
- * Name: ConnectSend
+ * Name: connect_send
  *
  * Description:
  *   Send over connected socket
@@ -202,7 +201,8 @@ static void Send(FAR struct usrsocktest_daemon_conf_s *dconf)
  *   None
  *
  ****************************************************************************/
-static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
+
+static void connect_send(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   struct sockaddr_in addr;
   ssize_t ret;
@@ -266,7 +266,7 @@ static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BasicSend test group setup
+ * Name: basic_send test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -282,14 +282,14 @@ static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BasicSend)
+TEST_SETUP(basic_send)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BasicSend test group teardown
+ * Name: basic_send test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -305,7 +305,7 @@ TEST_SETUP(BasicSend)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BasicSend)
+TEST_TEAR_DOWN(basic_send)
 {
   int ret;
   if (sd >= 0)
@@ -313,6 +313,7 @@ TEST_TEAR_DOWN(BasicSend)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -320,40 +321,40 @@ TEST_TEAR_DOWN(BasicSend)
     }
 }
 
-TEST(BasicSend, Send)
+TEST(basic_send, basic_send_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Send(&usrsocktest_daemon_config);
+  basic_send_send(&usrsocktest_daemon_config);
 }
 
-TEST(BasicSend, SendDelay)
+TEST(basic_send, basic_send_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Send(&usrsocktest_daemon_config);
+  basic_send_send(&usrsocktest_daemon_config);
 }
 
-TEST(BasicSend, ConnectSend)
+TEST(basic_send, connect_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
-TEST(BasicSend, ConnectSendDelay)
+TEST(basic_send, connect_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicSend)
+TEST_GROUP(basic_send)
 {
-  RUN_TEST_CASE(BasicSend, Send);
-  RUN_TEST_CASE(BasicSend, SendDelay);
-  RUN_TEST_CASE(BasicSend, ConnectSend);
-  RUN_TEST_CASE(BasicSend, ConnectSendDelay);
+  RUN_TEST_CASE(basic_send, basic_send_send);
+  RUN_TEST_CASE(basic_send, basic_send_send_delay);
+  RUN_TEST_CASE(basic_send, connect_send);
+  RUN_TEST_CASE(basic_send, connect_send_delay);
 }

--- a/examples/usrsocktest/usrsocktest_basic_setsockopt.c
+++ b/examples/usrsocktest/usrsocktest_basic_setsockopt.c
@@ -77,7 +77,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Open
+ * Name: basic_setsockopt_open
  *
  * Description:
  *   Open and set socket options
@@ -93,7 +93,8 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
+static
+void basic_setsockopt_open(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   int ret;
   int value;
@@ -156,7 +157,7 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BasicSetSockOpt test group setup
+ * Name: basic_setsockopt test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -172,14 +173,14 @@ static void Open(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BasicSetSockOpt)
+TEST_SETUP(basic_setsockopt)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BasicSetSockOpt test group teardown
+ * Name: basic_setsockopt test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -195,7 +196,7 @@ TEST_SETUP(BasicSetSockOpt)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BasicSetSockOpt)
+TEST_TEAR_DOWN(basic_setsockopt)
 {
   int ret;
   if (sd >= 0)
@@ -203,6 +204,7 @@ TEST_TEAR_DOWN(BasicSetSockOpt)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -210,25 +212,25 @@ TEST_TEAR_DOWN(BasicSetSockOpt)
     }
 }
 
-TEST(BasicSetSockOpt, Open)
+TEST(basic_setsockopt, basic_setsockopt_open)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Open(&usrsocktest_daemon_config);
+  basic_setsockopt_open(&usrsocktest_daemon_config);
 }
 
-TEST(BasicSetSockOpt, OpenDelay)
+TEST(basic_setsockopt, basic_setsockopt_open_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Open(&usrsocktest_daemon_config);
+  basic_setsockopt_open(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BasicSetSockOpt)
+TEST_GROUP(basic_setsockopt)
 {
-  RUN_TEST_CASE(BasicSetSockOpt, Open);
-  RUN_TEST_CASE(BasicSetSockOpt, OpenDelay);
+  RUN_TEST_CASE(basic_setsockopt, basic_setsockopt_open);
+  RUN_TEST_CASE(basic_setsockopt, basic_setsockopt_open_delay);
 }

--- a/examples/usrsocktest/usrsocktest_block_recv.c
+++ b/examples/usrsocktest/usrsocktest_block_recv.c
@@ -79,7 +79,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ConnectReceive
+ * Name: connect_receive
  *
  * Description:
  *   Blocking connect and receive
@@ -95,7 +95,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void ConnectReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void connect_receive(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -181,7 +181,7 @@ static void ConnectReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: NoBlockConnect
+ * Name: no_block_connect
  *
  * Description:
  *   Non-blocking connect and blocking receive
@@ -197,7 +197,7 @@ static void ConnectReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void NoBlockConnect(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void no_block_connect(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -308,7 +308,7 @@ static void NoBlockConnect(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: ReceiveTimeout
+ * Name: receive_timeout
  *
  * Description:
  *   Blocking connect and receive with SO_RCVTIMEO
@@ -324,7 +324,7 @@ static void NoBlockConnect(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void ReceiveTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void receive_timeout(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -404,9 +404,8 @@ static void ReceiveTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-
 /****************************************************************************
- * Name: PeekReceive
+ * Name: peek_receive
  *
  * Description:
  *   Blocking connect and receive with MSG_PEEK flag
@@ -422,7 +421,7 @@ static void ReceiveTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void PeekReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void peek_receive(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -533,7 +532,7 @@ static void PeekReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BlockRecv test group setup
+ * Name: block_recv test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -549,14 +548,14 @@ static void PeekReceive(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BlockRecv)
+TEST_SETUP(block_recv)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BlockRecv test group teardown
+ * Name: block_recv test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -572,14 +571,16 @@ TEST_SETUP(BlockRecv)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BlockRecv)
+TEST_TEAR_DOWN(block_recv)
 {
   int ret;
+
   if (sd >= 0)
     {
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -587,70 +588,70 @@ TEST_TEAR_DOWN(BlockRecv)
     }
 }
 
-TEST(BlockRecv, ConnectReceive)
+TEST(block_recv, connect_receive)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  ConnectReceive(&usrsocktest_daemon_config);
+  connect_receive(&usrsocktest_daemon_config);
 }
 
-TEST(BlockRecv, ConnectReceiveDelay)
+TEST(block_recv, connect_receive_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  ConnectReceive(&usrsocktest_daemon_config);
+  connect_receive(&usrsocktest_daemon_config);
 }
 
-TEST(BlockRecv, NoBlockConnect)
+TEST(block_recv, no_block_connect)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  NoBlockConnect(&usrsocktest_daemon_config);
+  no_block_connect(&usrsocktest_daemon_config);
 }
 
-TEST(BlockRecv, NoBlockConnectDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  NoBlockConnect(&usrsocktest_daemon_config);
-}
-
-TEST(BlockRecv, ReceiveTimeout)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  ReceiveTimeout(&usrsocktest_daemon_config);
-}
-
-TEST(BlockRecv, ReceiveTimeoutDelay)
+TEST(block_recv, no_block_connect_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  ReceiveTimeout(&usrsocktest_daemon_config);
+  no_block_connect(&usrsocktest_daemon_config);
 }
 
-TEST(BlockRecv, PeekReceive)
+TEST(block_recv, receive_timeout)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  PeekReceive(&usrsocktest_daemon_config);
+  receive_timeout(&usrsocktest_daemon_config);
 }
 
-TEST(BlockRecv, PeekReceiveDelay)
+TEST(block_recv, receive_timeout_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  PeekReceive(&usrsocktest_daemon_config);
+  receive_timeout(&usrsocktest_daemon_config);
+}
+
+TEST(block_recv, peek_receive)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  peek_receive(&usrsocktest_daemon_config);
+}
+
+TEST(block_recv, peek_receive_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  peek_receive(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BlockRecv)
+TEST_GROUP(block_recv)
 {
-  RUN_TEST_CASE(BlockRecv, ConnectReceive);
-  RUN_TEST_CASE(BlockRecv, ConnectReceiveDelay);
-  RUN_TEST_CASE(BlockRecv, NoBlockConnect);
-  RUN_TEST_CASE(BlockRecv, NoBlockConnectDelay);
-  RUN_TEST_CASE(BlockRecv, ReceiveTimeout);
-  RUN_TEST_CASE(BlockRecv, ReceiveTimeoutDelay);
-  RUN_TEST_CASE(BlockRecv, PeekReceive);
-  RUN_TEST_CASE(BlockRecv, PeekReceiveDelay);
+  RUN_TEST_CASE(block_recv, connect_receive);
+  RUN_TEST_CASE(block_recv, connect_receive_delay);
+  RUN_TEST_CASE(block_recv, no_block_connect);
+  RUN_TEST_CASE(block_recv, no_block_connect_delay);
+  RUN_TEST_CASE(block_recv, receive_timeout);
+  RUN_TEST_CASE(block_recv, receive_timeout_delay);
+  RUN_TEST_CASE(block_recv, peek_receive);
+  RUN_TEST_CASE(block_recv, peek_receive_delay);
 }

--- a/examples/usrsocktest/usrsocktest_block_send.c
+++ b/examples/usrsocktest/usrsocktest_block_send.c
@@ -80,7 +80,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ConnectSend
+ * Name: connect_send
  *
  * Description:
  *   Open socket, connect in blocking mode and send
@@ -96,7 +96,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void connect_send(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -162,7 +162,7 @@ static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: NonBlockConnectSend
+ * Name: non_block_connect_send
  *
  * Description:
  *   Open socket, connect in non-blocking mode and send
@@ -178,7 +178,8 @@ static void ConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void NonBlockConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
+static
+void non_block_connect_send(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -244,7 +245,7 @@ static void NonBlockConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: SendTimeout
+ * Name: send_timeout
  *
  * Description:
  *   Open socket, connect in blocking mode and send with SO_SNDTIMEO
@@ -260,7 +261,7 @@ static void NonBlockConnectSend(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void SendTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
+static void send_timeout(FAR struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -333,7 +334,7 @@ static void SendTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: BlockSend test group setup
+ * Name: block_send test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -349,14 +350,14 @@ static void SendTimeout(FAR struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(BlockSend)
+TEST_SETUP(block_send)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: BlockSend test group teardown
+ * Name: block_send test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -372,7 +373,7 @@ TEST_SETUP(BlockSend)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(BlockSend)
+TEST_TEAR_DOWN(block_send)
 {
   int ret;
   if (sd >= 0)
@@ -380,6 +381,7 @@ TEST_TEAR_DOWN(BlockSend)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -387,55 +389,55 @@ TEST_TEAR_DOWN(BlockSend)
     }
 }
 
-TEST(BlockSend, ConnectSend)
+TEST(block_send, connect_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
-TEST(BlockSend, ConnectSendDelay)
+TEST(block_send, connect_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
-TEST(BlockSend, NonBlockConnectSend)
+TEST(block_send, non_block_connect_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  NonBlockConnectSend(&usrsocktest_daemon_config);
+  non_block_connect_send(&usrsocktest_daemon_config);
 }
 
-TEST(BlockSend, NonBlockConnectSendDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  NonBlockConnectSend(&usrsocktest_daemon_config);
-}
-
-TEST(BlockSend, SendTimeout)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  SendTimeout(&usrsocktest_daemon_config);
-}
-
-TEST(BlockSend, SendTimeoutDelay)
+TEST(block_send, non_block_connect_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  SendTimeout(&usrsocktest_daemon_config);
+  non_block_connect_send(&usrsocktest_daemon_config);
+}
+
+TEST(block_send, send_timeout)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  send_timeout(&usrsocktest_daemon_config);
+}
+
+TEST(block_send, send_timeout_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  send_timeout(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(BlockSend)
+TEST_GROUP(block_send)
 {
-  RUN_TEST_CASE(BlockSend, ConnectSend);
-  RUN_TEST_CASE(BlockSend, ConnectSendDelay);
-  RUN_TEST_CASE(BlockSend, NonBlockConnectSend);
-  RUN_TEST_CASE(BlockSend, NonBlockConnectSendDelay);
-  RUN_TEST_CASE(BlockSend, SendTimeout);
-  RUN_TEST_CASE(BlockSend, SendTimeoutDelay);
+  RUN_TEST_CASE(block_send, connect_send);
+  RUN_TEST_CASE(block_send, connect_send_delay);
+  RUN_TEST_CASE(block_send, non_block_connect_send);
+  RUN_TEST_CASE(block_send, non_block_connect_send_delay);
+  RUN_TEST_CASE(block_send, send_timeout);
+  RUN_TEST_CASE(block_send, send_timeout_delay);
 }

--- a/examples/usrsocktest/usrsocktest_chardev.c
+++ b/examples/usrsocktest/usrsocktest_chardev.c
@@ -72,7 +72,7 @@ static int us_fd_two;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: CharDev test group setup
+ * Name: char_dev test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -88,14 +88,14 @@ static int us_fd_two;
  *
  ****************************************************************************/
 
-TEST_SETUP(CharDev)
+TEST_SETUP(char_dev)
 {
   us_fd = -1;
   us_fd_two = -1;
 }
 
 /****************************************************************************
- * Name: CharDev test group teardown
+ * Name: char_dev test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -111,7 +111,7 @@ TEST_SETUP(CharDev)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(CharDev)
+TEST_TEAR_DOWN(char_dev)
 {
   int ret;
 
@@ -120,6 +120,7 @@ TEST_TEAR_DOWN(CharDev)
       ret = close(us_fd);
       assert(ret >= 0);
     }
+
   if (us_fd_two >= 0)
     {
       ret = close(us_fd_two);
@@ -128,7 +129,7 @@ TEST_TEAR_DOWN(CharDev)
 }
 
 /****************************************************************************
- * Name: OpenRw
+ * Name: open_rw
  *
  * Description:
  *   Simple test for opening and closing usrsock node
@@ -144,7 +145,7 @@ TEST_TEAR_DOWN(CharDev)
  *
  ****************************************************************************/
 
-TEST(CharDev, OpenRw)
+TEST(char_dev, open_rw)
 {
   int ret;
 
@@ -157,7 +158,7 @@ TEST(CharDev, OpenRw)
 }
 
 /****************************************************************************
- * Name: ReopenRw
+ * Name: reopen_rw
  *
  * Description:
  *   Repeated simple test for opening and closing usrsock node, reopen should
@@ -174,7 +175,7 @@ TEST(CharDev, OpenRw)
  *
  ****************************************************************************/
 
-TEST(CharDev, ReopenRw)
+TEST(char_dev, reopen_rw)
 {
   int ret;
 
@@ -194,7 +195,7 @@ TEST(CharDev, ReopenRw)
 }
 
 /****************************************************************************
- * Name: NoMultipleOpen
+ * Name: no_multiple_open
  *
  * Description:
  *   No permission for multiple access,
@@ -211,7 +212,7 @@ TEST(CharDev, ReopenRw)
  *
  ****************************************************************************/
 
-TEST(CharDev, NoMultipleOpen)
+TEST(char_dev, no_multiple_open)
 {
   us_fd = open(USRSOCK_NODE, O_RDWR);
   TEST_ASSERT_TRUE(us_fd >= 0);
@@ -225,9 +226,9 @@ TEST(CharDev, NoMultipleOpen)
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(CharDev)
+TEST_GROUP(char_dev)
 {
-  RUN_TEST_CASE(CharDev, OpenRw);
-  RUN_TEST_CASE(CharDev, ReopenRw);
-  RUN_TEST_CASE(CharDev, NoMultipleOpen);
+  RUN_TEST_CASE(char_dev, open_rw);
+  RUN_TEST_CASE(char_dev, reopen_rw);
+  RUN_TEST_CASE(char_dev, no_multiple_open);
 }

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -879,7 +879,12 @@ prepare:
         {
           char tmp = 'a' + i;
 
-          tsock->recv_avail_bytes--;
+          /* Check if MSG_PEEK flag is specified. */
+
+          if ((req->flags & MSG_PEEK) != MSG_PEEK)
+            {
+              tsock->recv_avail_bytes--;
+            }
 
           wlen = write(fd, &tmp, 1);
           if (wlen < 0)

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -173,15 +173,20 @@ static int test_socket_alloc(FAR struct daemon_priv_s *priv)
   return -1;
 }
 
-static FAR struct test_socket_s *test_socket_get(FAR struct daemon_priv_s *priv,
-                                                 int sockid)
+static FAR struct test_socket_s *test_socket_get(
+  FAR struct daemon_priv_s *priv,
+  int sockid)
 {
   if (sockid < TEST_SOCKET_SOCKID_BASE)
-    return NULL;
+    {
+      return NULL;
+    }
 
   sockid -= TEST_SOCKET_SOCKID_BASE;
   if (sockid >= ARRAY_SIZE(priv->test_sockets))
-    return NULL;
+    {
+      return NULL;
+    }
 
   return &priv->test_sockets[sockid];
 }
@@ -191,35 +196,44 @@ static int test_socket_free(FAR struct daemon_priv_s *priv, int sockid)
   FAR struct test_socket_s *tsock = test_socket_get(priv, sockid);
 
   if (!tsock)
-    return -EBADFD;
+    {
+      return -EBADFD;
+    }
 
   if (!tsock->opened)
-    return -EFAULT;
+    {
+      return -EFAULT;
+    }
 
   if (tsock->connected)
     {
       priv->sockets_connected--;
       tsock->connected = false;
     }
+
   if (tsock->blocked_connect)
     {
       priv->sockets_waiting_connect--;
       tsock->blocked_connect = false;
     }
+
   if (tsock->endp)
     {
       free(tsock->endp);
       usrsocktest_endp_malloc_cnt--;
       tsock->endp = NULL;
     }
+
   if (tsock->recv_avail_bytes == 0)
     {
       priv->sockets_recv_empty--;
     }
+
   if (tsock->connect_refused)
     {
       priv->sockets_not_connected_refused--;
     }
+
   if (tsock->disconnected)
     {
       priv->sockets_remote_disconnected--;
@@ -234,9 +248,10 @@ static int test_socket_free(FAR struct daemon_priv_s *priv, int sockid)
 static int tsock_send_event(int fd, FAR struct daemon_priv_s *priv,
                             FAR struct test_socket_s *tsock, int events)
 {
-  FAR struct usrsock_message_socket_event_s event = {};
   ssize_t wlen;
   int i;
+  FAR struct usrsock_message_socket_event_s event = {
+  };
 
   event.head.flags = USRSOCK_MESSAGE_FLAG_EVENT;
   event.head.msgid = USRSOCK_MESSAGE_SOCKET_EVENT;
@@ -248,20 +263,26 @@ static int tsock_send_event(int fd, FAR struct daemon_priv_s *priv,
     }
 
   if (i == ARRAY_SIZE(priv->test_sockets))
-    return -EINVAL;
+    {
+      return -EINVAL;
+    }
 
   event.usockid = i + TEST_SOCKET_SOCKID_BASE;
   event.events = events;
 
   wlen = write(fd, &event, sizeof(event));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(event))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   return OK;
 }
-
 
 static FAR void *find_endpoint(FAR struct daemon_priv_s *priv,
                                in_addr_t ipaddr)
@@ -280,7 +301,9 @@ static FAR void *find_endpoint(FAR struct daemon_priv_s *priv,
   assert(ok);
 
   if (endpaddr->sin_addr.s_addr == ipaddr)
-    return endpaddr;
+    {
+      return endpaddr;
+    }
 
   free(endpaddr);
   usrsocktest_endp_malloc_cnt--;
@@ -293,9 +316,13 @@ static bool endpoint_connect(FAR struct daemon_priv_s *priv, FAR void *endp,
   FAR struct sockaddr_in *endpaddr = endp;
 
   if (endpaddr->sin_port == port)
-    return true;
+    {
+      return true;
+    }
   else
-    return false;
+    {
+      return false;
+    }
 }
 
 static void get_endpoint_sockaddr(FAR void *endp,
@@ -316,10 +343,12 @@ read_req(int fd, FAR const struct usrsock_request_common_s *common_hdr,
   if (rlen < 0)
     {
       err = errno;
-      usrsocktest_dbg("Error reading %d bytes of request: ret=%d, errno=%d\n",
+      usrsocktest_dbg(
+          "Error reading %d bytes of request: ret=%d, errno=%d\n",
           reqsize - sizeof(*common_hdr), (int)rlen, errno);
       return -err;
     }
+
   if (rlen + sizeof(*common_hdr) != reqsize)
     {
       return -EMSGSIZE;
@@ -332,9 +361,10 @@ static int socket_request(int fd, FAR struct daemon_priv_s *priv,
                           FAR void *hdrbuf)
 {
   FAR struct usrsock_request_socket_s *req = hdrbuf;
-  struct usrsock_message_req_ack_s resp = {};
   int socketid;
   ssize_t wlen;
+  struct usrsock_message_req_ack_s resp = {
+  };
 
   /* Validate input. */
 
@@ -371,9 +401,14 @@ static int socket_request(int fd, FAR struct daemon_priv_s *priv,
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   return OK;
 }
@@ -382,9 +417,10 @@ static int close_request(int fd, FAR struct daemon_priv_s *priv,
                          FAR void *hdrbuf)
 {
   FAR struct usrsock_request_close_s *req = hdrbuf;
-  struct usrsock_message_req_ack_s resp = {};
   ssize_t wlen;
   int ret;
+  struct usrsock_message_req_ack_s resp = {
+  };
 
   /* Check if this socket exists. */
 
@@ -409,9 +445,14 @@ static int close_request(int fd, FAR struct daemon_priv_s *priv,
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (priv->conf->delay_all_responses)
     {
@@ -420,16 +461,22 @@ static int close_request(int fd, FAR struct daemon_priv_s *priv,
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.result = ret;
       resp.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   return OK;
@@ -441,9 +488,11 @@ static int connect_request(int fd, FAR struct daemon_priv_s *priv,
   FAR struct usrsock_request_connect_s *req = hdrbuf;
   struct sockaddr_in addr;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_req_ack_s resp = {};
-  ssize_t wlen, rlen;
+  ssize_t wlen;
+  ssize_t rlen;
   int ret = 0;
+  struct usrsock_message_req_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -513,6 +562,7 @@ static int connect_request(int fd, FAR struct daemon_priv_s *priv,
   ret = OK;
 
 prepare:
+
   /* Prepare response. */
 
   resp.xid = req->head.xid;
@@ -553,13 +603,19 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (priv->conf->endpoint_block_connect)
     {
-      tsock->pending_resp.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
+      tsock->pending_resp.head.flags &=
+        ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
     }
   else
     {
@@ -571,8 +627,10 @@ prepare:
           usleep(50 * 1000);
           pthread_mutex_lock(&daemon_mutex);
 
-          /* Previous write was acknowledgment to request, informing that request
-           * is still in progress. Now write actual completion response. */
+          /* Previous write was acknowledgment to request, informing that
+           * request is still in progress. Now write actual completion
+           * response.
+           */
 
           resp.result = ret;
 
@@ -586,22 +644,34 @@ prepare:
 
           wlen = write(fd, &resp, sizeof(resp));
           if (wlen < 0)
-            return -errno;
+            {
+              return -errno;
+            }
+
           if (wlen != sizeof(resp))
-            return -ENOSPC;
+            {
+              return -ENOSPC;
+            }
         }
 
       events = 0;
       if (!tsock->block_send)
-        events |= USRSOCK_EVENT_SENDTO_READY;
+        {
+          events |= USRSOCK_EVENT_SENDTO_READY;
+        }
+
       if (tsock->recv_avail_bytes > 0)
-        events |= USRSOCK_EVENT_RECVFROM_AVAIL;
+        {
+          events |= USRSOCK_EVENT_RECVFROM_AVAIL;
+        }
 
       if (events)
         {
           wlen = tsock_send_event(fd, priv, tsock, events);
           if (wlen < 0)
-            return wlen;
+            {
+              return wlen;
+            }
         }
     }
 
@@ -613,11 +683,13 @@ static int sendto_request(int fd, FAR struct daemon_priv_s *priv,
 {
   FAR struct usrsock_request_sendto_s *req = hdrbuf;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_req_ack_s resp = {};
-  ssize_t wlen, rlen;
+  ssize_t wlen;
+  ssize_t rlen;
   int ret = 0;
   uint8_t sendbuf[16];
   int sendbuflen = 0;
+  struct usrsock_message_req_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -683,6 +755,7 @@ static int sendto_request(int fd, FAR struct daemon_priv_s *priv,
   ret = sendbuflen;
 
 prepare:
+
   /* Prepare response. */
 
   resp.xid = req->head.xid;
@@ -709,9 +782,14 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (priv->conf->delay_all_responses)
     {
@@ -720,7 +798,8 @@ prepare:
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.result = ret;
 
@@ -733,9 +812,14 @@ prepare:
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   if (!tsock->block_send)
@@ -744,7 +828,9 @@ prepare:
 
       wlen = tsock_send_event(fd, priv, tsock, USRSOCK_EVENT_SENDTO_READY);
       if (wlen < 0)
-        return wlen;
+        {
+          return wlen;
+        }
     }
 
   return OK;
@@ -755,12 +841,13 @@ static int recvfrom_request(int fd, FAR struct daemon_priv_s *priv,
 {
   FAR struct usrsock_request_recvfrom_s *req = hdrbuf;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_datareq_ack_s resp = {};
   ssize_t wlen;
   size_t i;
   int ret = 0;
   size_t outbuflen;
   struct sockaddr_in endpointaddr;
+  struct usrsock_message_datareq_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -804,6 +891,7 @@ static int recvfrom_request(int fd, FAR struct daemon_priv_s *priv,
   ret = outbuflen;
 
 prepare:
+
   /* Prepare response. */
 
   resp.reqack.xid = req->head.xid;
@@ -821,16 +909,22 @@ prepare:
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
 
       pthread_mutex_unlock(&daemon_mutex);
       usleep(50 * 1000);
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
       resp.reqack.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
@@ -856,9 +950,14 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (resp.valuelen > 0)
     {
@@ -866,9 +965,14 @@ prepare:
 
       wlen = write(fd, &endpointaddr, resp.valuelen);
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != resp.valuelen)
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   if (resp.reqack.result > 0)
@@ -888,13 +992,20 @@ prepare:
 
           wlen = write(fd, &tmp, 1);
           if (wlen < 0)
-            return -errno;
+            {
+              return -errno;
+            }
+
           if (wlen != 1)
-            return -ENOSPC;
+            {
+              return -ENOSPC;
+            }
         }
 
       if (tsock->recv_avail_bytes == 0)
-        priv->sockets_recv_empty++;
+        {
+          priv->sockets_recv_empty++;
+        }
     }
 
   if (tsock->recv_avail_bytes > 0)
@@ -903,7 +1014,9 @@ prepare:
 
       wlen = tsock_send_event(fd, priv, tsock, USRSOCK_EVENT_RECVFROM_AVAIL);
       if (wlen < 0)
-        return wlen;
+        {
+          return wlen;
+        }
     }
 
   return OK;
@@ -914,10 +1027,12 @@ static int setsockopt_request(int fd, FAR struct daemon_priv_s *priv,
 {
   FAR struct usrsock_request_setsockopt_s *req = hdrbuf;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_req_ack_s resp = {};
-  ssize_t wlen, rlen;
+  ssize_t wlen;
+  ssize_t rlen;
   int ret = 0;
   int value;
+  struct usrsock_message_req_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -967,6 +1082,7 @@ static int setsockopt_request(int fd, FAR struct daemon_priv_s *priv,
   ret = OK;
 
 prepare:
+
   /* Prepare response. */
 
   resp.xid = req->head.xid;
@@ -988,9 +1104,14 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (priv->conf->delay_all_responses)
     {
@@ -999,16 +1120,22 @@ prepare:
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.result = ret;
       resp.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   return OK;
@@ -1019,10 +1146,11 @@ static int getsockopt_request(int fd, FAR struct daemon_priv_s *priv,
 {
   FAR struct usrsock_request_getsockopt_s *req = hdrbuf;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_datareq_ack_s resp = {};
   ssize_t wlen;
   int ret = 0;
   int value;
+  struct usrsock_message_datareq_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -1060,6 +1188,7 @@ static int getsockopt_request(int fd, FAR struct daemon_priv_s *priv,
   ret = OK;
 
 prepare:
+
   /* Prepare response. */
 
   resp.reqack.xid = req->head.xid;
@@ -1077,16 +1206,22 @@ prepare:
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
 
       pthread_mutex_unlock(&daemon_mutex);
       usleep(50 * 1000);
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
       resp.reqack.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
@@ -1107,9 +1242,14 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (resp.valuelen > 0)
     {
@@ -1117,9 +1257,14 @@ prepare:
 
       wlen = write(fd, &value, resp.valuelen);
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != resp.valuelen)
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   return OK;
@@ -1130,10 +1275,11 @@ static int getsockname_request(int fd, FAR struct daemon_priv_s *priv,
 {
   FAR struct usrsock_request_getsockname_s *req = hdrbuf;
   FAR struct test_socket_s *tsock;
-  struct usrsock_message_datareq_ack_s resp = {};
   ssize_t wlen;
   int ret = 0;
   struct sockaddr_in addr;
+  struct usrsock_message_datareq_ack_s resp = {
+  };
 
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
@@ -1153,6 +1299,7 @@ static int getsockname_request(int fd, FAR struct daemon_priv_s *priv,
   ret = ret == 1 ? 0 : -EINVAL;
 
 prepare:
+
   /* Prepare response. */
 
   resp.reqack.xid = req->head.xid;
@@ -1170,16 +1317,22 @@ prepare:
 
       wlen = write(fd, &resp, sizeof(resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
 
       pthread_mutex_unlock(&daemon_mutex);
       usleep(50 * 1000);
       pthread_mutex_lock(&daemon_mutex);
 
       /* Previous write was acknowledgment to request, informing that request
-       * is still in progress. Now write actual completion response. */
+       * is still in progress. Now write actual completion response.
+       */
 
       resp.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
       resp.reqack.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
@@ -1192,7 +1345,9 @@ prepare:
       resp.valuelen = sizeof(addr);
       resp.valuelen_nontrunc = sizeof(addr);
       if (resp.valuelen > req->max_addrlen)
-        resp.valuelen = req->max_addrlen;
+        {
+          resp.valuelen = req->max_addrlen;
+        }
     }
   else
     {
@@ -1204,9 +1359,14 @@ prepare:
 
   wlen = write(fd, &resp, sizeof(resp));
   if (wlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (wlen != sizeof(resp))
-    return -ENOSPC;
+    {
+      return -ENOSPC;
+    }
 
   if (resp.valuelen > 0)
     {
@@ -1214,9 +1374,14 @@ prepare:
 
       wlen = write(fd, &addr, resp.valuelen);
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != resp.valuelen)
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   return OK;
@@ -1228,58 +1393,73 @@ static int handle_usrsock_request(int fd, FAR struct daemon_priv_s *priv)
   {
     unsigned int hdrlen;
     int (CODE *fn)(int fd, FAR struct daemon_priv_s *priv, FAR void *req);
-  } handlers[USRSOCK_REQUEST__MAX] =
+  }
+
+  handlers[USRSOCK_REQUEST__MAX] =
     {
       [USRSOCK_REQUEST_SOCKET] =
         {
           sizeof(struct usrsock_request_socket_s),
           socket_request,
         },
+
       [USRSOCK_REQUEST_CLOSE] =
         {
           sizeof(struct usrsock_request_close_s),
           close_request,
         },
+
       [USRSOCK_REQUEST_CONNECT] =
         {
           sizeof(struct usrsock_request_connect_s),
           connect_request,
         },
+
       [USRSOCK_REQUEST_SENDTO] =
         {
           sizeof(struct usrsock_request_sendto_s),
           sendto_request,
         },
+
       [USRSOCK_REQUEST_RECVFROM] =
         {
           sizeof(struct usrsock_request_recvfrom_s),
           recvfrom_request,
         },
+
       [USRSOCK_REQUEST_SETSOCKOPT] =
         {
           sizeof(struct usrsock_request_setsockopt_s),
           setsockopt_request,
         },
+
       [USRSOCK_REQUEST_GETSOCKOPT] =
         {
           sizeof(struct usrsock_request_getsockopt_s),
           getsockopt_request,
         },
+
       [USRSOCK_REQUEST_GETSOCKNAME] =
         {
           sizeof(struct usrsock_request_getsockname_s),
           getsockname_request,
         },
     };
+
   uint8_t hdrbuf[16];
   FAR struct usrsock_request_common_s *common_hdr = (FAR void *)hdrbuf;
   ssize_t rlen;
 
   rlen = read(fd, common_hdr, sizeof(*common_hdr));
   if (rlen < 0)
-    return -errno;
+    {
+      return -errno;
+    }
+
   if (rlen != sizeof(*common_hdr))
-    return -EMSGSIZE;
+    {
+      return -EMSGSIZE;
+    }
 
   if (common_hdr->reqid >= USRSOCK_REQUEST__MAX ||
       !handlers[common_hdr->reqid].fn)
@@ -1290,9 +1470,12 @@ static int handle_usrsock_request(int fd, FAR struct daemon_priv_s *priv)
 
   assert(handlers[common_hdr->reqid].hdrlen < sizeof(hdrbuf));
 
-  rlen = read_req(fd, common_hdr, hdrbuf, handlers[common_hdr->reqid].hdrlen);
+  rlen = read_req(fd, common_hdr, hdrbuf,
+                  handlers[common_hdr->reqid].hdrlen);
   if (rlen < 0)
-    return rlen;
+    {
+      return rlen;
+    }
 
   return handlers[common_hdr->reqid].fn(fd, priv, hdrbuf);
 }
@@ -1308,7 +1491,9 @@ static int unblock_sendto(int fd, FAR struct daemon_priv_s *priv,
 
       ret = tsock_send_event(fd, priv, tsock, USRSOCK_EVENT_SENDTO_READY);
       if (ret < 0)
-        return ret;
+        {
+          return ret;
+        }
     }
 
   return OK;
@@ -1328,7 +1513,9 @@ static int reset_recv_avail(int fd, FAR struct daemon_priv_s *priv,
       ret = tsock_send_event(fd, priv, tsock,
                              USRSOCK_EVENT_RECVFROM_AVAIL);
       if (ret < 0)
-        return ret;
+        {
+          return ret;
+        }
     }
 
   return OK;
@@ -1349,13 +1536,16 @@ static int disconnect_connection(int fd, FAR struct daemon_priv_s *priv,
 
       ret = tsock_send_event(fd, priv, tsock, USRSOCK_EVENT_REMOTE_CLOSED);
       if (ret < 0)
-        return ret;
+        {
+          return ret;
+        }
     }
 
   return OK;
 }
 
-static int establish_blocked_connection(int fd, FAR struct daemon_priv_s *priv,
+static int establish_blocked_connection(int fd,
+                                        FAR struct daemon_priv_s *priv,
                                         FAR struct test_socket_s *tsock)
 {
   if (tsock->blocked_connect)
@@ -1377,21 +1567,33 @@ static int establish_blocked_connection(int fd, FAR struct daemon_priv_s *priv,
 
       wlen = write(fd, resp, sizeof(*resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(*resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
 
       events = 0;
       if (!tsock->block_send)
-        events |= USRSOCK_EVENT_SENDTO_READY;
+        {
+          events |= USRSOCK_EVENT_SENDTO_READY;
+        }
+
       if (tsock->recv_avail_bytes > 0)
-        events |= USRSOCK_EVENT_RECVFROM_AVAIL;
+        {
+          events |= USRSOCK_EVENT_RECVFROM_AVAIL;
+        }
 
       if (events)
         {
           wlen = tsock_send_event(fd, priv, tsock, events);
           if (wlen < 0)
-            return wlen;
+            {
+              return wlen;
+            }
         }
     }
 
@@ -1416,9 +1618,14 @@ static int fail_blocked_connection(int fd, FAR struct daemon_priv_s *priv,
 
       wlen = write(fd, resp, sizeof(*resp));
       if (wlen < 0)
-        return -errno;
+        {
+          return -errno;
+        }
+
       if (wlen != sizeof(*resp))
-        return -ENOSPC;
+        {
+          return -ENOSPC;
+        }
     }
 
   return OK;
@@ -1440,7 +1647,9 @@ static int for_each_connection(int fd, FAR struct daemon_priv_s *priv,
         {
           int ret = iter_fn(fd, priv, tsock);
           if (ret < 0)
-            return ret;
+            {
+              return ret;
+            }
         }
     }
 
@@ -1467,10 +1676,11 @@ static FAR void *usrsocktest_daemon(FAR void *param)
 
   do
     {
-      struct pollfd pfd[2] = {};
       int npfds = 0;
       int usrsock_pfdpos = -1;
       int pipe_pdfpos = -1;
+      struct pollfd pfd[2] = {
+      };
 
       stopped = false;
 
@@ -1483,6 +1693,7 @@ static FAR void *usrsocktest_daemon(FAR void *param)
           pfd[npfds].events = POLLIN;
           usrsock_pfdpos = npfds++;
         }
+
       pfd[npfds].fd = priv->pipefd[0];
       pfd[npfds].events = POLLIN;
       pipe_pdfpos = npfds++;
@@ -1492,6 +1703,7 @@ static FAR void *usrsocktest_daemon(FAR void *param)
       if (ret < 0)
         {
           /* Error? */
+
           ret = -errno;
           goto errout;
         }
@@ -1502,7 +1714,9 @@ static FAR void *usrsocktest_daemon(FAR void *param)
           ret = handle_usrsock_request(fd, priv);
           pthread_mutex_unlock(&daemon_mutex);
           if (ret < 0)
-            goto errout;
+            {
+              goto errout;
+            }
         }
 
       if (pipe_pdfpos >= 0 && (pfd[pipe_pdfpos].revents & POLLIN))
@@ -1544,12 +1758,15 @@ static FAR void *usrsocktest_daemon(FAR void *param)
                                             &reset_recv_avail);
                   break;
                 case 'K':
+
                   /* Kill usrsockdev */
+
                   if (fd >= 0)
                     {
                       close(fd);
                       fd = -1;
                     }
+
                   break;
                 case '*':
                   sem_post(&priv->wakewaitsem);
@@ -1559,7 +1776,9 @@ static FAR void *usrsocktest_daemon(FAR void *param)
               pthread_mutex_unlock(&daemon_mutex);
 
               if (ret < 0)
-                goto errout;
+                {
+                  goto errout;
+                }
             }
         }
 
@@ -1615,14 +1834,18 @@ static FAR void *delayed_cmd_thread(FAR void *priv)
   FAR struct delayed_cmd_s *cmd = priv;
 
   if (cmd->delay_msec)
-    sem_post(&cmd->startsem);
+    {
+      sem_post(&cmd->startsem);
+    }
 
   usleep(cmd->delay_msec * 1000);
 
   write(cmd->pipefd, &cmd->cmd, 1);
 
   if (!cmd->delay_msec)
-    sem_post(&cmd->startsem);
+    {
+      sem_post(&cmd->startsem);
+    }
 
   return NULL;
 }
@@ -1631,7 +1854,8 @@ static FAR void *delayed_cmd_thread(FAR void *priv)
  * Public Functions
  ****************************************************************************/
 
-int usrsocktest_daemon_start(FAR const struct usrsocktest_daemon_conf_s *conf)
+int usrsocktest_daemon_start(
+  FAR const struct usrsocktest_daemon_conf_s *conf)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
   pthread_attr_t attr;
@@ -1690,6 +1914,7 @@ errout_closepipe:
       close(priv->pipefd[0]);
       close(priv->pipefd[1]);
     }
+
 out:
   pthread_mutex_unlock(&daemon_mutex);
   usrsocktest_dbg("ret: %d\n", ret);
@@ -1699,7 +1924,8 @@ out:
 int usrsocktest_daemon_stop(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  FAR struct delayed_cmd_s *item, *next;
+  FAR struct delayed_cmd_s *item;
+  FAR struct delayed_cmd_s *next;
   FAR pthread_addr_t retval;
   char stopped;
   int ret;
@@ -1771,11 +1997,14 @@ out:
 int usrsocktest_daemon_get_num_active_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
   err = get_daemon_value(priv, &ret, &priv->sockets_active, sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1783,11 +2012,14 @@ int usrsocktest_daemon_get_num_active_sockets(void)
 int usrsocktest_daemon_get_num_connected_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
   err = get_daemon_value(priv, &ret, &priv->sockets_connected, sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1795,11 +2027,15 @@ int usrsocktest_daemon_get_num_connected_sockets(void)
 int usrsocktest_daemon_get_num_waiting_connect_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
-  err = get_daemon_value(priv, &ret, &priv->sockets_waiting_connect, sizeof(ret));
+  err = get_daemon_value(priv, &ret, &priv->sockets_waiting_connect,
+                         sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1807,11 +2043,14 @@ int usrsocktest_daemon_get_num_waiting_connect_sockets(void)
 int usrsocktest_daemon_get_num_recv_empty_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
   err = get_daemon_value(priv, &ret, &priv->sockets_recv_empty, sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1824,7 +2063,9 @@ ssize_t usrsocktest_daemon_get_send_bytes(void)
 
   err = get_daemon_value(priv, &ret, &priv->total_send_bytes, sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1837,7 +2078,9 @@ ssize_t usrsocktest_daemon_get_recv_bytes(void)
 
   err = get_daemon_value(priv, &ret, &priv->total_recv_bytes, sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1845,12 +2088,15 @@ ssize_t usrsocktest_daemon_get_recv_bytes(void)
 int usrsocktest_daemon_get_num_unreachable_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
   err = get_daemon_value(priv, &ret, &priv->sockets_not_connected_refused,
                          sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1858,12 +2104,15 @@ int usrsocktest_daemon_get_num_unreachable_sockets(void)
 int usrsocktest_daemon_get_num_remote_disconnected_sockets(void)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
-  int ret, err;
+  int ret;
+  int err;
 
   err = get_daemon_value(priv, &ret, &priv->sockets_remote_disconnected,
                          sizeof(ret));
   if (err < 0)
-    return err;
+    {
+      return err;
+    }
 
   return ret;
 }
@@ -1896,7 +2145,8 @@ int usrsocktest_daemon_pause_usrsock_handling(bool pause)
   return ret;
 }
 
-bool usrsocktest_send_delayed_command(const char cmd, unsigned int delay_msec)
+bool usrsocktest_send_delayed_command(const char cmd,
+                                      unsigned int delay_msec)
 {
   FAR struct daemon_priv_s *priv = &g_ub_daemon;
   pthread_attr_t attr;

--- a/examples/usrsocktest/usrsocktest_main.c
+++ b/examples/usrsocktest/usrsocktest_main.c
@@ -163,23 +163,23 @@ static void run_tests(FAR const char *name, void (CODE *test_fn)(void))
 
 static void run_all_tests(void)
 {
-  RUN_TEST_GROUP(CharDev);
-  RUN_TEST_GROUP(NoDaemon);
-  RUN_TEST_GROUP(BasicDaemon);
-  RUN_TEST_GROUP(BasicConnect);
-  RUN_TEST_GROUP(BasicConnectDelay);
-  RUN_TEST_GROUP(NoBlockConnect);
-  RUN_TEST_GROUP(BasicSend);
-  RUN_TEST_GROUP(NoBlockSend);
-  RUN_TEST_GROUP(BlockSend);
-  RUN_TEST_GROUP(NoBlockRecv);
-  RUN_TEST_GROUP(BlockRecv);
-  RUN_TEST_GROUP(RemoteDisconnect);
-  RUN_TEST_GROUP(BasicSetSockOpt);
-  RUN_TEST_GROUP(BasicGetSockOpt);
-  RUN_TEST_GROUP(BasicGetSockName);
-  RUN_TEST_GROUP(WakeWithSignal);
-  RUN_TEST_GROUP(MultiThread);
+  RUN_TEST_GROUP(char_dev);
+  RUN_TEST_GROUP(no_daemon);
+  RUN_TEST_GROUP(basic_daemon);
+  RUN_TEST_GROUP(basic_connect);
+  RUN_TEST_GROUP(basic_connect_delay);
+  RUN_TEST_GROUP(no_block_connect);
+  RUN_TEST_GROUP(basic_send);
+  RUN_TEST_GROUP(no_block_send);
+  RUN_TEST_GROUP(block_send);
+  RUN_TEST_GROUP(no_block_recv);
+  RUN_TEST_GROUP(block_recv);
+  RUN_TEST_GROUP(remote_disconnect);
+  RUN_TEST_GROUP(basic_setsockopt);
+  RUN_TEST_GROUP(basic_getsockopt);
+  RUN_TEST_GROUP(basic_getsockname);
+  RUN_TEST_GROUP(wake_with_signal);
+  RUN_TEST_GROUP(multithread);
 }
 
 /****************************************************************************

--- a/examples/usrsocktest/usrsocktest_multi_thread.c
+++ b/examples/usrsocktest/usrsocktest_multi_thread.c
@@ -106,12 +106,12 @@ static void usrsock_socket_multitask_do_work(int *sd)
 
 static FAR void *usrsock_socket_multitask_thread(FAR void *param)
 {
-  usrsock_socket_multitask_do_work((int*)param);
+  usrsock_socket_multitask_do_work((int *)param);
   return NULL;
 }
 
 /****************************************************************************
- * Name: MultiThread test group setup
+ * Name: multithread test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -127,22 +127,25 @@ static FAR void *usrsock_socket_multitask_thread(FAR void *param)
  *
  ****************************************************************************/
 
-TEST_SETUP(MultiThread)
+TEST_SETUP(multithread)
 {
   int i;
+
   for (i = 0; i < ARRAY_SIZE(sds); i++)
     {
       sds[i] = -1;
     }
+
   for (i = 0; i < ARRAY_SIZE(tids); i++)
     {
       tids[i] = -1;
     }
+
   started = false;
 }
 
 /****************************************************************************
- * Name: MultiThread test group teardown
+ * Name: multithread test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -158,7 +161,7 @@ TEST_SETUP(MultiThread)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(MultiThread)
+TEST_TEAR_DOWN(multithread)
 {
   int ret;
   int i;
@@ -173,6 +176,7 @@ TEST_TEAR_DOWN(MultiThread)
           assert(ret == OK);
         }
     }
+
   for (i = 0; i < ARRAY_SIZE(sds); i++)
     {
       if (sds[i] != -1)
@@ -181,6 +185,7 @@ TEST_TEAR_DOWN(MultiThread)
           assert(ret >= 0);
         }
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -189,7 +194,7 @@ TEST_TEAR_DOWN(MultiThread)
 }
 
 /****************************************************************************
- * Name: OpenClose
+ * Name: open_close
  *
  * Description:
  *   Open and close socket with multiple threads
@@ -205,7 +210,7 @@ TEST_TEAR_DOWN(MultiThread)
  *
  ****************************************************************************/
 
-TEST(MultiThread, OpenClose)
+TEST(multithread, open_close)
 {
   int ret;
   int i;
@@ -218,7 +223,8 @@ TEST(MultiThread, OpenClose)
   usrsocktest_daemon_config.endpoint_block_connect = false;
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
   /* Launch worker threads. */
@@ -260,7 +266,7 @@ TEST(MultiThread, OpenClose)
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(MultiThread)
+TEST_GROUP(multithread)
 {
-  RUN_TEST_CASE(MultiThread, OpenClose);
+  RUN_TEST_CASE(multithread, open_close);
 }

--- a/examples/usrsocktest/usrsocktest_noblock_connect.c
+++ b/examples/usrsocktest/usrsocktest_noblock_connect.c
@@ -48,7 +48,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-
 #include "defines.h"
 
 /****************************************************************************
@@ -68,7 +67,8 @@
  ****************************************************************************/
 
 static bool started;
-static int sd, sd2;
+static int sd;
+static int sd2;
 
 /****************************************************************************
  * Public Data
@@ -78,14 +78,14 @@ static int sd, sd2;
  * Private Functions
  ****************************************************************************/
 
-TEST_SETUP(NoBlockConnect)
+TEST_SETUP(no_block_connect)
 {
   sd = -1;
   sd2 = -1;
   started = false;
 }
 
-TEST_TEAR_DOWN(NoBlockConnect)
+TEST_TEAR_DOWN(no_block_connect)
 {
   int ret;
 
@@ -94,11 +94,13 @@ TEST_TEAR_DOWN(NoBlockConnect)
       ret = close(sd);
       assert(ret == 0);
     }
+
   if (sd2 >= 0)
     {
       ret = close(sd2);
       assert(ret == 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -106,7 +108,7 @@ TEST_TEAR_DOWN(NoBlockConnect)
     }
 }
 
-TEST(NoBlockConnect, InstantConnect)
+TEST(no_block_connect, instant_connect)
 {
   int flags;
   int ret;
@@ -115,7 +117,8 @@ TEST(NoBlockConnect, InstantConnect)
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -168,9 +171,11 @@ TEST(NoBlockConnect, InstantConnect)
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-TEST(NoBlockConnect, DelayedConnect)
+TEST(no_block_connect, delayed_connect)
 {
-  int flags, ret, count;
+  int flags;
+  int ret;
+  int count;
   struct sockaddr_in addr;
 
   /* Start test daemon. */
@@ -180,7 +185,8 @@ TEST(NoBlockConnect, DelayedConnect)
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
   usrsocktest_daemon_config.delay_all_responses = true;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -205,7 +211,9 @@ TEST(NoBlockConnect, DelayedConnect)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -229,11 +237,13 @@ TEST(NoBlockConnect, DelayedConnect)
   /* Release delayed connect. */
 
   TEST_ASSERT_TRUE(usrsocktest_daemon_establish_waiting_connections());
-  for (count = 0; usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -258,14 +268,16 @@ TEST(NoBlockConnect, DelayedConnect)
   started = false;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-TEST(NoBlockConnect, CloseNotConnected)
+TEST(no_block_connect, close_not_connected)
 {
-  int flags, ret;
+  int flags;
+  int ret;
   struct sockaddr_in addr;
 
   /* Start test daemon. */
@@ -275,7 +287,8 @@ TEST(NoBlockConnect, CloseNotConnected)
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
   usrsocktest_daemon_config.delay_all_responses = true;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -300,7 +313,9 @@ TEST(NoBlockConnect, CloseNotConnected)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -326,14 +341,16 @@ TEST(NoBlockConnect, CloseNotConnected)
   started = false;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-TEST(NoBlockConnect, EarlyDrop)
+TEST(no_block_connect, early_drop)
 {
-  int flags, ret;
+  int flags;
+  int ret;
   struct sockaddr_in addr;
 
   /* Start test daemon. */
@@ -343,7 +360,8 @@ TEST(NoBlockConnect, EarlyDrop)
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
   usrsocktest_daemon_config.delay_all_responses = false;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -368,7 +386,9 @@ TEST(NoBlockConnect, EarlyDrop)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -386,7 +406,8 @@ TEST(NoBlockConnect, EarlyDrop)
   started = false;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 
@@ -396,12 +417,15 @@ TEST(NoBlockConnect, EarlyDrop)
   sd = -1;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
 }
 
-TEST(NoBlockConnect, Multiple)
+TEST(no_block_connect, multiple)
 {
-  int flags, ret, count;
+  int flags;
+  int ret;
+  int count;
   struct sockaddr_in addr;
 
   /* Start test daemon. */
@@ -411,7 +435,8 @@ TEST(NoBlockConnect, Multiple)
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
   usrsocktest_daemon_config.delay_all_responses = false;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -452,7 +477,9 @@ TEST(NoBlockConnect, Multiple)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempts, daemon delays actual connection until triggered. */
+  /* Launch connect attempts, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -467,11 +494,13 @@ TEST(NoBlockConnect, Multiple)
   /* Release delayed connections. */
 
   TEST_ASSERT_TRUE(usrsocktest_daemon_establish_waiting_connections());
-  for (count = 0; usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -502,6 +531,7 @@ TEST(NoBlockConnect, Multiple)
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -556,7 +586,9 @@ TEST(NoBlockConnect, Multiple)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempts, daemon delays actual connection until triggered. */
+  /* Launch connect attempts, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -578,11 +610,13 @@ TEST(NoBlockConnect, Multiple)
   /* Release delayed connections. */
 
   TEST_ASSERT_TRUE(usrsocktest_daemon_establish_waiting_connections());
-  for (count = 0; usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -637,7 +671,9 @@ TEST(NoBlockConnect, Multiple)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -652,16 +688,20 @@ TEST(NoBlockConnect, Multiple)
   /* Release delayed connections. */
 
   TEST_ASSERT_TRUE(usrsocktest_daemon_establish_waiting_connections());
-  for (count = 0; usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
 
-  /* Launch another connect attempt, daemon delays actual connection until triggered. */
+  /* Launch another connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   ret = connect(sd2, (FAR const struct sockaddr *)&addr, sizeof(addr));
   TEST_ASSERT_EQUAL(-1, ret);
@@ -689,14 +729,17 @@ TEST(NoBlockConnect, Multiple)
   started = false;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
-TEST(NoBlockConnect, Dup2)
+TEST(no_block_connect, basic_daemon_dup2)
 {
-  int flags, ret, count;
+  int flags;
+  int ret;
+  int count;
   struct sockaddr_in addr;
 
   /* Start test daemon. */
@@ -706,7 +749,8 @@ TEST(NoBlockConnect, Dup2)
   usrsocktest_daemon_config.endpoint_addr = "127.0.0.1";
   usrsocktest_daemon_config.endpoint_port = 255;
   usrsocktest_daemon_config.delay_all_responses = true;
-  TEST_ASSERT_EQUAL(OK, usrsocktest_daemon_start(&usrsocktest_daemon_config));
+  TEST_ASSERT_EQUAL(OK,
+                    usrsocktest_daemon_start(&usrsocktest_daemon_config));
   started = true;
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_active_sockets());
 
@@ -737,7 +781,9 @@ TEST(NoBlockConnect, Dup2)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -761,11 +807,13 @@ TEST(NoBlockConnect, Dup2)
   /* Release delayed connect. */
 
   TEST_ASSERT_TRUE(usrsocktest_daemon_establish_waiting_connections());
-  for (count = 0; usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_waiting_connect_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -796,7 +844,8 @@ TEST(NoBlockConnect, Dup2)
   started = false;
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_waiting_connect_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
@@ -805,12 +854,12 @@ TEST(NoBlockConnect, Dup2)
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(NoBlockConnect)
+TEST_GROUP(no_block_connect)
 {
-  RUN_TEST_CASE(NoBlockConnect, InstantConnect);
-  RUN_TEST_CASE(NoBlockConnect, DelayedConnect);
-  RUN_TEST_CASE(NoBlockConnect, CloseNotConnected);
-  RUN_TEST_CASE(NoBlockConnect, EarlyDrop);
-  RUN_TEST_CASE(NoBlockConnect, Multiple);
-  RUN_TEST_CASE(NoBlockConnect, Dup2);
+  RUN_TEST_CASE(no_block_connect, instant_connect);
+  RUN_TEST_CASE(no_block_connect, delayed_connect);
+  RUN_TEST_CASE(no_block_connect, close_not_connected);
+  RUN_TEST_CASE(no_block_connect, early_drop);
+  RUN_TEST_CASE(no_block_connect, multiple);
+  RUN_TEST_CASE(no_block_connect, basic_daemon_dup2);
 }

--- a/examples/usrsocktest/usrsocktest_noblock_recv.c
+++ b/examples/usrsocktest/usrsocktest_noblock_recv.c
@@ -78,7 +78,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Receive
+ * Name: receive
  *
  * Description:
  *   Non-blocking & instant connect+recv
@@ -94,7 +94,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Receive(struct usrsocktest_daemon_conf_s *dconf)
+static void receive(struct usrsocktest_daemon_conf_s *dconf)
 {
   int flags;
   int count;
@@ -149,7 +149,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
       TEST_ASSERT_EQUAL(0,
-                        usrsocktest_daemon_get_num_waiting_connect_sockets());
+                      usrsocktest_daemon_get_num_waiting_connect_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_recv_empty_sockets());
     }
   else
@@ -159,7 +159,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
       TEST_ASSERT_EQUAL(0,
-                        usrsocktest_daemon_get_num_waiting_connect_sockets());
+                      usrsocktest_daemon_get_num_waiting_connect_sockets());
 
       for (count = 0; usrsocktest_daemon_get_num_connected_sockets() != 1;
            count++)
@@ -230,11 +230,13 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
   /* Reset recv buffer for open sockets */
 
   TEST_ASSERT_TRUE(usrsocktest_send_delayed_command('r', 0));
-  for (count = 0; usrsocktest_daemon_get_num_recv_empty_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_recv_empty_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(5 * 1000);
     }
+
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_recv_empty_sockets());
 
   /* Receive data from remote, daemon returns 4 bytes. */
@@ -270,7 +272,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: DelayedConnect
+ * Name: delayed_connect
  *
  * Description:
  *   Non-blocking & delayed connect
@@ -286,7 +288,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
+static void delayed_connect(struct usrsocktest_daemon_conf_s *dconf)
 {
   int flags;
   int count;
@@ -330,7 +332,9 @@ static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -363,6 +367,7 @@ static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -386,7 +391,8 @@ static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
   /* Reset recv buffer for open sockets */
 
   TEST_ASSERT_TRUE(usrsocktest_send_delayed_command('r', 0));
-  for (count = 0; usrsocktest_daemon_get_num_recv_empty_sockets() > 0; count++)
+  for (count = 0;
+       usrsocktest_daemon_get_num_recv_empty_sockets() > 0; count++)
     {
       TEST_ASSERT_TRUE(count <= 5);
       usleep(5 * 1000);
@@ -422,13 +428,14 @@ static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(-ENODEV,
                     usrsocktest_daemon_get_num_waiting_connect_sockets());
-  TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_recv_empty_sockets());
+  TEST_ASSERT_EQUAL(-ENODEV,
+                    usrsocktest_daemon_get_num_recv_empty_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
 }
 
 /****************************************************************************
- * Name: NoBlockRecv test group setup
+ * Name: no_block_recv test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -444,14 +451,14 @@ static void DelayedConnect(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(NoBlockRecv)
+TEST_SETUP(no_block_recv)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: NoBlockRecv test group teardown
+ * Name: no_block_recv test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -467,7 +474,7 @@ TEST_SETUP(NoBlockRecv)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(NoBlockRecv)
+TEST_TEAR_DOWN(no_block_recv)
 {
   int ret;
   if (sd >= 0)
@@ -475,6 +482,7 @@ TEST_TEAR_DOWN(NoBlockRecv)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -482,40 +490,40 @@ TEST_TEAR_DOWN(NoBlockRecv)
     }
 }
 
-TEST(NoBlockRecv, Receive)
+TEST(no_block_recv, receive)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Receive(&usrsocktest_daemon_config);
+  receive(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockRecv, ReceiveDelay)
+TEST(no_block_recv, receive_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Receive(&usrsocktest_daemon_config);
+  receive(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockRecv, DelayedConnect)
+TEST(no_block_recv, delayed_connect)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  DelayedConnect(&usrsocktest_daemon_config);
+  delayed_connect(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockRecv, DelayedConnectDelay)
+TEST(no_block_recv, delayed_connect_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  DelayedConnect(&usrsocktest_daemon_config);
+  delayed_connect(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(NoBlockRecv)
+TEST_GROUP(no_block_recv)
 {
-  RUN_TEST_CASE(NoBlockRecv, Receive);
-  RUN_TEST_CASE(NoBlockRecv, ReceiveDelay);
-  RUN_TEST_CASE(NoBlockRecv, DelayedConnect);
-  RUN_TEST_CASE(NoBlockRecv, DelayedConnectDelay);
+  RUN_TEST_CASE(no_block_recv, receive);
+  RUN_TEST_CASE(no_block_recv, receive_delay);
+  RUN_TEST_CASE(no_block_recv, delayed_connect);
+  RUN_TEST_CASE(no_block_recv, delayed_connect_delay);
 }

--- a/examples/usrsocktest/usrsocktest_noblock_send.c
+++ b/examples/usrsocktest/usrsocktest_noblock_send.c
@@ -79,7 +79,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Send
+ * Name: _send
  *
  * Description:
  *   Open socket, connect instantly and send
@@ -95,7 +95,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Send(struct usrsocktest_daemon_conf_s *dconf)
+static void _send(struct usrsocktest_daemon_conf_s *dconf)
 {
   int flags;
   int count;
@@ -144,7 +144,8 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(0, ret);
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
+      TEST_ASSERT_EQUAL(0,
+                      usrsocktest_daemon_get_num_waiting_connect_sockets());
     }
   else
     {
@@ -152,7 +153,8 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(EINPROGRESS, errno);
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
+      TEST_ASSERT_EQUAL(0,
+                      usrsocktest_daemon_get_num_waiting_connect_sockets());
 
       for (count = 0; usrsocktest_daemon_get_num_connected_sockets() != 1;
            count++)
@@ -196,7 +198,7 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: ConnectSend
+ * Name: connect_send
  *
  * Description:
  *   Open socket, connect is delayed and send
@@ -212,7 +214,7 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void ConnectSend(struct usrsocktest_daemon_conf_s *dconf)
+static void connect_send(struct usrsocktest_daemon_conf_s *dconf)
 {
   int flags;
   int count;
@@ -252,7 +254,9 @@ static void ConnectSend(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
-  /* Launch connect attempt, daemon delays actual connection until triggered. */
+  /* Launch connect attempt, daemon delays actual connection until
+   * triggered.
+   */
 
   inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr.s_addr);
   addr.sin_family = AF_INET;
@@ -285,6 +289,7 @@ static void ConnectSend(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_TRUE(count <= 5);
       usleep(10 * 1000);
     }
+
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
@@ -321,7 +326,7 @@ static void ConnectSend(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: NoBlockSend test group setup
+ * Name: no_block_send test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -337,14 +342,14 @@ static void ConnectSend(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(NoBlockSend)
+TEST_SETUP(no_block_send)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: NoBlockSend test group teardown
+ * Name: no_block_send test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -360,7 +365,7 @@ TEST_SETUP(NoBlockSend)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(NoBlockSend)
+TEST_TEAR_DOWN(no_block_send)
 {
   int ret;
   if (sd >= 0)
@@ -368,6 +373,7 @@ TEST_TEAR_DOWN(NoBlockSend)
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -375,40 +381,40 @@ TEST_TEAR_DOWN(NoBlockSend)
     }
 }
 
-TEST(NoBlockSend, Send)
+TEST(no_block_send, _send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Send(&usrsocktest_daemon_config);
+  _send(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockSend, SendDelay)
+TEST(no_block_send, _send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Send(&usrsocktest_daemon_config);
+  _send(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockSend, ConnectSend)
+TEST(no_block_send, connect_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
-TEST(NoBlockSend, ConnectSendDelay)
+TEST(no_block_send, connect_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  ConnectSend(&usrsocktest_daemon_config);
+  connect_send(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(NoBlockSend)
+TEST_GROUP(no_block_send)
 {
-  RUN_TEST_CASE(NoBlockSend, Send);
-  RUN_TEST_CASE(NoBlockSend, SendDelay);
-  RUN_TEST_CASE(NoBlockSend, ConnectSend);
-  RUN_TEST_CASE(NoBlockSend, ConnectSendDelay);
+  RUN_TEST_CASE(no_block_send, _send);
+  RUN_TEST_CASE(no_block_send, _send_delay);
+  RUN_TEST_CASE(no_block_send, connect_send);
+  RUN_TEST_CASE(no_block_send, connect_send_delay);
 }

--- a/examples/usrsocktest/usrsocktest_nodaemon.c
+++ b/examples/usrsocktest/usrsocktest_nodaemon.c
@@ -71,7 +71,7 @@ static int sd;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: NoDaemon test group setup
+ * Name: no_daemon test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -87,13 +87,13 @@ static int sd;
  *
  ****************************************************************************/
 
-TEST_SETUP(NoDaemon)
+TEST_SETUP(no_daemon)
 {
   sd = -1;
 }
 
 /****************************************************************************
- * Name: NoDaemon test group teardown
+ * Name: no_daemon test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -109,7 +109,7 @@ TEST_SETUP(NoDaemon)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(NoDaemon)
+TEST_TEAR_DOWN(no_daemon)
 {
   int ret;
 
@@ -121,7 +121,7 @@ TEST_TEAR_DOWN(NoDaemon)
 }
 
 /****************************************************************************
- * Name: NoSocket
+ * Name: no_socket
  *
  * Description:
  *   Simple test for opening socket without usrsock daemon running
@@ -137,18 +137,19 @@ TEST_TEAR_DOWN(NoDaemon)
  *
  ****************************************************************************/
 
-TEST(NoDaemon, NoSocket)
+TEST(no_daemon, no_socket)
 {
   sd = socket(AF_INET, SOCK_STREAM, 0);
   TEST_ASSERT_EQUAL(-1, sd);
-  TEST_ASSERT_TRUE(errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT || errno == ENETDOWN);
+  TEST_ASSERT_TRUE(errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT ||
+                   errno == ENETDOWN);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(NoDaemon)
+TEST_GROUP(no_daemon)
 {
-  RUN_TEST_CASE(NoDaemon, NoSocket);
+  RUN_TEST_CASE(no_daemon, no_socket);
 }

--- a/examples/usrsocktest/usrsocktest_remote_disconnect.c
+++ b/examples/usrsocktest/usrsocktest_remote_disconnect.c
@@ -68,7 +68,10 @@
  * Private Data
  ****************************************************************************/
 
-static const uint8_t tevents[] = { POLLIN, POLLOUT, POLLOUT|POLLIN, 0};
+static const uint8_t tevents[] =
+{
+  POLLIN, POLLOUT, POLLOUT | POLLIN, 0
+};
 static bool started;
 static int sd;
 
@@ -97,7 +100,7 @@ static int sd;
  *
  ****************************************************************************/
 
-static void Unreachable(struct usrsocktest_daemon_conf_s *dconf)
+static void unreachable(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   struct sockaddr_in addr;
@@ -215,11 +218,10 @@ static void Unreachable(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(-ENODEV, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_endp_malloc_cnt);
   TEST_ASSERT_EQUAL(0, usrsocktest_dcmd_malloc_cnt);
-
 }
 
 /****************************************************************************
- * Name: Send
+ * Name: remote_disconnect_send
  *
  * Description:
  *   Send and disconnect
@@ -235,7 +237,7 @@ static void Unreachable(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Send(struct usrsocktest_daemon_conf_s *dconf)
+static void remote_disconnect_send(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -276,18 +278,22 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   /* Disconnect connections. */
 
   TEST_ASSERT_TRUE(usrsocktest_send_delayed_command('D', 0));
-  for (count = 0; usrsocktest_daemon_get_num_connected_sockets() > 0; count++)
+  for (count = 0; usrsocktest_daemon_get_num_connected_sockets() > 0;
+       count++)
     {
       TEST_ASSERT_TRUE(count <= 3);
       usleep(5 * 1000);
     }
+
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   for (count = 0; count < 2; count++)
     {
@@ -299,7 +305,8 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(-1, ret);
       TEST_ASSERT_EQUAL(EPIPE, errno);
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+      TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_send_bytes());
     }
@@ -322,7 +329,7 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Send2
+ * Name: remote_disconnect_send2
  *
  * Description:
  *   Send and disconnect
@@ -338,7 +345,7 @@ static void Send(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Send2(struct usrsocktest_daemon_conf_s *dconf)
+static void remote_disconnect_send2(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -366,7 +373,8 @@ static void Send2(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_recv_empty_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   /* Try connect. */
 
@@ -379,7 +387,8 @@ static void Send2(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   /* Disconnect connections with delay. */
 
@@ -396,7 +405,8 @@ static void Send2(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(EPIPE, errno);
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
-      TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+      TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_send_bytes());
     }
 
@@ -418,7 +428,7 @@ static void Send2(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Receive
+ * Name: receive
  *
  * Description:
  *   Receive and disconnect
@@ -434,7 +444,7 @@ static void Send2(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Receive(struct usrsocktest_daemon_conf_s *dconf)
+static void receive(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -475,19 +485,23 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                   usrsocktest_daemon_get_num_remote_disconnected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_recv_empty_sockets());
 
   /* Disconnect connections. */
 
   TEST_ASSERT_TRUE(usrsocktest_send_delayed_command('D', 0));
-  for (count = 0; usrsocktest_daemon_get_num_connected_sockets() > 0; count++)
+  for (count = 0; usrsocktest_daemon_get_num_connected_sockets() > 0;
+       count++)
     {
       TEST_ASSERT_TRUE(count <= 3);
       usleep(5 * 1000);
     }
+
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_recv_empty_sockets());
 
   for (count = 0; count < 2; count++)
@@ -499,7 +513,8 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
       ret = read(sd, data, datalen);
       TEST_ASSERT_EQUAL(0, ret);
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+      TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_recv_bytes());
     }
@@ -522,7 +537,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Receive2
+ * Name: receive2
  *
  * Description:
  *   Receive and disconnect
@@ -538,7 +553,7 @@ static void Receive(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
+static void receive2(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -568,7 +583,8 @@ static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_recv_empty_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   /* Try connect. */
 
@@ -581,7 +597,8 @@ static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_unreachable_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
   /* Disconnect connections with delay. */
 
@@ -596,7 +613,8 @@ static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
       ret = read(sd, data, datalen);
       TEST_ASSERT_EQUAL(0, ret);
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+      TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_recv_bytes());
     }
@@ -619,7 +637,7 @@ static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Poll
+ * Name: remote_disconnect_poll
  *
  * Description:
  *   Poll and disconnect
@@ -635,7 +653,7 @@ static void Receive2(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Poll(struct usrsocktest_daemon_conf_s *dconf)
+static void remote_disconnect_poll(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   struct sockaddr_in addr;
@@ -713,7 +731,8 @@ static void Poll(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(0, pfd.revents & POLLOUT);
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-  TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+  TEST_ASSERT_EQUAL(0,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_unreachable_sockets());
 
   /* Close socket */
@@ -734,7 +753,7 @@ static void Poll(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: Poll2
+ * Name: remote_disconnect_poll2
  *
  * Description:
  *   Poll and disconnect
@@ -750,7 +769,7 @@ static void Poll(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
+static void remote_disconnect_poll2(struct usrsocktest_daemon_conf_s *dconf)
 {
   ssize_t ret;
   size_t datalen;
@@ -776,7 +795,8 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
 
   do
     {
-      TEST_ASSERT_TRUE(*events == POLLIN || *events == POLLOUT || *events == (POLLOUT|POLLIN));
+      TEST_ASSERT_TRUE(*events == POLLIN || *events == POLLOUT ||
+                       *events == (POLLOUT | POLLIN));
 
       /* Open socket */
 
@@ -784,7 +804,8 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_TRUE(sd >= 0);
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
+      TEST_ASSERT_EQUAL(0,
+                    usrsocktest_daemon_get_num_waiting_connect_sockets());
 
       /* Make socket non-blocking */
 
@@ -821,29 +842,37 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
         {
           TEST_ASSERT_EQUAL(0, ret);
           TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
-          TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_waiting_connect_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_recv_empty_sockets());
+          TEST_ASSERT_EQUAL(1,
+                            usrsocktest_daemon_get_num_connected_sockets());
+          TEST_ASSERT_EQUAL(0,
+                      usrsocktest_daemon_get_num_waiting_connect_sockets());
+          TEST_ASSERT_EQUAL(1,
+                           usrsocktest_daemon_get_num_recv_empty_sockets());
         }
       else
         {
           TEST_ASSERT_EQUAL(-1, ret);
           TEST_ASSERT_EQUAL(EINPROGRESS, errno);
           TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
-          TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
+          TEST_ASSERT_EQUAL(0,
+                            usrsocktest_daemon_get_num_connected_sockets());
 
-          for (count = 0; usrsocktest_daemon_get_num_connected_sockets() != 1; count++)
+          for (count = 0;
+               usrsocktest_daemon_get_num_connected_sockets() != 1; count++)
             {
               TEST_ASSERT_TRUE(count <= 3);
               usleep(25 * 1000);
             }
 
-          ret = connect(sd, (FAR const struct sockaddr *)&addr, sizeof(addr));
+          ret = connect(sd, (FAR const struct sockaddr *)&addr,
+                        sizeof(addr));
           TEST_ASSERT_EQUAL(-1, ret);
           TEST_ASSERT_EQUAL(EISCONN, errno);
           TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_recv_empty_sockets());
+          TEST_ASSERT_EQUAL(1,
+                            usrsocktest_daemon_get_num_connected_sockets());
+          TEST_ASSERT_EQUAL(1,
+                           usrsocktest_daemon_get_num_recv_empty_sockets());
         }
 
       /* Poll for output (no timeout). Close connection. */
@@ -860,7 +889,8 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(0, pfd.revents & POLLOUT);
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-      TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+      TEST_ASSERT_EQUAL(1,
+                 usrsocktest_daemon_get_num_remote_disconnected_sockets());
 
       for (count = 0; count < 2; count++)
         {
@@ -870,8 +900,10 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
           datalen = sizeof(databuf);
           ret = read(sd, data, datalen);
           TEST_ASSERT_EQUAL(0, ret);
-          TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+          TEST_ASSERT_EQUAL(0,
+                          usrsocktest_daemon_get_num_connected_sockets());
+          TEST_ASSERT_EQUAL(1,
+                  usrsocktest_daemon_get_num_remote_disconnected_sockets());
           TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
           TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_recv_bytes());
         }
@@ -885,9 +917,11 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
           ret = write(sd, data, datalen);
           TEST_ASSERT_EQUAL(-1, ret);
           TEST_ASSERT_EQUAL(EPIPE, errno);
-          TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());
+          TEST_ASSERT_EQUAL(0,
+                          usrsocktest_daemon_get_num_connected_sockets());
           TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
-          TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_remote_disconnected_sockets());
+          TEST_ASSERT_EQUAL(1,
+                   usrsocktest_daemon_get_num_remote_disconnected_sockets());
           TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_send_bytes());
         }
 
@@ -913,7 +947,7 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
 }
 
 /****************************************************************************
- * Name: RemoteDisconnect test group setup
+ * Name: remote_disconnect test group setup
  *
  * Description:
  *   Setup function executed before each testcase in this test group
@@ -929,14 +963,14 @@ static void Poll2(struct usrsocktest_daemon_conf_s *dconf)
  *
  ****************************************************************************/
 
-TEST_SETUP(RemoteDisconnect)
+TEST_SETUP(remote_disconnect)
 {
   sd = -1;
   started = false;
 }
 
 /****************************************************************************
- * Name: RemoteDisconnect test group teardown
+ * Name: remote_disconnect test group teardown
  *
  * Description:
  *   Setup function executed after each testcase in this test group
@@ -952,14 +986,16 @@ TEST_SETUP(RemoteDisconnect)
  *
  ****************************************************************************/
 
-TEST_TEAR_DOWN(RemoteDisconnect)
+TEST_TEAR_DOWN(remote_disconnect)
 {
   int ret;
+
   if (sd >= 0)
     {
       ret = close(sd);
       assert(ret >= 0);
     }
+
   if (started)
     {
       ret = usrsocktest_daemon_stop();
@@ -967,115 +1003,115 @@ TEST_TEAR_DOWN(RemoteDisconnect)
     }
 }
 
-TEST(RemoteDisconnect, Unreachable)
+TEST(remote_disconnect, unreachable)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Unreachable(&usrsocktest_daemon_config);
+  unreachable(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, UnreachableDelay)
+TEST(remote_disconnect, unreachable_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Unreachable(&usrsocktest_daemon_config);
+  unreachable(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, Send)
+TEST(remote_disconnect, remote_disconnect_send)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Send(&usrsocktest_daemon_config);
+  remote_disconnect_send(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, SendDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  Send(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Send2)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Send2(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Send2Delay)
+TEST(remote_disconnect, remote_disconnect_send_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Send2(&usrsocktest_daemon_config);
+  remote_disconnect_send(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, Receive)
+TEST(remote_disconnect, remote_disconnect_send2)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Receive(&usrsocktest_daemon_config);
+  remote_disconnect_send2(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, ReceiveDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  Receive(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Receive2)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Receive2(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Receive2Delay)
+TEST(remote_disconnect, remote_disconnect_send2_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Receive2(&usrsocktest_daemon_config);
+  remote_disconnect_send2(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, Poll)
+TEST(remote_disconnect, receive)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Poll(&usrsocktest_daemon_config);
+  receive(&usrsocktest_daemon_config);
 }
 
-TEST(RemoteDisconnect, PollDelay)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  usrsocktest_daemon_config.delay_all_responses = true;
-  Poll(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Poll2)
-{
-  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
-  Poll2(&usrsocktest_daemon_config);
-}
-
-TEST(RemoteDisconnect, Poll2Delay)
+TEST(remote_disconnect, receive_delay)
 {
   usrsocktest_daemon_config = usrsocktest_daemon_defconf;
   usrsocktest_daemon_config.delay_all_responses = true;
-  Poll2(&usrsocktest_daemon_config);
+  receive(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, receive2)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  receive2(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, receive2_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  receive2(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, remote_disconnect_poll)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  remote_disconnect_poll(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, remote_disconnect_poll_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  remote_disconnect_poll(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, remote_disconnect_poll2)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  remote_disconnect_poll2(&usrsocktest_daemon_config);
+}
+
+TEST(remote_disconnect, remote_disconnect_poll2_delay)
+{
+  usrsocktest_daemon_config = usrsocktest_daemon_defconf;
+  usrsocktest_daemon_config.delay_all_responses = true;
+  remote_disconnect_poll2(&usrsocktest_daemon_config);
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-TEST_GROUP(RemoteDisconnect)
+TEST_GROUP(remote_disconnect)
 {
-  RUN_TEST_CASE(RemoteDisconnect, Unreachable);
-  RUN_TEST_CASE(RemoteDisconnect, UnreachableDelay);
-  RUN_TEST_CASE(RemoteDisconnect, Send);
-  RUN_TEST_CASE(RemoteDisconnect, SendDelay);
-  RUN_TEST_CASE(RemoteDisconnect, Send2);
-  RUN_TEST_CASE(RemoteDisconnect, Send2Delay);
-  RUN_TEST_CASE(RemoteDisconnect, Receive);
-  RUN_TEST_CASE(RemoteDisconnect, ReceiveDelay);
-  RUN_TEST_CASE(RemoteDisconnect, Receive2);
-  RUN_TEST_CASE(RemoteDisconnect, Receive2Delay);
-  RUN_TEST_CASE(RemoteDisconnect, Poll);
-  RUN_TEST_CASE(RemoteDisconnect, PollDelay);
-  RUN_TEST_CASE(RemoteDisconnect, Poll2);
-  RUN_TEST_CASE(RemoteDisconnect, Poll2Delay);
+  RUN_TEST_CASE(remote_disconnect, unreachable);
+  RUN_TEST_CASE(remote_disconnect, unreachable_delay);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_send);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_send_delay);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_send2);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_send2_delay);
+  RUN_TEST_CASE(remote_disconnect, receive);
+  RUN_TEST_CASE(remote_disconnect, receive_delay);
+  RUN_TEST_CASE(remote_disconnect, receive2);
+  RUN_TEST_CASE(remote_disconnect, receive2_delay);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_poll);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_poll_delay);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_poll2);
+  RUN_TEST_CASE(remote_disconnect, remote_disconnect_poll2_delay);
 }

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -348,7 +348,8 @@ static int usrsock_rpmsg_sendto_handler(struct rpmsg_endpoint *ept,
   if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
     {
       ret = psock_sendto(&priv->socks[req->usockid],
-              (const void *)(req + 1) + req->addrlen, req->buflen, 0,
+              (const void *)(req + 1) + req->addrlen, req->buflen,
+              req->flags,
               req->addrlen ? (const struct sockaddr *)(req + 1) : NULL,
               req->addrlen);
     }
@@ -395,7 +396,7 @@ static int usrsock_rpmsg_recvfrom_handler(struct rpmsg_endpoint *ept,
   if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
     {
       ret = psock_recvfrom(&priv->socks[req->usockid],
-              (void *)(ack + 1) + inaddrlen, buflen, 0,
+              (void *)(ack + 1) + inaddrlen, buflen, req->flags,
               outaddrlen ? (struct sockaddr *)(ack + 1) : NULL,
               outaddrlen ? &outaddrlen : NULL);
       if (ret > 0 && outaddrlen < inaddrlen)

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -853,6 +853,7 @@ static int recvfrom_request(int fd, FAR struct gs2200m_s *priv,
   rmsg.cid = usock->cid;
   rmsg.reqlen = req->max_buflen;
   rmsg.is_tcp = (usock->type == SOCK_STREAM) ? true : false;
+  rmsg.flags = req->flags;
 
   ret = ioctl(priv->gsfd, GS2200M_IOC_RECV,
               (unsigned long)&rmsg);


### PR DESCRIPTION
## Summary

- Add flags to usrsock daemons
- Fix coding style

## Impact

usrsock drivers can be process recv() flags.

## Testing

Tested by spresense:wifi
