### PR TITLE
ntpclient: fix NTP daemon state in case of DNS failure

### DIFF
--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -383,6 +383,9 @@ static int ntpc_daemon(int argc, char **argv)
     {
       nerr("ERROR: Failed to resolve '%s'\n",
            CONFIG_NETUTILS_NTPCLIENT_SERVER);
+
+      g_ntpc_daemon.state = NTP_STOPPED;
+      sem_post(&g_ntpc_daemon.sync);
       return EXIT_FAILURE;
     }
 #endif


### PR DESCRIPTION
## Summary

In case of DNS resolution failure the NTP daemon was exiting without updating its state, which caused later calls to ntpc_start or ntpc_stop to fail.

## Impact

## Testing

