### PR TITLE
Incorporate IP configuration files into netinit.

### DIFF
--- a/fsutils/ipcfg/ipcfg_text.c
+++ b/fsutils/ipcfg/ipcfg_text.c
@@ -336,7 +336,7 @@ int ipcfg_read_text_ipv4(FAR const char *path, FAR const char *netdev,
   int index;
   int ret = -ENOENT;
 
-  DEBUGASSERT(stream != NULL && ipv4cfg != NULL);
+  DEBUGASSERT(path != NULL && netdev != NULL && ipv4cfg != NULL);
 
   /* Open the file for reading */
 
@@ -418,7 +418,7 @@ int ipcfg_read_text_ipv4(FAR const char *path, FAR const char *netdev,
                        variable, value);
                 }
 
-              /* Assume IPv4 settings are present if the IPv4BOOTPROTO
+              /* Assume IPv4 settings are present if the IPv4PROTO
                * setting is encountered.
                */
 
@@ -655,7 +655,7 @@ int ipcfg_write_text_ipv4(FAR const char *path, FAR const char *netdev,
   FAR FILE *stream;
   int ret;
 
-  DEBUGASSERT(stream != NULL && ipv4cfg != NULL);
+  DEBUGASSERT(path != NULL && netdev != NULL && ipv4cfg != NULL);
 
 #ifdef CONFIG_NET_IPv6
   /* Read any IPv6 data in the file */
@@ -742,7 +742,7 @@ int ipcfg_write_text_ipv6(FAR const char *path, FAR const char *netdev,
   FAR FILE *stream;
   int ret;
 
-  DEBUGASSERT(netdev != NULL && ipv6cfg != NULL);
+  DEBUGASSERT(path != NULL && netdev != NULL && ipv6cfg != NULL);
 
 #ifdef CONFIG_NET_IPv4
   /* Read any IPv4 data in the file */

--- a/include/fsutils/ipcfg.h
+++ b/include/fsutils/ipcfg.h
@@ -28,6 +28,20 @@
 #include <netinet/in.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Prototype enumerations are bit encoded */
+
+#define _IPCFG_STATIC   (1 << 0)  /* Bit 0: Have static addresses */
+#define _IPCFG_DHCP     (1 << 1)  /* Bit 1: Use DHCP (IPv4) */
+#define _IPCFG_AUTOCONF (1 << 1)  /* Bit 1: Use ICMPv4 auto-configuration */
+
+#define IPCFG_HAVE_STATIC(p)  (((p) & _IPCFG_STATIC) != 0)
+#define IPCFG_USE_DHCP(p)     (((p) & _IPCFG_DHCP) != 0)
+#define IPCFG_USE_AUTOCONF(p) (((p) & _IPCFG_AUTOCONF) != 0)
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -41,7 +55,7 @@
  *
  * IPv4 Settings:
  *
- * IPv4BOOTPROTO=protocol
+ * IPv4PROTO=protocol
  *   where protocol is one of the following:
  *
  *     none     - No protocol selected
@@ -52,7 +66,7 @@
  * All of the following addresses are in network order.  The special value
  * zero is used to indicate that the address is not available:
  *
- * IPv4ADDR=address
+ * IPv4IPADDR=address
  *    where address is the IPv4 address.  Used only with static or fallback
  *    protocols.
  *
@@ -68,14 +82,14 @@
  *   where address is a (optional) name server address.
  */
 
-/* Values for the IPv4BOOTPROTO setting */
+/* Values for the IPv4PROTO setting */
 
 enum ipv4cfg_bootproto_e
 {
-  IPv4PROTO_NONE     = 0, /* No protocol assigned */
-  IPv4PROTO_STATIC   = 1, /* Use static IP */
-  IPv4PROTO_DHCP     = 2, /* Use DHCP */
-  IPv4PROTO_FALLBACK = 3  /* Use DHCP with fall back static IP */
+  IPv4PROTO_NONE     = 0, /* 00: No protocol assigned */
+  IPv4PROTO_STATIC   = 1, /* 01: Use static IP */
+  IPv4PROTO_DHCP     = 2, /* 10: Use DHCP */
+  IPv4PROTO_FALLBACK = 3  /* 11: Use DHCP with fall back static IP */
 };
 
 struct ipv4cfg_s
@@ -84,13 +98,13 @@ struct ipv4cfg_s
 
   /* The following fields are required for static/fallback configurations */
 
-  in_addr_t ipaddr;             /* IPv4 address */
-  in_addr_t netmask;            /* Network mask */
-  in_addr_t router;             /* Default router */
+  in_addr_t ipaddr;               /* IPv4 address */
+  in_addr_t netmask;              /* Network mask */
+  in_addr_t router;               /* Default router */
 
   /* The following fields are optional for dhcp and fallback configurations */
 
-  in_addr_t dnsaddr;            /* Name server address */
+  in_addr_t dnsaddr;              /* Name server address */
 };
 
 /* IPv6 Settings:
@@ -106,7 +120,7 @@ struct ipv4cfg_s
  * All of the following addresses are in network order.  The special value
  * zero is used to indicate that the address is not available:
  *
- * IPv6ADDR=address
+ * IPv6IPADDR=address
  *    where address is the IPv6 address.  Used only with static or fallback
  *    protocols.
  *
@@ -123,10 +137,10 @@ struct ipv4cfg_s
 
 enum ipv6cfg_bootproto_e
 {
-  IPv6PROTO_NONE     = 0, /* No protocol assigned */
-  IPv6PROTO_STATIC   = 1, /* Use static IP */
-  IPv6PROTO_AUTOCONF = 2, /* Use ICMPv6 auto-configuration */
-  IPv6PROTO_FALLBACK = 3  /* Use auto-configuration with fall back static IP */
+  IPv6PROTO_NONE     = 0, /* 00: No protocol assigned */
+  IPv6PROTO_STATIC   = 1, /* 01: Use static IP */
+  IPv6PROTO_AUTOCONF = 2, /* 10: Use ICMPv6 auto-configuration */
+  IPv6PROTO_FALLBACK = 3  /* 11: Use auto-configuration with fall back static IP */
 };
 
 struct ipv6cfg_s
@@ -135,9 +149,9 @@ struct ipv6cfg_s
 
   /* The following fields are required for static/fallback configurations */
 
-  struct in6_addr ipaddr;       /* IPv6 address */
-  struct in6_addr netmask;      /* Network mask */
-  struct in6_addr router;       /* Default router */
+  struct in6_addr ipaddr;         /* IPv6 address */
+  struct in6_addr netmask;        /* Network mask */
+  struct in6_addr router;         /* Default router */
 };
 
 /****************************************************************************

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -1,34 +1,21 @@
 /****************************************************************************
  * apps/netutils/netinit/netinit.c
  *
- *   Copyright (C) 2010-2012, 2014-2016, 2019 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the Institute nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+
  ****************************************************************************/
 
 /****************************************************************************
@@ -63,7 +50,7 @@
 #include <nuttx/net/mii.h>
 
 #include "netutils/netlib.h"
-#if defined(CONFIG_NETINIT_DHCPC) || defined(CONFIG_NETINIT_DNS)
+#if defined(CONFIG_NETUTILS_DHCPC) || defined(CONFIG_NETINIT_DNS)
 #  include "netutils/dhcpc.h"
 #endif
 
@@ -77,6 +64,10 @@
 
 #ifdef CONFIG_NETUTILS_NTPCLIENT
 #  include "netutils/ntpclient.h"
+#endif
+
+#if defined(CONFIG_FSUTILS_IPCFG)
+#  include "fsutils/ipcfg.h"
 #endif
 
 #include "netutils/netinit.h"
@@ -237,6 +228,10 @@
 static sem_t g_notify_sem;
 #endif
 
+#ifdef CONFIG_NETUTILS_DHCPC
+bool g_use_dhcpc;
+#endif
+
 #if defined(CONFIG_NET_IPv6) && !defined(CONFIG_NET_ICMPv6_AUTOCONF) && \
    !defined(CONFIG_NET_6LOWPAN)
 /* Host IPv6 address */
@@ -295,7 +290,8 @@ static const uint16_t g_ipv6_netmask[8] =
  *
  ****************************************************************************/
 
-#if defined(NETINIT_HAVE_NETDEV) && defined(CONFIG_NETINIT_NOMAC) && defined(HAVE_MAC)
+#if defined(NETINIT_HAVE_NETDEV) && defined(CONFIG_NETINIT_NOMAC) && \
+    defined(HAVE_MAC)
 static void netinit_set_macaddr(void)
 {
 #if defined(CONFIG_NET_ETHERNET)
@@ -344,6 +340,221 @@ static void netinit_set_macaddr(void)
 #endif
 
 /****************************************************************************
+ * Name: netinit_set_ipv4addrs
+ *
+ * Description:
+ *   Setup IPv4 addresses.
+ *
+ ****************************************************************************/
+
+#if defined(NETINIT_HAVE_NETDEV) && !defined(CONFIG_NET_6LOWPAN) && ! \
+    defined(CONFIG_NET_IEEE802154) && defined(CONFIG_NET_IPv4)
+static inline void netinit_set_ipv4addrs(void)
+{
+  struct in_addr addr;
+#ifdef CONFIG_FSUTILS_IPCFG
+  struct ipv4cfg_s ipv4cfg;
+  int ret;
+
+  /* Attempt to obtain IPv4 address configuration from the IP configuration
+   * file.
+   */
+
+  ret = ipcfg_read(NET_DEVNAME, (FAR struct ipcfg_s *)&ipv4cfg, AF_INET);
+#ifdef CONFIG_NETUTILS_DHCPC
+  if (ret >= 0 && ipv4cfg.proto != IPv4PROTO_NONE)
+#else
+  if (ret >= 0 && IPCFG_HAVE_STATIC(ipv4cfg.proto))
+#endif
+    {
+      /* Check if we are using DHCPC */
+
+#ifdef CONFIG_NETUTILS_DHCPC
+      if (IPCFG_USE_DHCPC(ipv4cfg.proto))
+        {
+          g_use_dhcpc = true;
+          addr.s_addr = 0;
+        }
+      else
+#endif
+        {
+          /* We are not using DHCPC.  We need an IP address */
+
+#ifdef CONFIG_NETINIT_IPADDR
+          /* Check if we have a static IP address in the configuration file */
+
+          if (IPCFG_HAVE_STATIC(ipv4cfg.proto))
+            {
+              addr.s_addr = ipv4cfg.ipaddr;
+            }
+          else
+            {
+              /* This is not a good option, but in this case what else can
+               * we do?
+               */
+
+              addr.s_addr = HTONL(CONFIG_NETINIT_IPADDR);
+            }
+#else
+          /* Use whatever was provided in the file (might be zero) */
+
+          addr.s_addr = ipv4cfg.ipaddr;
+#endif
+        }
+
+      netlib_set_ipv4addr(NET_DEVNAME, &addr);
+
+      /* Set up the remaining addresses */
+
+      if (IPCFG_HAVE_STATIC(ipv4cfg.proto))
+        {
+          /* Set up the default router address */
+
+          addr.s_addr = ipv4cfg.router;
+          netlib_set_dripv4addr(NET_DEVNAME, &addr);
+
+          /* Setup the subnet mask */
+
+          addr.s_addr = ipv4cfg.netmask;
+          netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+        }
+
+#ifdef CONFIG_NETUTILS_DHCPC
+      /* No static addresses?  That is fine if we are have addresses
+       * provided by the configuration, or if we are using DHCP.
+       */
+
+      else if (g_use_dhcpc)
+        {
+          /* Set up the default router address and sub-net mask */
+
+          addr.s_addr = 0;
+          netlib_set_dripv4addr(NET_DEVNAME, &addr);
+          netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+        }
+#endif
+      else
+        {
+          /* Otherwise, set up the configured default router address */
+
+          addr.s_addr = HTONL(CONFIG_NETINIT_DRIPADDR);
+          netlib_set_dripv4addr(NET_DEVNAME, &addr);
+
+          /* Setup the subnet mask */
+
+          addr.s_addr = HTONL(CONFIG_NETINIT_NETMASK);
+          netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+        }
+
+#ifdef CONFIG_NETINIT_DNS
+      /* Set up the DNS address.  Was one provided in the configuration? */
+
+      if (ipv4cfg.dnsaddr == 0)
+        {
+          /* No, use the configured default */
+
+          addr.s_addr = HTONL(CONFIG_NETINIT_DNSIPADDR);
+        }
+      else
+        {
+          addr.s_addr = ipv4cfg.dnsaddr;
+        }
+
+      netlib_set_ipv4dnsaddr(&addr);
+#endif
+    }
+  else
+#endif
+    {
+      /* Set up our host address */
+
+#ifdef CONFIG_NETINIT_DHCPC
+      g_use_dhcpc = true;
+      addr.s_addr = 0;
+#else
+      addr.s_addr = HTONL(CONFIG_NETINIT_IPADDR);
+#endif
+      netlib_set_ipv4addr(NET_DEVNAME, &addr);
+
+      /* Set up the default router address */
+
+      addr.s_addr = HTONL(CONFIG_NETINIT_DRIPADDR);
+      netlib_set_dripv4addr(NET_DEVNAME, &addr);
+
+      /* Setup the subnet mask */
+
+      addr.s_addr = HTONL(CONFIG_NETINIT_NETMASK);
+      netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+
+#ifdef CONFIG_NETINIT_DNS
+      addr.s_addr = HTONL(CONFIG_NETINIT_DNSIPADDR);
+      netlib_set_ipv4dnsaddr(&addr);
+#endif
+    }
+}
+#endif
+
+/****************************************************************************
+ * Name: netinit_set_ipv6addrs
+ *
+ * Description:
+ *   Setup IPv6 addresses.
+ *
+ ****************************************************************************/
+
+#if defined(NETINIT_HAVE_NETDEV) && !defined(CONFIG_NET_6LOWPAN) && ! \
+    defined(CONFIG_NET_IEEE802154) && defined(CONFIG_NET_IPv6)
+static inline void netinit_set_ipv6addrs(void)
+{
+#ifndef CONFIG_NET_ICMPv6_AUTOCONF
+#ifdef CONFIG_FSUTILS_IPCFG
+  struct ipv6cfg_s ipv6cfg;
+  int ret;
+#endif
+
+#ifdef CONFIG_FSUTILS_IPCFG
+  /* Attempt to obtain IPv6 address configuration from the IP configuration
+   * file.
+   */
+
+  ret = ipcfg_read(NET_DEVNAME, (FAR struct ipcfg_s *)&ipv6cfg, AF_INET6);
+  if (ret >= 0 && IPCFG_HAVE_STATIC(ipv6cfg.proto))
+    {
+      /* Set up our fixed host address */
+
+      netlib_set_ipv6addr(NET_DEVNAME, &ipv6cfg.ipaddr);
+
+      /* Set up the default router address */
+
+      netlib_set_dripv6addr(NET_DEVNAME, &ipv6cfg.router);
+
+      /* Setup the subnet mask */
+
+      netlib_set_ipv6netmask(NET_DEVNAME, &ipv6cfg.netmask);
+    }
+  else
+#endif
+    {
+      /* Set up our fixed host address */
+
+      netlib_set_ipv6addr(NET_DEVNAME,
+                          (FAR const struct in6_addr *)g_ipv6_hostaddr);
+
+      /* Set up the default router address */
+
+      netlib_set_dripv6addr(NET_DEVNAME,
+                            (FAR const struct in6_addr *)g_ipv6_draddr);
+
+      /* Setup the subnet mask */
+
+      netlib_set_ipv6netmask(NET_DEVNAME,
+                            (FAR const struct in6_addr *)g_ipv6_netmask);
+    }
+#endif /* CONFIG_NET_ICMPv6_AUTOCONF */
+}
+#endif
+
+/****************************************************************************
  * Name: netinit_set_ipaddrs
  *
  * Description:
@@ -359,51 +570,11 @@ static void netinit_set_macaddr(void)
 static void netinit_set_ipaddrs(void)
 {
 #ifdef CONFIG_NET_IPv4
-  struct in_addr addr;
-
-  /* Set up our host address */
-
-#ifndef CONFIG_NETINIT_DHCPC
-  addr.s_addr = HTONL(CONFIG_NETINIT_IPADDR);
-#else
-  addr.s_addr = 0;
-#endif
-  netlib_set_ipv4addr(NET_DEVNAME, &addr);
-
-  /* Set up the default router address */
-
-  addr.s_addr = HTONL(CONFIG_NETINIT_DRIPADDR);
-  netlib_set_dripv4addr(NET_DEVNAME, &addr);
-
-  /* Setup the subnet mask */
-
-  addr.s_addr = HTONL(CONFIG_NETINIT_NETMASK);
-  netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+  netinit_set_ipv4addrs();
 #endif
 
 #ifdef CONFIG_NET_IPv6
-#ifndef CONFIG_NET_ICMPv6_AUTOCONF
-  /* Set up our fixed host address */
-
-  netlib_set_ipv6addr(NET_DEVNAME,
-                      (FAR const struct in6_addr *)g_ipv6_hostaddr);
-
-  /* Set up the default router address */
-
-  netlib_set_dripv6addr(NET_DEVNAME,
-                        (FAR const struct in6_addr *)g_ipv6_draddr);
-
-  /* Setup the subnet mask */
-
-  netlib_set_ipv6netmask(NET_DEVNAME,
-                        (FAR const struct in6_addr *)g_ipv6_netmask);
-
-#endif /* CONFIG_NET_ICMPv6_AUTOCONF */
-#endif /* CONFIG_NET_IPv6 */
-
-#ifdef CONFIG_NETINIT_DNS
-  addr.s_addr = HTONL(CONFIG_NETINIT_DNSIPADDR);
-  netlib_set_ipv4dnsaddr(&addr);
+  netinit_set_ipv6addrs();
 #endif
 }
 #else
@@ -421,7 +592,7 @@ static void netinit_set_ipaddrs(void)
 #if defined(NETINIT_HAVE_NETDEV) && !defined(CONFIG_NETINIT_NETLOCAL)
 static void netinit_net_bringup(void)
 {
-#ifdef CONFIG_NETINIT_DHCPC
+#ifdef CONFIG_NETUTILS_DHCPC
   uint8_t mac[IFHWADDRLEN];
   struct dhcpc_state ds;
   FAR void *handle;
@@ -449,45 +620,48 @@ static void netinit_net_bringup(void)
   netlib_icmpv6_autoconfiguration(NET_DEVNAME);
 #endif
 
-#ifdef CONFIG_NETINIT_DHCPC
-  /* Get the MAC address of the NIC */
-
-  netlib_getmacaddr(NET_DEVNAME, mac);
-
-  /* Set up the DHCPC modules */
-
-  handle = dhcpc_open(NET_DEVNAME, &mac, IFHWADDRLEN);
-  if (handle == NULL)
+#ifdef CONFIG_NETUTILS_DHCPC
+  if (g_use_dhcpc)
     {
-      return;
+      /* Get the MAC address of the NIC */
+
+      netlib_getmacaddr(NET_DEVNAME, mac);
+
+      /* Set up the DHCPC modules */
+
+      handle = dhcpc_open(NET_DEVNAME, &mac, IFHWADDRLEN);
+      if (handle == NULL)
+        {
+          return;
+        }
+
+      /* Get an IP address.  Note that there is no logic for renewing the
+       * IP address in this example. The address should be renewed in
+       * (ds.lease_time / 2) seconds.
+       */
+
+      if (dhcpc_request(handle, &ds) == OK)
+        {
+          netlib_set_ipv4addr(NET_DEVNAME, &ds.ipaddr);
+
+          if (ds.netmask.s_addr != 0)
+            {
+              netlib_set_ipv4netmask(NET_DEVNAME, &ds.netmask);
+            }
+
+          if (ds.default_router.s_addr != 0)
+            {
+              netlib_set_dripv4addr(NET_DEVNAME, &ds.default_router);
+            }
+
+          if (ds.dnsaddr.s_addr != 0)
+            {
+              netlib_set_ipv4dnsaddr(&ds.dnsaddr);
+            }
+        }
+
+      dhcpc_close(handle);
     }
-
-  /* Get an IP address.  Note that there is no logic for renewing the
-   * IP address in this example. The address should be renewed in
-   * (ds.lease_time / 2) seconds.
-   */
-
-  if (dhcpc_request(handle, &ds) == OK)
-    {
-      netlib_set_ipv4addr(NET_DEVNAME, &ds.ipaddr);
-
-      if (ds.netmask.s_addr != 0)
-        {
-          netlib_set_ipv4netmask(NET_DEVNAME, &ds.netmask);
-        }
-
-      if (ds.default_router.s_addr != 0)
-        {
-          netlib_set_dripv4addr(NET_DEVNAME, &ds.default_router);
-        }
-
-      if (ds.dnsaddr.s_addr != 0)
-        {
-          netlib_set_ipv4dnsaddr(&ds.dnsaddr);
-        }
-    }
-
-  dhcpc_close(handle);
 #endif
 
 #ifdef CONFIG_NETUTILS_NTPCLIENT


### PR DESCRIPTION
## Summary

Uses logic from apps/fsutils/ipcfg to obtain the IP address configuration from a file, if available.  This only effects the behavior of netinit if CONFIG_FSUTILS_IPCFG is selected and if an IP configuration file is available on a file system. Otherwise, it reverts to the preceding behavior.

Also adds definitions to apps/include/fsutils/ipcfg.h to formalize a bit encoding of the prototype which was already in use, but not documented.

This PR also corrects a few problems with fsutils/ipcfg:

- Corrects some bad assertions (duplicated in PR #420, we can close that PR if this one is merged first.
- Corrects some inconsitent variable naming between apps/includes/fsutils/ipcfg.c and apps/fsutils/ipcfg/ipcfg_text.c

## Impact

Obviously, the apps/netutils/netinit logic is affected.  The use of the ipcfg IP configuration file is conditional so, if all was done right, there should be no impact.

## Testing

Everything tests out.  Due to complexities of different test setups, only a few configurations could be verified:

**Test strategy**

- Create an ASCII IP configuration file on an SD card using an editor.  The name of the IP configuration file must be ipcfg-eth0.
- Use stm32f4discovery:netnsh configuration.  This configuration already supports IPv4 networking, the netinit thread, and SD card.  It has this default IP configuration:

    CONFIG_NETINIT_IPADDR=0x0a000002
    CONFIG_NETINIT_DRIPADDR=0x0a000001
    CONFIG_NETINIT_NETMASK=0xffffff00
    
    CONFIG_NETINIT_IPv6ADDR_1=0xfc00
    CONFIG_NETINIT_IPv6ADDR_2=0x0000
    CONFIG_NETINIT_IPv6ADDR_3=0x0000
    CONFIG_NETINIT_IPv6ADDR_4=0x0000
    CONFIG_NETINIT_IPv6ADDR_5=0x0000
    CONFIG_NETINIT_IPv6ADDR_6=0x0000
    CONFIG_NETINIT_IPv6ADDR_7=0x0000
    CONFIG_NETINIT_IPv6ADDR_8=0x0002
    CONFIG_NETINIT_DRIPv6ADDR_1=0xfc00
    CONFIG_NETINIT_DRIPv6ADDR_2=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_3=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_4=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_5=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_6=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_7=0x0000
    CONFIG_NETINIT_DRIPv6ADDR_8=0x0001
    CONFIG_NETINIT_IPv6NETMASK_1=0xffff
    CONFIG_NETINIT_IPv6NETMASK_2=0xffff
    CONFIG_NETINIT_IPv6NETMASK_3=0xffff
    CONFIG_NETINIT_IPv6NETMASK_4=0xffff
    CONFIG_NETINIT_IPv6NETMASK_5=0xffff
    CONFIG_NETINIT_IPv6NETMASK_6=0xffff
    CONFIG_NETINIT_IPv6NETMASK_7=0xffff
    CONFIG_NETINIT_IPv6NETMASK_8=0x0000

- Enable IPv6 and ICMPv6
- Enable IPCFG with Text file support

    CONFIG_IPCFG_WRITABLE=y
    \# CONFIG_IPCFG_BINARY is not set
    CONFIG_IPCFG_PATH="/ipcfg"

- Build and execute with SD card in place
- Mount the SD card prior to running NSH and netinit (requires a small code change to the board bring-up logic).
- Use the NSH ifconfig command to see if the network is properly configured.

```
diff --git a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
index fedd8ecec0..80cd76fa94 100644
--- a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
@@ -526,5 +526,12 @@ int stm32_bringup(void)
     }
 #endif /* CONFIG_LPWAN_SX127X */

+  ret = mount("/dev/mmcsd0", CONFIG_IPCFG_PATH, "vfat", 0, NULL);
+  if (ret < 0)
+    { 
+      int errcode = errno; 
+      _err("ERROR: Failed to mount " CONFIG_IPCFG_PATH "\n: %d", errcode);
+    } 
+
   return ret;
 }
```

Testing only with a text file is not limitation since the unit under test is netinit, not ipcfg.  Various text files can be created with an editor and many possible IP configurations can be verified.  For example,

    IPv4PROTO=static
    IPv4IPADDR=10.0.0.42
    IPv4NETMASK=255.255.0.0
    IPv4ROUTER=10.0.0.77
    IPv4DNS=10.0.0.32
    IPv6PROTO=static
    IPv6IPADDR=fc00::42
    IPv6NETMASK=ffff:ffff::
    IPv6ROUTER=fc00::77

**Test Result**

_Without_ SD card inserted, we get the configured default settings:

    eth0    Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at UP
            inet addr:10.0.0.2 DRaddr:10.0.0.1 Mask:255.255.255.0
            inet6 addr: fc00::2/112
            inet6 DRaddr: fc00::1/112

_With_ SD card inserted, we get the settings from the ipcfg-eth0 file:

    eth0    Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at UP
            inet addr:10.0.0.42 DRaddr:10.0.0.77 Mask:255.255.0.0
            inet6 addr: fc00::42/32
            inet6 DRaddr: fc00::77/32