### PR TITLE
system: nxplayer: Fix a compile error if CONFIG_DEBUG_AUDIO_ERROR=y

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -669,7 +669,7 @@ static int nxplayer_readbuffer(FAR struct nxplayer_s *pplayer,
 
   if (apb->nbytes < apb->nmaxbytes)
     {
-#ifdef CONFIG_DEBUG_AUDIO_INFO
+#if defined (CONFIG_DEBUG_AUDIO_INFO) || defined (CONFIG_DEBUG_AUDIO_ERROR)
       int errcode = errno;
 
       audinfo("Closing audio file, nbytes=%d errcode=%d\n",


### PR DESCRIPTION
## Summary

- This commit fixes a compile error

## Impact

- Affects nxplayer with CONFIG_DEBUG_AUDIO_ERROR=y

## Testing

- Tested with spresense:rndis
