### PR TITLE
nshlib: Fix memory corruption in nsh_parse.c

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -654,8 +654,10 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "sched_getparm",
                     NSH_ERRNO);
+
+          /* NOTE: bkgvtbl is released in nsh_relaseargs() */
+
           nsh_releaseargs(args);
-          nsh_release(bkgvtbl);
           goto errout;
         }
 
@@ -699,8 +701,10 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "pthread_create",
                     NSH_ERRNO_OF(ret));
+
+          /* NOTE: bkgvtbl is released in nsh_relaseargs() */
+
           nsh_releaseargs(args);
-          nsh_release(bkgvtbl);
           goto errout;
         }
 


### PR DESCRIPTION
## Summary

- Fix memory corruption when pthread_create() failed in nsh_execute()

## Impact

- nsh builtin command execution in background with errors

## Testing

- Tested with hifive1-revb:nsh
- Set CONFIG_MAX_TASKS=4
- Run 'sleep 1000 &' in 3 times will cause pthread_create error
- Run free, ps command
