### PR TITLE
ftpc_transfer.c:667:15: Fix error: ‘argc’ undeclared

### DIFF
--- a/netutils/ftpc/ftpc_transfer.c
+++ b/netutils/ftpc/ftpc_transfer.c
@@ -664,7 +664,7 @@ void ftpc_timeout(wdparm_t arg)
   FAR struct ftpc_session_s *session = (FAR struct ftpc_session_s *)arg;
 
   nerr("ERROR: Timeout!\n");
-  DEBUGASSERT(argc == 1 && session);
+  DEBUGASSERT(session);
   kill(session->pid, CONFIG_FTP_SIGNAL);
 }
 


### PR DESCRIPTION
## Summary
forget in commit efeb1d10b1bbc43255406f8ab7d32284357e2211

## Impact

## Testing

