### PR TITLE
apps/MAKE: Add register staging to context

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -198,6 +198,8 @@ install::
 
 endif # BUILD_MODULE
 
+context::
+
 ifeq ($(CONFIG_NSH_BUILTIN_APPS),y)
 ifneq ($(PROGNAME),)
 ifneq ($(PRIORITY),)
@@ -212,18 +214,18 @@ $(REGLIST): $(DEPCONFIG) Makefile
 	$(if $(filter-out $(firstword $(PRIORITY)),$(PRIORITY)),$(eval PRIORITY=$(filter-out $(firstword $(PRIORITY)),$(PRIORITY))))
 	$(if $(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE)),$(eval STACKSIZE=$(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE))))
 
-context:: $(REGLIST)
+register:: $(REGLIST)
 else
-context::
+register::
 endif
 else
-context::
+register::
 endif
 else
-context::
+register::
 endif
 else
-context::
+register::
 endif
 
 .depend: Makefile $(wildcard $(foreach SRC, $(SRCS), $(addsuffix /$(SRC), $(subst :, ,$(VPATH))))) $(DEPCONFIG)

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,14 @@ all:
 	$(RM) $(BIN)
 	$(MAKE) $(BIN)
   
-.PHONY: import install dirlinks context context_serialize clean_context context_rest export .depdirs preconfig depend clean distclean
+.PHONY: import install dirlinks export .depdirs preconfig depend clean distclean
+.PHONY: context clean_context context_all register register_all
 .PRECIOUS: $(BIN)
 
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),all)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),install)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),context)))
+$(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),register)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),depend)))
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
@@ -82,6 +84,7 @@ install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
 import: $(IMPORT_TOOLS)
 	$(Q) $(MAKE) context TOPDIR="$(APPDIR)$(DELIM)import"
+	$(Q) $(MAKE) register TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) depend TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) .import TOPDIR="$(APPDIR)$(DELIM)import"
 
@@ -144,6 +147,7 @@ endif
 
 import: $(IMPORT_TOOLS)
 	$(Q) $(MAKE) context TOPDIR="$(APPDIR)$(DELIM)import"
+	$(Q) $(MAKE) register TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) depend TOPDIR="$(APPDIR)$(DELIM)import"
 	$(Q) $(MAKE) .import TOPDIR="$(APPDIR)$(DELIM)import"
 
@@ -152,13 +156,12 @@ endif # CONFIG_BUILD_KERNEL
 dirlinks:
 	$(Q) $(MAKE) -C platform dirlinks
 
-context_rest: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_context)
+context_all: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_context)
+register_all: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_register)
 
-context_serialize:
-	$(Q) $(MAKE) -C builtin context
-	$(Q) $(MAKE) context_rest
-
-context: context_serialize
+context:
+	$(Q) $(MAKE) context_all
+	$(Q) $(MAKE) register_all
 
 Kconfig:
 	$(foreach SDIR, $(CONFIGDIRS), $(call MAKE_template,$(SDIR),preconfig))

--- a/import/Makefile
+++ b/import/Makefile
@@ -41,11 +41,13 @@ SUBDIRS = arch include libs scripts startup tmp tools
 FILES   = .config System.map User.map
 
 all:
-.PHONY: context depend clean distclean
+.PHONY: context register depend clean distclean
 
 install:
 
 context:
+
+register:
 
 depend:
 


### PR DESCRIPTION
## Summary

apps/MAKE: Add register staging to context

## Impact

When compiling an external library, and the library need "configure" firstly.
Then there are 2 ways to doing the "configure" :
1. preconfig stage:
   If put "configure" in this stage, the global config.h (external library also needed) hasn't ready.
2. context stage:
   If put "configure" in this stage, the action of registering will be failed, because PROGNAME in library
   has dependency to action "configure".

In another word, compiler should follow this step for this library:
preconfig(config.h) ->  configure to library -> PROGNAME -> action of registering to built-in list

So, to resolve this.

preconfig(config.h) ->  configure to library -> PROGNAME -> action of registering to built-in list
preconfig stage &emsp; &emsp; &emsp;   context stage   &emsp;  &emsp; &emsp; &emsp; &emsp;&emsp; &emsp; register stage                                         

## Testing

