### PR TITLE
wireless/wapi: add scan partial channel support

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -644,6 +644,19 @@ int wapi_make_socket(void);
 int wapi_scan_init(int sock, FAR const char *ifname, FAR const char *essid);
 
 /****************************************************************************
+ * Name: wapi_scan_channel_init
+ *
+ * Description:
+ *   Starts a scan on the given interface. Root privileges are required to
+ *   start a scan with specified channels.
+ *
+ ****************************************************************************/
+
+int wapi_scan_channel_init(int sock, FAR const char *ifname,
+                           FAR const char *essid,
+                           uint8_t *channels, int num_channels);
+
+/****************************************************************************
  * Name: wapi_scan_stat
  *
  * Description:


### PR DESCRIPTION

## Summary

wireless/wapi: add scan partial channel support

Change-Id: I2279406a9ca0cc3a9535ce79fbf651dbaf14ad4c
Signed-off-by: chao.an <anchao@xiaomi.com>
