### PR TITLE
Fix: ensure archive files do not carry object files from prior builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,8 @@
 *.swp
 *.sym
 *~
-.built
 .depend
 .kconfig
-/*.lock
 /bin
 /boot_romfsimg.h
 /external

--- a/Application.mk
+++ b/Application.mk
@@ -95,7 +95,7 @@ VPATH += :.
 
 # Targets follow
 
-all:: .built
+all:: $(OBJS)
 .PHONY: clean depend distclean
 .PRECIOUS: $(BIN)
 
@@ -131,13 +131,12 @@ $(CXXOBJS): %$(SUFFIX)$(OBJEXT): %$(CXXEXT)
 	$(if $(and $(CONFIG_BUILD_LOADABLE),$(CXXELFFLAGS)), \
 		$(call ELFCOMPILEXX, $<, $@), $(call COMPILEXX, $<, $@))
 
-.built: $(OBJS)
+archive:
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-	$(call ARLOCK, "${shell cygpath -w $(BIN)}", $^)
+	$(call ARCHIVE_ADD, "${shell cygpath -w $(BIN)}", $(OBJS))
 else
-	$(call ARLOCK, $(BIN), $^)
+	$(call ARCHIVE_ADD, $(BIN), $(OBJS))
 endif
-	$(Q) touch $@
 
 ifeq ($(BUILD_MODULE),y)
 
@@ -234,7 +233,6 @@ endif
 depend:: .depend
 
 clean::
-	$(call DELFILE, .built)
 	$(call CLEAN)
 
 distclean:: clean

--- a/Directory.mk
+++ b/Directory.mk
@@ -39,7 +39,6 @@ include $(APPDIR)/Make.defs
 
 SUBDIRS       := $(dir $(wildcard *$(DELIM)Makefile))
 CONFIGSUBDIRS := $(filter-out $(dir $(wildcard *$(DELIM)Kconfig)),$(SUBDIRS))
-CLEANSUBDIRS  := $(dir $(wildcard *$(DELIM).built))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).depend))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).kconfig))
 CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))

--- a/Make.defs
+++ b/Make.defs
@@ -108,10 +108,6 @@ define REGISTER
 	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
 
-define ARLOCK
-	$(Q) flock $1.lock $(call ARCHIVE, $1, $(2))
-endef
-
 # Standard include path
 
 CFLAGS   += ${shell $(INCDIR) "$(CC)" "$(APPDIR)$(DELIM)include"}


### PR DESCRIPTION
## Summary

This is the corresponding change to the one on main NuttX repo (see https://github.com/apache/incubator-nuttx/pull/1765).
In this case this involves splitting the build of libapps.a into: a) building
all applications (which is safely parallelizable), b) adding each
application's object files to the archive in turns (serial by nature).

This removes the need for the flock used to protect the parallel build.

NOTE: this will not pass CI since it depends on the other PR

## Impact

Build

## Testing

Builds correctly
