### PR TITLE
apps: use CONFIGURED_APPS to iterate clean targets

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -50,14 +50,10 @@ endif
 # Application Directories
 
 # BUILDIRS is the list of top-level directories containing Make.defs files
-# CLEANDIRS is the list of all top-level directories containing Makefiles.
-#   It is used only for cleaning.
-
 BUILDIRS   := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Make.defs))
 BUILDIRS   := $(filter-out $(APPDIR)$(DELIM)import$(DELIM),$(BUILDIRS))
 CONFIGDIRS := $(filter-out $(APPDIR)$(DELIM)builtin$(DELIM),$(BUILDIRS))
 CONFIGDIRS := $(filter-out $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Kconfig)),$(CONFIGDIRS))
-CLEANDIRS  := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
 
 # CONFIGURED_APPS is the application directories that should be built in
 #   the current configuration.

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),install)
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),context)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),register)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),depend)))
-$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
-$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+$(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),clean)))
+$(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
 $(MKDEP): $(TOPDIR)/tools/mkdeps.c
 	$(HOSTCC) $(HOSTINCLUDES) $(HOSTCFLAGS) $< -o $@
@@ -190,7 +190,7 @@ clean_context:
 	$(Q) $(MAKE) -C platform clean_context
 	$(Q) $(MAKE) -C builtin clean_context
 
-clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
+clean: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_clean)
 	$(call DELFILE, $(SYMTABSRC))
 	$(call DELFILE, $(SYMTABOBJ))
 	$(call DELFILE, $(BIN))
@@ -198,7 +198,7 @@ clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(call DELDIR, $(BINDIR))
 	$(call CLEAN)
 
-distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
+distclean: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_distclean)
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) ( if exist  external ( \
 		echo ********************************************************" \


### PR DESCRIPTION

## Summary

Before this change CLEANDIRS was used, which is built from
detecting dummy .depend/.kconfig files, which is problematic
since when there's an intermediate subdirectory which does not
have it, subdirectories below this level will not be found
(even if they do have these files).

Since we already know exactly which subdirectories we need
to clean based on configured apps, we directly clean over these.

I started looking into this since I found that the `btsak` application
was not being cleaned due to this reason, which sits at `apps/wireless/bluetooth/btsak`
and `bluetooth` was not being cleaned since there were none of this dummy files there.

I would like to hear your thoughts on why this might be wrong
or not. I feel there's quite a bit of "magic files" placed around and 
these are used to drive many targets and this is becoming very confusing
to maintain. My reasoning is that we should go into the subdirectories
we know need cleaning from the top-level Makefile directly and then let
each application Makefile drive the cleaning using its `clean` target.

I have not changed yet the similar logic in `Directory.mk` for `CLEANSUBDIRS`
which is still driven by `.depend` and `.kconfig` files as it is not clear to me
how works. I'm guessing that after this change, it is not necessary, but I'm unsure.

## Impact

Application build system

## Testing

Building and cleaning and looking for leftover `.o`s