### PR TITLE
interpreters/duktape:Add duktape to global search path

### DIFF
--- a/interpreters/duktape/.gitignore
+++ b/interpreters/duktape/.gitignore
@@ -1,1 +1,1 @@
-duktape-*
+duktape*

--- a/interpreters/duktape/Make.defs
+++ b/interpreters/duktape/Make.defs
@@ -20,4 +20,11 @@
 
 ifneq ($(CONFIG_INTERPRETERS_DUKTAPE),)
 CONFIGURED_APPS += $(APPDIR)/interpreters/duktape
+
+# It allows `<duktape/duktape.h>` import.
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
+    $(APPDIR)/interpreters/duktape/duktape/src-noline}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
+    $(APPDIR)/interpreters/duktape/duktape/src-noline}
+
 endif

--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -21,7 +21,7 @@
 include $(APPDIR)/Make.defs
 
 DUKTAPE_VERSION  = 2.5.0
-DUKTAPE_UNPACK   = duktape-$(DUKTAPE_VERSION)
+DUKTAPE_UNPACK   = duktape
 DUKTAPE_TARBALL  = duktape-$(DUKTAPE_VERSION).tar.xz
 DUKTAPE_URL_BASE = https://github.com/svaarala/duktape/releases/download/
 DUKTAPE_URL      = $(DUKTAPE_URL_BASE)v$(DUKTAPE_VERSION)/$(DUKTAPE_TARBALL)
@@ -49,17 +49,18 @@ CFLAGS += -DDUK_CMDLINE_CONSOLE_SUPPORT
 CFLAGS += -DDUK_CMDLINE_PRINTALERT_SUPPORT
 
 $(DUKTAPE_TARBALL):
-	@echo "Downloading $(DUKTAPE_TARBALL)"
-	@wget $(DUKTAPE_URL)
+	$(Q) echo "Downloading $(DUKTAPE_TARBALL)"
+	$(Q) wget $(DUKTAPE_URL)
 
 $(DUKTAPE_UNPACK): $(DUKTAPE_TARBALL)
-	@echo "Unpacking $(DUKTAPE_TARBALL) to $(DUKTAPE_UNPACK)"
-	@tar xvfJ $(DUKTAPE_TARBALL)
-	@echo "Patching $(DUKTAPE_UNPACK)"
-	@patch -p0 < duk_cmdline.patch
-	@touch $(DUKTAPE_UNPACK)/.patch
+	$(Q) echo "Unpacking $(DUKTAPE_TARBALL) to $(DUKTAPE_UNPACK)"
+	$(Q) tar xvfJ $(DUKTAPE_TARBALL)
+	$(Q) mv duktape-$(DUKTAPE_VERSION) $(DUKTAPE_UNPACK)
+	$(Q) echo "Patching $(DUKTAPE_UNPACK)"
+	$(Q) patch -p0 < duk_cmdline.patch
 
 $(DUKTAPE_UNPACK)/.patch: $(DUKTAPE_UNPACK)
+	$(Q) touch $(DUKTAPE_UNPACK)/.patch
 
 context:: $(DUKTAPE_UNPACK)/.patch
 

--- a/interpreters/duktape/duk_cmdline.patch
+++ b/interpreters/duktape/duk_cmdline.patch
@@ -1,5 +1,5 @@
-diff --color -ur duktape-2.5.0/examples/cmdline/duk_cmdline.c duktape-2.5.0-modifed/examples/cmdline/duk_cmdline.c
---- duktape-2.5.0/examples/cmdline/duk_cmdline.c	2019-11-25 06:04:27.000000000 +0800
+diff --color -ur duktape/examples/cmdline/duk_cmdline.c duktape-2.5.0-modifed/examples/cmdline/duk_cmdline.c
+--- duktape/examples/cmdline/duk_cmdline.c	2019-11-25 06:04:27.000000000 +0800
 +++ duktape-2.5.0-modifed/examples/cmdline/duk_cmdline.c	2020-08-07 23:20:27.320000000 +0800
 @@ -103,7 +103,7 @@
  #define  MEM_LIMIT_NORMAL   (128*1024*1024)   /* 128 MB */
@@ -25,8 +25,8 @@ diff --color -ur duktape-2.5.0/examples/cmdline/duk_cmdline.c duktape-2.5.0-modi
  			} else if (idx >= LINEBUF_SIZE) {
  				fprintf(stderr, "line too long\n");
 
-diff --color -ur duktape-2.5.0/src-noline/duk_config.h duktape-2.5.0-modifed/src-noline/duk_config.h
---- duktape-2.5.0/src-noline/duk_config.h	2019-11-25 06:04:27.000000000 +0800
+diff --color -ur duktape/src-noline/duk_config.h duktape-2.5.0-modifed/src-noline/duk_config.h
+--- duktape/src-noline/duk_config.h	2019-11-25 06:04:27.000000000 +0800
 +++ duktape-2.5.0-modifed/src-noline/duk_config.h	2020-08-07 23:14:55.880000000 +0800
 @@ -402,7 +402,7 @@
  /* --- Mac OSX, iPhone, Darwin --- */


### PR DESCRIPTION
## Summary

This is useful for using duktape as a library.

## Impact
None

## Testing
Tested on sim & stm32