### PR TITLE
fsutils/ipcfg fixes

### DIFF
--- a/fsutils/ipcfg/ipcfg.c
+++ b/fsutils/ipcfg/ipcfg.c
@@ -201,8 +201,6 @@ static int ipcfg_open(FAR const char *netdev, int oflags, mode_t mode)
   /* Now open the file */
 
   fd  = open(path, oflags, mode);
-  ret = OK;
-
   if (fd < 0)
     {
       ret = -errno;
@@ -220,11 +218,14 @@ static int ipcfg_open(FAR const char *netdev, int oflags, mode_t mode)
   if (ret < 0)
     {
       ret = -errno;
+      close(fd);
       fprintf(stderr, "ERROR: Failed to seek to $ld: %d\n",
               (long)CONFIG_IPCFG_OFFSET, ret);
-      close(fd);
+      goto errout_with_path;
     }
+
 #endif
+  ret = fd;
 
 errout_with_path:
   free(path);

--- a/fsutils/ipcfg/ipcfg.c
+++ b/fsutils/ipcfg/ipcfg.c
@@ -551,7 +551,7 @@ int ipcfg_write(FAR const char *netdev, FAR const struct ipcfg_s *ipcfg)
 
   /* Format and write the file */
 
-  if ((unsigned)ipcfg->proto == MAX_BOOTPROTO)
+  if ((unsigned)ipcfg->proto > MAX_BOOTPROTO)
     {
       fprintf(stderr, "ERROR: Unrecognized BOOTPROTO value: %d\n",
               ipcfg->proto);

--- a/include/fsutils/ipcfg.h
+++ b/include/fsutils/ipcfg.h
@@ -92,6 +92,13 @@ struct ipcfg_s
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
 
 /****************************************************************************
  * Name: ipcfg_read
@@ -131,6 +138,10 @@ int ipcfg_read(FAR const char *netdev, FAR struct ipcfg_s *ipcfg);
 
 #ifdef CONFIG_IPCFG_WRITABLE
 int ipcfg_write(FAR const char *netdev, FAR const struct ipcfg_s *ipcfg);
+#endif
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __APPS_INCLUDE_FSUTILS_IPCFG_H */


### PR DESCRIPTION
## Summary

1. fsutils:ipcfg Add extern 'C' under cpp
2. fsutils:ipcfg Fix range checking for PRTOCOL in bin mode
3. fsutils:ipcfg Fix fd propagation as return value in bin mode 

## Impact
Fixes use with C++
Fixes use with CONFIG_IPCFG_BINARY set

## Testing
px4_fmuv5x 
