### PR TITLE
wireless/wapi: add option to associate with bssid 

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -262,6 +262,7 @@ struct wpa_wconfig_s
   uint8_t phraselen;             /* Length of the passphrase */
   FAR const char *ifname;        /* E.g., "wlan0" */
   FAR const char *ssid;          /* E.g., "myApSSID" */
+  FAR const char *bssid;         /* Options to associate with bssid */
   FAR const char *passphrase;    /* E.g., "mySSIDpassphrase" */
 };
 

--- a/netutils/netinit/netinit_associate.c
+++ b/netutils/netinit/netinit_associate.c
@@ -76,6 +76,7 @@ int netinit_associate(FAR const char *ifname)
       conf.passphrase  = CONFIG_NETINIT_WAPI_PASSPHRASE;
       conf.ssidlen     = strlen(conf.ssid);
       conf.phraselen   = strlen(conf.passphrase);
+      conf.bssid       = NULL;
     }
 
   if (conf.ssidlen > 0)

--- a/wireless/wapi/src/driver_wext.c
+++ b/wireless/wapi/src/driver_wext.c
@@ -292,8 +292,17 @@ int wpa_driver_wext_associate(FAR struct wpa_wconfig_s *wconfig)
         }
     }
 
-  ret = wapi_set_essid(sockfd, wconfig->ifname, wconfig->ssid,
-                       WAPI_ESSID_ON);
+  if (wconfig->bssid)
+    {
+      ret = wapi_set_ap(sockfd, wconfig->ifname,
+                        (FAR const struct ether_addr *)wconfig->bssid);
+    }
+  else
+    {
+      ret = wapi_set_essid(sockfd, wconfig->ifname, wconfig->ssid,
+                           WAPI_ESSID_ON);
+    }
+
   if (ret < 0)
     {
       nerr("ERROR: Fail set ssid: %d\n", ret);

--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -376,6 +376,14 @@ FAR void *wapi_load_config(FAR const char *ifname,
 
   conf->ssid = (FAR const char *)obj->valuestring;
 
+  obj = cJSON_GetObjectItem(ifobj, "bssid");
+  if (!obj || !obj->valuestring)
+    {
+      goto errout;
+    }
+
+  conf->bssid = (FAR const char *)obj->valuestring;
+
   obj = cJSON_GetObjectItem(ifobj, "psk");
   if (!obj || !obj->valuestring)
     {
@@ -460,6 +468,8 @@ int wapi_save_config(FAR const char *ifname,
                              (FAR void *)(intptr_t)conf->alg, true);
   update |= wapi_json_update(ifobj, "ssid",
                              (FAR void *)conf->ssid, false);
+  update |= wapi_json_update(ifobj, "bssid",
+                             (FAR void *)conf->bssid, false);
   update |= wapi_json_update(ifobj, "psk",
                              (FAR void *)conf->passphrase, false);
 

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -798,6 +798,7 @@ static int wapi_save_config_cmd(int sock, int argc, FAR char **argv)
   char essid[WAPI_ESSID_MAX_SIZE + 1];
   enum wapi_essid_flag_e essid_flag;
   struct wpa_wconfig_s conf;
+  struct ether_addr ap;
   uint8_t if_flags;
   uint32_t value;
   size_t psk_len;
@@ -833,6 +834,14 @@ static int wapi_save_config_cmd(int sock, int argc, FAR char **argv)
 
   conf.ssid = essid;
   conf.ssidlen = strnlen(essid, sizeof(essid));
+
+  ret = wapi_get_ap(sock, argv[0], &ap);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  conf.bssid = (FAR const char *)ap.ether_addr_octet;
 
   memset(psk, 0, sizeof(psk));
   ret = wpa_driver_wext_get_key_ext(sock,


### PR DESCRIPTION

## Summary

wireless/wapi: add option to associate with bssid 

Change-Id: I68ef42edfc50ef5baf0f02a570d0e7f79669659f
Signed-off-by: chao.an <anchao@xiaomi.com>

