### PR TITLE
make/clean: clean the OBJ directly if declare in subdirectory

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -238,6 +238,7 @@ depend:: .depend
 
 clean::
 	$(call CLEAN)
+	$(call DELFILE, $(wildcard $(foreach obj, $(OBJS), $(addsuffix /$(obj), $(subst :, ,$(VPATH))))))
 
 distclean:: clean
 	$(call DELFILE, Make.dep)


### PR DESCRIPTION
## Summary
make/clean: clean the OBJ directly if declare in subdirectory

Change-Id: Iabfb3c5ed4d37a5534e3bab63a6b3cffb4816230
Signed-off-by: chao.an <anchao@xiaomi.com>