### PR TITLE
Remove -x from cibuild.sh call in CI since this will abort the build on first error and we do not want that

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
         with:
           run: |
             cd sources/testing
-            ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+            ./cibuild.sh testlist/${{matrix.boards}}.dat
 
   macOS:
     runs-on: macos-10.15
@@ -231,4 +231,4 @@ jobs:
       - name: Run Builds
         run: |
           cd sources/testing
-          ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -i testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
## Summary

Follow up change to https://github.com/apache/incubator-nuttx/pull/1771

## Impact

CI

## Testing

CI