### PR TITLE
nxplayer&nxrecoder: add channel map support

### DIFF
--- a/include/system/nxplayer.h
+++ b/include/system/nxplayer.h
@@ -222,6 +222,7 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  *   nchannels  channel num
  *   bpsampe    bit width
  *   samprate   sample rate
+ *   chmap      channel map
  *
  * Returned Value:
  *   OK if file found, device found, and playback started.
@@ -230,7 +231,7 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
 
 int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
                      FAR const char *filename, uint8_t nchannels,
-                     uint8_t bpsamp, uint32_t samprate);
+                     uint8_t bpsamp, uint32_t samprate, uint8_t chmap);
 
 /****************************************************************************
  * Name: nxplayer_stop

--- a/include/system/nxrecorder.h
+++ b/include/system/nxrecorder.h
@@ -163,7 +163,7 @@ int nxrecorder_setdevice(FAR struct nxrecorder_s *precorder,
  *   nchannels - channels num
  *   bpsampe   - bit width
  *   samprate  - sample rate
- *
+ *   chmap      channel map
  *
  * Returned Value:
  *   OK if file found, device found, and recordback started.
@@ -172,7 +172,7 @@ int nxrecorder_setdevice(FAR struct nxrecorder_s *precorder,
 
 int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
                          FAR const char *filename, uint8_t nchannels,
-                         uint8_t bpsamp, uint32_t samprate);
+                         uint8_t bpsamp, uint32_t samprate, uint8_t chmap);
 
 /****************************************************************************
  * Name: nxrecorder_stop

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -1768,7 +1768,8 @@ int nxplayer_stop(FAR struct nxplayer_s *pplayer)
  *              determined by nxplayer_playfile()
  *   nchannels  channels num (raw data playback needed)
  *   bpsamp     bits pre sample (raw data playback needed)
- *   samplrate  samplre rate (raw data playback needed)
+ *   samprate  samplre rate (raw data playback needed)
+ *   chmap      channel map (raw data playback needed)
  *
  * Returns:
  *   OK         File is being played
@@ -1783,7 +1784,8 @@ int nxplayer_stop(FAR struct nxplayer_s *pplayer)
 static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
                                  FAR const char *pfilename, int filefmt,
                                  int subfmt, uint8_t nchannels,
-                                 uint8_t bpsamp, uint32_t samprate)
+                                 uint8_t bpsamp, uint32_t samprate,
+                                 uint8_t chmap)
 {
   struct mq_attr      attr;
   struct sched_param  sparam;
@@ -1917,6 +1919,7 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
       cap_desc.caps.ac_len            = sizeof(struct audio_caps_s);
       cap_desc.caps.ac_type           = AUDIO_TYPE_OUTPUT;
       cap_desc.caps.ac_channels       = nchannels;
+      cap_desc.caps.ac_chmap          = chmap;
       cap_desc.caps.ac_controls.hw[0] = samprate;
       cap_desc.caps.ac_controls.b[3]  = samprate >> 16;
       cap_desc.caps.ac_controls.b[2]  = bpsamp;
@@ -2026,7 +2029,8 @@ err_out_nodev:
 int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
                       FAR const char *pfilename, int filefmt, int subfmt)
 {
-  return nxplayer_playinternal(pplayer, pfilename, filefmt, subfmt, 0, 0, 0);
+  return nxplayer_playinternal(pplayer, pfilename, filefmt,
+                               subfmt, 0, 0, 0, 0);
 }
 
 /****************************************************************************
@@ -2043,6 +2047,7 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  *   nchannels  channel num
  *   bpsampe    bit width
  *   samprate   sample rate
+ *   chmap      channel map
  *
  * Returns:
  *   OK         File is being played
@@ -2055,7 +2060,7 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
 
 int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
                      FAR const char *pfilename, uint8_t nchannels,
-                     uint8_t bpsamp, uint32_t samprate)
+                     uint8_t bpsamp, uint32_t samprate, uint8_t chmap)
 {
   if (nchannels == 0)
     {
@@ -2073,7 +2078,7 @@ int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
     }
 
   return nxplayer_playinternal(pplayer, pfilename, AUDIO_FMT_PCM, 0,
-                               nchannels, bpsamp, samprate);
+                               nchannels, bpsamp, samprate, chmap);
 }
 
 /****************************************************************************

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -329,13 +329,16 @@ static int nxplayer_cmd_playraw(FAR struct nxplayer_s *pplayer, char *parg)
   int channels = 0;
   int bpsamp = 0;
   int samprate = 0;
+  int chmap = 0;
   char filename[128];
 
-  sscanf(parg, "%s %d %d %d", filename, &channels, &bpsamp, &samprate);
+  sscanf(parg, "%s %d %d %d", filename, &channels, &bpsamp,
+                              &samprate, &chmap);
 
   /* Try to play the file specified */
 
-  ret = nxplayer_playraw(pplayer, filename, channels, bpsamp, samprate);
+  ret = nxplayer_playraw(pplayer, filename, channels,
+                         bpsamp, samprate, chmap);
 
   /* nxplayer_playfile returned values:
    *

--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -749,6 +749,7 @@ int nxrecorder_stop(FAR struct nxrecorder_s *precorder)
  *   nchannels  channel num
  *   bpsampe    bit width
  *   samprate   sample rate
+ *   chmap      channel map
  *
  * Returns:
  *   OK         File is being recorded
@@ -761,7 +762,7 @@ int nxrecorder_stop(FAR struct nxrecorder_s *precorder)
 
 int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
                          FAR const char *pfilename, uint8_t nchannels,
-                         uint8_t bpsamp, uint32_t samprate)
+                         uint8_t bpsamp, uint32_t samprate, uint8_t chmap)
 {
   struct mq_attr           attr;
   struct sched_param       sparam;
@@ -826,6 +827,7 @@ int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
   cap_desc.caps.ac_len = sizeof(struct audio_caps_s);
   cap_desc.caps.ac_type = AUDIO_TYPE_INPUT;
   cap_desc.caps.ac_channels = nchannels ? nchannels : 2;
+  cap_desc.caps.ac_chmap    = chmap;
   cap_desc.caps.ac_controls.hw[0] = samprate ? samprate : 48000;
   cap_desc.caps.ac_controls.b[3] = samprate >> 16;
   cap_desc.caps.ac_controls.b[2]  = bpsamp ? bpsamp : 16;

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -178,9 +178,11 @@ static int nxrecorder_cmd_recordraw(FAR struct nxrecorder_s *precorder,
   int channels = 0;
   int bpsamp = 0;
   int samprate = 0;
+  int chmap = 0;
   char filename[128];
 
-  sscanf(parg, "%s %d %d %d", filename, &channels, &bpsamp, &samprate);
+  sscanf(parg, "%s %d %d %d %d", filename, &channels, &bpsamp,
+                                 &samprate, &chmap);
 
   /* Try to record the file specified */
 
@@ -188,7 +190,8 @@ static int nxrecorder_cmd_recordraw(FAR struct nxrecorder_s *precorder,
                              filename,
                              channels,
                              bpsamp,
-                             samprate);
+                             samprate,
+                             chmap);
 
   /* nxrecorder_recordfile returned values:
    *


### PR DESCRIPTION
## Summary

nxplayer&nxrecoder: add channel map support

## Impact

add channel map as the last cmd line param,
this is base on :
https://github.com/apache/incubator-nuttx/pull/1892

## Testing

