### PR TITLE
examples/fb: correct the munmap(2) parameter type 

### DIFF
--- a/examples/fb/fb_main.c
+++ b/examples/fb/fb_main.c
@@ -470,7 +470,7 @@ int main(int argc, FAR char *argv[])
     }
 
   printf("Test finished\n");
-  munmap(state.fd, state.fbmem);
+  munmap(state.fbmem, state.pinfo.fblen);
   close(state.fd);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION

## Summary
examples/fb: correct the munmap(2) parameter type 


```
fb_main.c: In function 'fb_main':
fb_main.c:473:15: warning: passing argument 1 of 'munmap' makes pointer from integer without a cast [-Wint-conversion]
  473 |   munmap(state.fd, state.fbmem);
      |          ~~~~~^~~
      |               |
      |               int
In file included from fb_main.c:43:
/home/archer/code/upload/incubator-nuttx/include/sys/mman.h:177:22: note: expected 'void *' but argument is of type 'int'
  177 | int munmap(FAR void *start, size_t length);
      |                ~~~~~~^~~~~
fb_main.c:473:25: warning: passing argument 2 of 'munmap' makes integer from pointer without a cast [-Wint-conversion]
  473 |   munmap(state.fd, state.fbmem);
      |                    ~~~~~^~~~~~
      |                         |
      |                         void *
In file included from fb_main.c:43:
/home/archer/code/upload/incubator-nuttx/include/sys/mman.h:177:36: note: expected 'size_t' {aka 'unsigned int'} but argument is of type 'void *'
  177 | int munmap(FAR void *start, size_t length);
      |                             ~~~~~~~^~~~~~

Signed-off-by: chao.an <anchao@xiaomi.com>
```


