### PR TITLE
Bluetooth: Use the new l2cap socket address type

### DIFF
--- a/wireless/bluetooth/btsak/btsak.h
+++ b/wireless/bluetooth/btsak/btsak.h
@@ -98,11 +98,14 @@ static inline void btsak_update_ipv6addr(FAR struct btsak_s *btsak)
   btsak->ep_in6addr.sin6_addr.in6_u.u6_addr16[3] = 0;
   btsak->ep_in6addr.sin6_addr.in6_u.u6_addr16[4] = HTONS(0x0200);
   btsak->ep_in6addr.sin6_addr.in6_u.u6_addr16[5] =
-    ((uint16_t)btsak->ep_btaddr.val[0] << 8 | (uint16_t)btsak->ep_btaddr.val[1]);
+    ((uint16_t)btsak->ep_btaddr.val[0] << 8 |
+     (uint16_t)btsak->ep_btaddr.val[1]);
   btsak->ep_in6addr.sin6_addr.in6_u.u6_addr16[6] =
-    ((uint16_t)btsak->ep_btaddr.val[2] << 8 | (uint16_t)btsak->ep_btaddr.val[3]);
+    ((uint16_t)btsak->ep_btaddr.val[2] << 8 |
+     (uint16_t)btsak->ep_btaddr.val[3]);
   btsak->ep_in6addr.sin6_addr.in6_u.u6_addr16[7] =
-    ((uint16_t)btsak->ep_btaddr.val[4] << 8 | (uint16_t)btsak->ep_btaddr.val[5]);
+    ((uint16_t)btsak->ep_btaddr.val[4] << 8 |
+     (uint16_t)btsak->ep_btaddr.val[5]);
 }
 #endif
 

--- a/wireless/bluetooth/btsak/btsak.h
+++ b/wireless/bluetooth/btsak/btsak.h
@@ -71,7 +71,7 @@ struct btsak_s
   FAR char *ifname;                  /* Interface name */
   bt_addr_t ep_btaddr;               /* Blue tooth address */
 #if defined(CONFIG_NET_BLUETOOTH)
-  struct sockaddr_bt_s ep_sockaddr;  /* AF_BLUETOOTH endpoint address */
+  struct sockaddr_l2 ep_sockaddr;    /* AF_BLUETOOTH endpoint address */
 #elif defined(CONFIG_NET_6LOWPAN)
   struct sockaddr_in6 ep_sockaddr;   /* IPv6 endpoint address */
 #endif

--- a/wireless/bluetooth/btsak/btsak_main.c
+++ b/wireless/bluetooth/btsak/btsak_main.c
@@ -626,9 +626,9 @@ int btsak_socket(FAR struct btsak_s *btsak)
   BLUETOOTH_ADDRCOPY(btsak->ep_btaddr.val, g_default_epaddr.val);
 
 #if defined(CONFIG_NET_BLUETOOTH)
-  btsak->ep_sockaddr.bt_family   = AF_BLUETOOTH;
-  btsak->ep_sockaddr.bt_channel  = 0;  /* REVISIT */
-  BLUETOOTH_ADDRCOPY(btsak->ep_sockaddr.bt_bdaddr.val, btsak->ep_btaddr.val);
+  btsak->ep_sockaddr.l2_family  = AF_BLUETOOTH;
+  btsak->ep_sockaddr.l2_cid     = 0;  /* REVISIT */
+  BLUETOOTH_ADDRCOPY(btsak->ep_sockaddr.l2_bdaddr.val, btsak->ep_btaddr.val);
 
   sockfd = socket(PF_BLUETOOTH, SOCK_RAW, BTPROTO_L2CAP);
 

--- a/wireless/bluetooth/btsak/btsak_main.c
+++ b/wireless/bluetooth/btsak/btsak_main.c
@@ -61,7 +61,8 @@
 struct btsak_command_s
 {
   FAR const char *name;
-  CODE void (*handler)(FAR struct btsak_s *btsak, int argc, FAR char *argv[]);
+  CODE void (*handler)(FAR struct btsak_s *btsak, int argc,
+                       FAR char *argv[]);
   FAR const char *help;
 };
 
@@ -233,7 +234,8 @@ void btsak_cmd_gatt(FAR struct btsak_s *btsak, int argc, FAR char *argv[])
 
   if (cmd == NULL)
     {
-      fprintf(stderr, "ERROR: Unrecognized gatt command: %s\n", argv[argind]);
+      fprintf(stderr, "ERROR: Unrecognized gatt command: %s\n",
+              argv[argind]);
       btsak_gatt_showusage(btsak->progname, argv[0], EXIT_SUCCESS);
     }
 
@@ -664,7 +666,8 @@ void btsak_showusage(FAR const char *progname, int exitcode)
   fprintf(stderr, "\nUsage:\n\n");
   fprintf(stderr, "\t%s <ifname> <cmd> [option [option [option...]]]\n",
           progname);
-  fprintf(stderr, "\nWhere <cmd> [option [option [option...]]] is one of:\n\n");
+  fprintf(stderr,
+          "\nWhere <cmd> [option [option [option...]]] is one of:\n\n");
 
   for (i = 0; i < NCOMMANDS; i++)
     {
@@ -698,9 +701,11 @@ void btsak_gatt_showusage(FAR const char *progname, FAR const char *cmd,
 
   fprintf(stderr, "%s:  Generic Attribute (GATT) commands:\n", cmd);
   fprintf(stderr, "Usage:\n\n");
-  fprintf(stderr, "\t%s <ifname> %s [-h] <cmd> [option [option [option...]]]\n",
+  fprintf(stderr,
+          "\t%s <ifname> %s [-h] <cmd> [option [option [option...]]]\n",
           progname, cmd);
-  fprintf(stderr, "\nWhere <cmd> [option [option [option...]]] is one of:\n\n");
+  fprintf(stderr,
+          "\nWhere <cmd> [option [option [option...]]] is one of:\n\n");
 
   for (i = 0; i < GATT_NCOMMANDS; i++)
     {


### PR DESCRIPTION
## Summary
Update btsak application to use the new BTPROTO_L2CAP `sockaddr_l2` struct instead of the generic one we had for Bluetooth before.

## Impact
No change in functionality.

## Testing
Tool works the same as before.
