### PR TITLE
nshlib: remove NSH_HAVE_WRITABLE_MOUNTPOINT to enable mkrd again

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -323,11 +323,9 @@ static const struct cmdmap_s g_cmdmap[] =
 # endif
 #endif
 
-#ifdef NSH_HAVE_WRITABLE_MOUNTPOINT
-# ifndef CONFIG_NSH_DISABLE_MKRD
+#ifndef CONFIG_NSH_DISABLE_MKRD
   { "mkrd",     cmd_mkrd,     2, 6,
     "[-m <minor>] [-s <sector-size>] <nsectors>" },
-# endif
 #endif
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_SMARTFS) && \

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1360,7 +1360,6 @@ int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  * Name: cmd_mkrd
  ****************************************************************************/
 
-#ifdef NSH_HAVE_WRITABLE_MOUNTPOINT
 #ifndef CONFIG_NSH_DISABLE_MKRD
 int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 {
@@ -1457,7 +1456,6 @@ errout_with_fmt:
   nsh_output(vtbl, fmt, argv[0]);
   return ERROR;
 }
-#endif
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Remove NSH_HAVE_WRITABLE_MOUNTPOINT define as it is not defined anymore (see commit 74c506b4d16bb91802da5f3f5f64a5fb5f63c78e)

## Impact

## Testing

