### PR TITLE
CI: Fix check patch to handle renames / deletes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check Pull Request
       run: |
         cd apps
-        commits=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
+        commits="${{ github.event.pull_request.base.sha }}..HEAD"
         git log --oneline $commits
         echo "../nuttx/tools/checkpatch.sh -g $commits"
         ../nuttx/tools/checkpatch.sh -g $commits


### PR DESCRIPTION
## Summary
Previously there were issues with how we identified changed files for running checkpatch.  Internally this is now handled with `git diff` instead of `git show`.  This also means we simplify the computing of the commit range.  This aligns with the changes in the OS repo https://github.com/apache/incubator-nuttx/pull/1706

Also Issue https://github.com/apache/incubator-nuttx/issues/1637