### PR TITLE
interpreters/duktape: Add console/print/alart support

### DIFF
--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -39,7 +39,7 @@ include $(APPDIR)/Make.defs
 
 CONFIG_LV_EXAMPLES_URL ?= https://github.com/lvgl/lv_examples/archive
 
-LVGL_EXAMPLES_VERSION ?= 7.0.2
+LVGL_EXAMPLES_VERSION = $(patsubst "%",%,$(strip $(CONFIG_LVGL_VERSION)))
 LVGL_EXAMPLES_TARBALL = v$(LVGL_EXAMPLES_VERSION).zip
 
 WGET ?= wget

--- a/graphics/lvgl/Kconfig
+++ b/graphics/lvgl/Kconfig
@@ -11,6 +11,10 @@ menuconfig GRAPHICS_LVGL
 
 if GRAPHICS_LVGL
 
+config LVGL_VERSION
+	string "LVGL Version"
+	default "7.3.0"
+
 config LV_MEM_SIZE
 	int "Heap size of the graphics library"
 	default 32768

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -57,7 +57,7 @@ WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
 CONFIG_GRAPH_LVGL_URL ?= "https://github.com/lvgl/lvgl/archive"
 
-LVGL_VERSION ?= 7.0.2
+LVGL_VERSION = $(patsubst "%",%,$(strip $(CONFIG_LVGL_VERSION)))
 LVGL_TARBALL = v$(LVGL_VERSION).zip
 WGET ?= wget
 

--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -27,6 +27,8 @@ DUKTAPE_URL_BASE = https://github.com/svaarala/duktape/releases/download/
 DUKTAPE_URL      = $(DUKTAPE_URL_BASE)v$(DUKTAPE_VERSION)/$(DUKTAPE_TARBALL)
 
 CSRCS = $(DUKTAPE_UNPACK)/src-noline/duktape.c
+CSRCS += $(DUKTAPE_UNPACK)/extras/console/duk_console.c
+CSRCS += $(DUKTAPE_UNPACK)/extras/print-alert/duk_print_alert.c
 
 MAINSRC = $(DUKTAPE_UNPACK)/examples/cmdline/duk_cmdline.c
 
@@ -36,6 +38,10 @@ STACKSIZE = $(CONFIG_INTERPRETERS_DUKTAPE_STACKSIZE)
 MODULE    = $(CONFIG_INTERPRETERS_DUKTAPE)
 
 CFLAGS += -I$(DUKTAPE_UNPACK)/src-noline
+CFLAGS += -I$(DUKTAPE_UNPACK)/extras/console
+CFLAGS += -I$(DUKTAPE_UNPACK)/extras/print-alert
+CFLAGS += -DDUK_CMDLINE_CONSOLE_SUPPORT
+CFLAGS += -DDUK_CMDLINE_PRINTALERT_SUPPORT
 
 $(DUKTAPE_TARBALL):
 	@echo "Downloading $(DUKTAPE_TARBALL)"
@@ -46,8 +52,11 @@ $(DUKTAPE_UNPACK): $(DUKTAPE_TARBALL)
 	@tar xvfJ $(DUKTAPE_TARBALL)
 	@echo "Patching $(DUKTAPE_UNPACK)"
 	@patch -p0 < duk_cmdline.patch
+	@touch $(DUKTAPE_UNPACK)/.patch
 
-context:: $(DUKTAPE_UNPACK)
+$(DUKTAPE_UNPACK)/.patch: $(DUKTAPE_UNPACK)
+
+context:: $(DUKTAPE_UNPACK)/.patch
 
 distclean::
 	$(call DELDIR, $(DUKTAPE_UNPACK))

--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -26,11 +26,16 @@ DUKTAPE_TARBALL  = duktape-$(DUKTAPE_VERSION).tar.xz
 DUKTAPE_URL_BASE = https://github.com/svaarala/duktape/releases/download/
 DUKTAPE_URL      = $(DUKTAPE_URL_BASE)v$(DUKTAPE_VERSION)/$(DUKTAPE_TARBALL)
 
-CSRCS = $(DUKTAPE_UNPACK)/src-noline/duktape.c
-CSRCS += $(DUKTAPE_UNPACK)/extras/console/duk_console.c
-CSRCS += $(DUKTAPE_UNPACK)/extras/print-alert/duk_print_alert.c
+CSRCS = duktape.c
+CSRCS += duk_console.c
+CSRCS += duk_print_alert.c
 
-MAINSRC = $(DUKTAPE_UNPACK)/examples/cmdline/duk_cmdline.c
+MAINSRC = duk_cmdline.c
+
+VPATH += $(DUKTAPE_UNPACK)/src-noline
+VPATH += $(DUKTAPE_UNPACK)/extras/console
+VPATH += $(DUKTAPE_UNPACK)/extras/print-alert
+VPATH += $(DUKTAPE_UNPACK)/examples/cmdline
 
 PROGNAME  = duk
 PRIORITY  = $(CONFIG_INTERPRETERS_DUKTAPE_PRIORITY)


### PR DESCRIPTION
## Summary
* Minor change for makefile, add duktape's builtin console/print/alart module support.
* Make lvgl version configurable by kconfig
## Impact
Duktape interpreter
## Testing
Tested on stm32f746g-disco & sim.
