### PR TITLE
netutils/dhcpd: correct the member name

### DIFF
--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -1730,7 +1730,7 @@ int dhcpd_stop(void)
           if (ret < 0)
             {
               nerr("ERROR: kill pid %d failed: %d\n",
-                   g_dhcpd_daemon.pid, errno);
+                   g_dhcpd_daemon.ds_pid, errno);
               break;
             }
 


### PR DESCRIPTION
##Summary

netutils/dhcpd: correct the member name

## Impact

build break if enable CONFIG_DEBUG_NET_ERROR

## Testing

enable CONFIG_DEBUG_NET_ERROR and compile pass

