### PR TITLE
Network Monitor: Runtime selection of DHCP/Static IP with fall back set by fsutil/ipcfg and a polled mode for HW lacking a PHY interrupt 

### DIFF
--- a/include/netutils/netinit.h
+++ b/include/netutils/netinit.h
@@ -74,7 +74,8 @@
 #  define CONFIG_NETINIT_MACADDR   0x00e0deadbeef
 #endif
 
-#if !defined(CONFIG_NETINIT_THREAD) || !defined(CONFIG_ARCH_PHY_INTERRUPT) || \
+#if !defined(CONFIG_NETINIT_THREAD) || \
+    !(defined(CONFIG_ARCH_PHY_INTERRUPT) || defined(CONFIG_ARCH_PHY_POLLED)) || \
     !defined(CONFIG_NETDEV_PHY_IOCTL) || !defined(CONFIG_NET_UDP)
 #  undef CONFIG_NETINIT_MONITOR
 #endif

--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -73,7 +73,7 @@ if NETINIT_THREAD
 config NETINIT_MONITOR
 	bool "Monitor link state"
 	default n
-	depends on ARCH_PHY_INTERRUPT && NETDEV_PHY_IOCTL && NET_UDP
+	depends on (ARCH_PHY_INTERRUPT || ARCH_PHY_POLLED) && NETDEV_PHY_IOCTL && NET_UDP
 	---help---
 		By default the net initialization thread will bring-up the network
 		then exit, freeing all of the resources that it required.  This is a
@@ -87,10 +87,26 @@ config NETINIT_MONITOR
 		required for network initialization are never released.
 
 if NETINIT_MONITOR
+config NETINIT_ESTABLISH_POLL_RATE
+	int "The poll rate in seconds, to check for link establishment."
+	default 2
+	depends on !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED
+	---help---
+		The network monitor will check the PHY link state every
+		NETINIT_ESTABLISH_POLL_RATE seconds for link establishment.
+
+config NETINIT_LOSS_POLL_RATE
+	int "The poll rate in seconds, to check for link loss."
+	default 3
+	depends on !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED
+	---help---
+		The network monitor will check the PHY link state every
+		NETINIT_LOSS_POLL_RATE seconds for link loss.
 
 config NETINIT_SIGNO
 	int "Notification signal number"
 	default 18
+	depends on ARCH_PHY_INTERRUPT && !ARCH_PHY_POLLED
 	---help---
 		The network monitor logic will receive signals when there is any
 		change in the link status.  This setting may be used to customize

--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -103,6 +103,18 @@ config NETINIT_LOSS_POLL_RATE
 		The network monitor will check the PHY link state every
 		NETINIT_LOSS_POLL_RATE seconds for link loss.
 
+config NETINIT_DHCP_FALLBACK
+	int "The number of failed DHCP attempts to fall back to using static settings"
+	default 5
+	depends on NETINIT_DHCPC && !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED && FSUTILS_IPCFG
+	---help---
+		When the network monitor is used with FSUTILS_IPCFG if, the
+		the BOOTPROTO_FALLBACK is the active protocol. NETINIT_DHCP_FALLBACK will
+		be used as the number of times, DHCP will be be attempted before
+		falling back to using the static settings. The time will be roughly
+		NETINIT_LOSS_POLL_RATE * NETINIT_DHCP_FALLBACK seconds.
+		Setting this value to 0, will disable this feature.
+
 config NETINIT_SIGNO
 	int "Notification signal number"
 	default 18

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -1,35 +1,21 @@
 /****************************************************************************
  * apps/netutils/netinit/netinit.c
  *
- *   Copyright (C) 2010-2012, 2014-2016, 2019-2020 Gregory Nutt. All rights
- *     reserved.
- *   AuthorS: Gregory Nutt <gnutt@nuttx.org>
- *            David Sidrane <david.sidrane@nscdg.com>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the Institute nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
  ****************************************************************************/
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Sister to https://github.com/apache/incubator-nuttx/pull/1924 - **merge this APP pr second**. 

**Please merge** https://github.com/apache/incubator-nuttx/pull/1924 and https://github.com/apache/incubator-nuttx-apps/pull/414 **first**.

 ### netinit:Network Monitor add a polled option
 
  Not all boards have in interrupt line from the phy to the Soc. This allows the phy to be polled for link status.
   This may not work on all MAC/PHY combination that have mutually exclusive link management and operating
   modes. The STM32F7 and LAN8742AI do not have such a limitation.

   To use this option the arch must supply CONFIG_ARCH_PHY_POLLED  and not CONFIG_ARCH_PHY_INTERRUPT.

 If the network is not connected the phy init may time out and netinit_net_bringup will return with out completing DHCP or initializing the ntp client.

This change uses the lack of the DHCP lease, to contiune the netinit_net_bringup, once the interface does come up. It also will renew the lease over time, and will re run the dhcp request after a network down/up transition.

###  netinit Net monitior support getting address from fsutils/ipcfg

Uses new fsutils/ipcfg to read the networks settings. 

 ###  netinit:Net monitior support fallback to static IP

   After CONFIG_NETINIT_FALLBACK dhcp attempts, fall back to  the static IP provided by the board via fsutils/ipcfg

## Impact

None All options have Kconfig knobs to turn them off by default

## Testing

FMUV5X with a test vector of all the new Kconfig options
