### PR TITLE
Add task trace support

### DIFF
--- a/system/trace/Kconfig
+++ b/system/trace/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_TRACE
+	tristate "Trace command"
+	default n
+	depends on DRIVER_NOTECTL
+	---help---
+		Enable support for the trace command.
+
+if SYSTEM_TRACE
+
+config SYSTEM_TRACE_PROGNAME
+	string "Trace program name"
+	default "trace"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config SYSTEM_TRACE_PRIORITY
+	int "Trace task priority"
+	default 100
+
+config SYSTEM_TRACE_STACKSIZE
+	int "Trace stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/system/trace/Make.defs
+++ b/system/trace/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/trace/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_TRACE),)
+CONFIGURED_APPS += $(APPDIR)/system/trace
+endif

--- a/system/trace/Makefile
+++ b/system/trace/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/system/trace/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# trace command
+
+PROGNAME = $(CONFIG_SYSTEM_TRACE_PROGNAME)
+PRIORITY = $(CONFIG_SYSTEM_TRACE_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_TRACE_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_TRACE)
+
+ifeq ($(CONFIG_DRIVER_NOTERAM),y)
+  CSRCS = trace_dump.c
+endif
+
+MAINSRC = trace.c
+
+include $(APPDIR)/Application.mk

--- a/system/trace/README.md
+++ b/system/trace/README.md
@@ -1,0 +1,266 @@
+System / `trace` Task Tracer
+============================
+
+Task Tracer is the tool to collect the various events in the NuttX kernel and display the result graphically.
+
+It can collect the following events.
+
+- Task execution, termination, switching
+- System call enter/leave
+- Interrupt handler enter/leave
+
+# Installation
+
+## Install Trace Compass
+
+Task Tracer uses the external tool "Trace Compass" to display the trace result.
+
+Download it from https://www.eclipse.org/tracecompass/ and install into the host environment.
+
+After the installation, execute it and choose `Tools` -> `add-ons` menu, then select `Install Extensions` to install the extension named "Trace Compass ftrace (Incubation)".
+
+## NuttX kernel configuration
+
+To enable the task trace function, the NuttX kernel configuration needs to be modified.
+
+The following configurations must be enabled.
+
+- `CONFIG_SCHED_INSTRUMENTATION`
+- `CONFIG_SCHED_INSTRUMENTATION_FILTER`
+- `CONFIG_SCHED_INSTRUMENTATION_SYSCALL`
+- `CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER`
+- `CONFIG_DRIVER_NOTE`
+- `CONFIG_DRIVER_NOTERAM`
+- `CONFIG_DRIVER_NOTECTL`
+- `CONFIG_SYSTEM_TRACE`
+- `CONFIG_SYSTEM_SYSTEM`
+
+The following configurations are configurable parameters for trace. 
+
+- `CONFIG_SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE`
+  - Specify the default filter mode.
+    If the following bits are set, the corresponding instrumentations are enabled on boot.
+    - Bit 0 = Enable instrumentation
+    - Bit 1 = Enable syscall instrumentation
+    - Bit 2 = Enable IRQ instrumentation
+
+- `CONFIG_SCHED_INSTRUMENTATION_NOTERAM_BUFSIZE`
+  - Specify the note buffer size in bytes.
+    Higher value can hold more note records, but consumes more kernel memory.
+
+- `CONFIG_SCHED_INSTRUMENTATION_NOTERAM_DEFAULT_NOOVERWRITE`
+  - If enabled, stop overwriting old notes in the circular buffer when the buffer is full by default.
+    This is useful to keep instrumentation data of the beginning of a system boot.
+
+After the configuration, rebuild the NuttX kernel and application.
+
+If the trace function is enabled, "`trace`" built-in command is available.
+
+# How to get trace data
+
+The trace function can be controlled by "`trace`" command.
+
+## Quick Guide
+
+### Getting the trace
+
+Trace is started by the following command.
+```
+nsh> trace start
+```
+
+Trace is stopped by the following command.
+```
+nsh> trace stop
+```
+
+If you want to get the trace while executing some command, the following command can be used.
+```
+nsh> trace cmd <command> [<args>...]
+```
+
+### Displaying the trace result
+
+The trace result is accumulated in the memory.
+After getting the trace, the following command displays the accumulated trace data to the console.
+```
+nsh> trace dump
+```
+This will be get the trace results like the followings:
+```
+<noname>-1   [0]   7.640000000: sys_close()
+<noname>-1   [0]   7.640000000: sys_close -> 0
+<noname>-1   [0]   7.640000000: sys_sched_lock()
+<noname>-1   [0]   7.640000000: sys_sched_lock -> 0
+<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo()
+<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo -> 0
+<noname>-1   [0]   7.640000000: sys_sched_unlock()
+<noname>-1   [0]   7.640000000: sys_sched_unlock -> 0
+<noname>-1   [0]   7.640000000: sys_clock_nanosleep()
+<noname>-1   [0]   7.640000000: sched_switch: prev_comm=<noname> prev_pid=1 prev_state=S ==> next_comm=<noname> next_pid=0
+<noname>-0   [0]   7.640000000: irq_handler_entry: irq=11
+<noname>-0   [0]   7.640000000: irq_handler_exit: irq=11
+<noname>-0   [0]   7.640000000: irq_handler_entry: irq=15
+<noname>-0   [0]   7.650000000: irq_handler_exit: irq=15
+<noname>-0   [0]   7.650000000: irq_handler_entry: irq=15
+    :
+```
+
+By using the logging function of your terminal software, the trace result can be saved into the host environment and it can be used as the input for "Trace Compass".
+
+If the target has a storage, the trace result can be stored into the file by using the following command.
+It also can be used as the input for "Trace Compass" by transferring the file in the target device to the host.
+```
+nsh> trace dump <file name>
+```
+
+To display the trace result by "Trace Compass", choose `File` -> `Open Trace` menu to specify the trace data file name.
+
+
+## Trace command description
+
+### **trace start**
+Start task tracing
+```
+trace start [-c][<duration>]
+```
+- `-c` : Continue the previous trace.
+The trace data is not cleared before starting new trace.
+- `<duration>` : Specify the duration of the trace by seconds.
+Task tracing is stopped after the specified period.
+If not specified, the tracing continues until stopped by the command.
+
+### **trace stop**
+Stop task tracing
+```
+trace stop
+```
+
+### **trace cmd**
+Get the trace while running the specified command.
+After the termination of the command, task tracing is stopped.
+To use this command, `CONFIG_SYSTEM_SYSTEM` needs to be enabled.
+
+```
+trace cmd [-c] <command> [<args>...]
+```
+- `-c` : Continue the previous trace.
+The trace data is not cleared before starting new trace.
+- `<command>` : Specify the command to get the task trace.
+- `<args>` : Arguments for the command.
+
+Example:
+```
+nsh> trace cmd sleep 1
+```
+
+### **trace dump**
+Output the trace result.
+If the task trace is running, it is stopped before the output.
+```
+trace dump [-c][<filename>]
+```
+- `-c` : Not stop tracing before the output.
+Because dumping trace itself is a task activity and new trace data is added while output, the dump will never stop.
+- `<filename>` : Specify the filename to save the trace result.
+If not specified, the trace result is displayed to console.
+
+
+### **trace mode**
+Set the task trace mode options.
+The default value is given by the kernel configuration `CONFIG_SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE`.
+```
+trace mode [{+|-}{o|s|i}...]
+```
+- `+o` : Enable overwrite mode.
+The trace buffer is a ring buffer and it can overwrite old data if no free space is available in the buffer.
+Enables this behavior.
+
+- `-o` : Disable overwrite mode.
+The new trace data will be disposed when the buffer is full.
+This is useful to keep the data of the beginning of the trace.
+
+- `+s` : Enable system call trace.
+It records the event of enter/leave system call which is issued by the application.
+All system calls are recorded by default. `trace syscall` command can filter the system calls to be recorded.
+
+- `-s` : Disable system call trace.
+
+- `+i` : Enable interrupt trace.
+It records the event of enter/leave interrupt handler which is occured while the tracing.
+All IRQs are recorded by default. `trace irq` command can filter the IRQs to be recorded.
+
+- `-i` : Disable interrupt trace.
+
+If no command parameters are specified, display the current mode as the follows.
+
+Example:
+```
+nsh> trace mode
+Task trace mode:
+ Trace                   : enabled
+ Overwrite               : on  (+o)
+ Syscall trace           : on  (+s)
+  Filtered Syscalls      : 16
+ IRQ trace               : on  (+i)
+  Filtered IRQs          : 2
+```
+
+### **trace syscall**
+Configure the filter of the system call trace.
+```
+trace syscall [{+|-}<syscallname>...]
+```
+- `+<syscallname>` : Add the specified system call name to the filter.
+The execution of the filtered system call is not recorded into the trace data.<p>
+
+- `-<syscallname>` : Remove the specified system call name from the filter.
+
+Wildcard "`*`" can be used to specify the system call name.
+For example, "`trace syscall +sem_*`" filters the system calls begin with "`sem_`", such as `sem_post()`, `sem_wait()`,...
+
+If no command parameters are specified, display the current filter settings as the follows.
+
+Example:
+```
+nsh> trace syscall
+Filtered Syscalls: 16
+  getpid
+  sem_destroy
+  sem_post
+  sem_timedwait
+  sem_trywait
+  sem_wait
+  mq_close
+  mq_getattr
+  mq_notify
+  mq_open
+  mq_receive
+  mq_send
+  mq_setattr
+  mq_timedreceive
+  mq_timedsend
+  mq_unlink
+```
+
+### **trace irq**
+Configure the filter of the interrupt trace.
+```
+trace irq [{+|-}<irqnum>...]
+```
+- `+<irqnum>` : Add the specified IRQ number to the filter.
+The execution of the filtered IRQ handler is not recorded into the trace data.
+
+- `-<irqnum>` : Remove the specified IRQ number from the filter.
+
+Wildcard "`*`" can be used to specify all IRQs.
+
+If no command parameters are specified, display the current filter settings as the follows.
+
+Example:
+```
+nsh> trace irq
+Filtered IRQs: 2
+  11
+  15
+```

--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -1,0 +1,752 @@
+/****************************************************************************
+ * apps/system/trace/trace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <nuttx/lib/regex.h>
+#include <nuttx/note/notectl_driver.h>
+
+#include "trace.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: notectl_enable
+ ****************************************************************************/
+
+static bool notectl_enable(int flag, int notectlfd)
+{
+  struct note_filter_mode_s mode;
+  int oldflag;
+
+  ioctl(notectlfd, NOTECTL_GETMODE, (unsigned long)&mode);
+
+  oldflag = (mode.flag & NOTE_FILTER_MODE_FLAG_ENABLE) != 0;
+  if (flag == oldflag)
+    {
+      /* Already set */
+
+      return false;
+    }
+
+  if (flag)
+    {
+      mode.flag |= NOTE_FILTER_MODE_FLAG_ENABLE;
+    }
+  else
+    {
+      mode.flag &= ~NOTE_FILTER_MODE_FLAG_ENABLE;
+    }
+
+  ioctl(notectlfd, NOTECTL_SETMODE, (unsigned long)&mode);
+
+  return true;
+}
+
+/****************************************************************************
+ * Name: trace_cmd_start
+ ****************************************************************************/
+
+static int trace_cmd_start(int index, int argc, FAR char **argv,
+                           int notectlfd)
+{
+  FAR char *endptr;
+  int duration = 0;
+  bool cont = false;
+
+  /* Usage: trace start [-c][<duration>] */
+
+  if (index < argc)
+    {
+      if (strcmp(argv[index], "-c") == 0)
+        {
+          cont = true;
+          index++;
+        }
+    }
+
+  if (index < argc)
+    {
+      duration = strtoul(argv[index], &endptr, 0);
+      if (!duration || endptr == argv[index] || *endptr != '\0')
+        {
+          fprintf(stderr,
+                  "trace start: invalid argument '%s'\n", argv[index]);
+          return ERROR;
+        }
+
+      index++;
+    }
+
+  /* Clear the trace buffer */
+
+  if (!cont)
+    {
+      trace_dump_clear();
+    }
+
+  /* Start tracing */
+
+  notectl_enable(true, notectlfd);
+
+  if (duration > 0)
+    {
+      /* If <duration> is given, stop tracing after specified seconds. */
+
+      sleep(duration);
+      notectl_enable(false, notectlfd);
+    }
+
+  return index;
+}
+
+/****************************************************************************
+ * Name: trace_cmd_dump
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVER_NOTERAM
+static int trace_cmd_dump(int index, int argc, FAR char **argv,
+                          int notectlfd)
+{
+  FAR FILE *out = stdout;
+  int ret;
+  bool changed = false;
+  bool cont = false;
+
+  /* Usage: trace dump [-c][<filename>] */
+
+  if (index < argc)
+    {
+      if (strcmp(argv[index], "-c") == 0)
+        {
+          cont = true;
+          index++;
+        }
+    }
+
+  /* If <filename> is '-' or not given, trace dump is displayed
+   * to stdout.
+   */
+
+  if (index < argc)
+    {
+      if (strcmp(argv[index], "-") != 0)
+        {
+          /* If <filename> is given, open the file stream for output. */
+
+          out = fopen(argv[index], "w");
+          if (out == NULL)
+            {
+              fprintf(stderr,
+                      "trace dump: cannot open '%s'\n", argv[index]);
+              return ERROR;
+            }
+        }
+
+      index++;
+    }
+
+  /* Stop the tracing before dump */
+
+  if (!cont)
+    {
+      changed = notectl_enable(false, notectlfd);
+    }
+
+  /* Dump the trace data */
+
+  ret = trace_dump(out);
+
+  if (changed)
+    {
+      notectl_enable(true, notectlfd);
+    }
+
+  /* If needed, close the file stream for dump. */
+
+  if (out != stdout)
+    {
+      fclose(out);
+    }
+
+  if (ret < 0)
+    {
+      fprintf(stderr,
+              "trace dump: dump failed\n");
+      return ERROR;
+    }
+
+  return index;
+}
+#endif
+
+/****************************************************************************
+ * Name: trace_cmd_cmd
+ ****************************************************************************/
+
+#ifdef CONFIG_SYSTEM_SYSTEM
+static int trace_cmd_cmd(int index, int argc, FAR char **argv, int notectlfd)
+{
+  char command[CONFIG_NSH_LINELEN];
+  bool changed;
+  bool cont = false;
+
+  /* Usage: trace cmd [-c] <command> [<args>...] */
+
+  if (index < argc)
+    {
+      if (strcmp(argv[index], "-c") == 0)
+        {
+          cont = true;
+          index++;
+        }
+    }
+
+  if (index >= argc)
+    {
+      /* <command> parameter is mandatory. */
+
+      fprintf(stderr,
+              "trace cmd: no argument\n");
+      return ERROR;
+    }
+
+  memset(command, 0, sizeof(command));
+  while (index < argc)
+    {
+      strcat(command, argv[index]);
+      strcat(command, " ");
+      index++;
+    }
+
+  /* Clear the trace buffer */
+
+  if (!cont)
+    {
+      trace_dump_clear();
+    }
+
+  /* Execute the command with tracing */
+
+  changed = notectl_enable(true, notectlfd);
+
+  system(command);
+
+  if (changed)
+    {
+      notectl_enable(false, notectlfd);
+    }
+
+  return index;
+}
+#endif
+
+/****************************************************************************
+ * Name: trace_cmd_mode
+ ****************************************************************************/
+
+static int trace_cmd_mode(int index, int argc, FAR char **argv,
+                          int notectlfd)
+{
+  struct note_filter_mode_s mode;
+  bool owmode;
+  bool enable;
+  bool modified = false;
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+  struct note_filter_syscall_s filter_syscall;
+#endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+  struct note_filter_irq_s filter_irq;
+#endif
+  int i;
+  int count;
+
+  /* Usage: trace mode [{+|-}{o|s|i}...] */
+
+  /* Get current trace mode */
+
+  ioctl(notectlfd, NOTECTL_GETMODE, (unsigned long)&mode);
+  owmode = trace_dump_get_overwrite();
+
+  /* Parse the mode setting parameters */
+
+  while (index < argc)
+    {
+      if (argv[index][0] != '-' && argv[index][0] != '+')
+        {
+          break;
+        }
+
+      enable = (argv[index][0] == '+');
+
+      switch (argv[index][1])
+        {
+#ifdef CONFIG_DRIVER_NOTERAM
+          case 'o':   /* Overwrite mode */
+            owmode = enable;
+            break;
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+          case 's':   /* Syscall trace */
+            if (enable)
+              {
+                mode.flag |= NOTE_FILTER_MODE_FLAG_SYSCALL;
+              }
+            else
+              {
+                mode.flag &= ~NOTE_FILTER_MODE_FLAG_SYSCALL;
+              }
+            break;
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+          case 'i':   /* IRQ trace */
+            if (enable)
+              {
+                mode.flag |= NOTE_FILTER_MODE_FLAG_IRQ;
+              }
+            else
+              {
+                mode.flag &= ~NOTE_FILTER_MODE_FLAG_IRQ;
+              }
+            break;
+#endif
+
+          default:
+            fprintf(stderr,
+                    "trace mode: invalid option '%s'\n", argv[index]);
+            return ERROR;
+        }
+
+      index++;
+      modified = true;
+    }
+
+  if (modified)
+    {
+      /* Update trace mode */
+
+      ioctl(notectlfd, NOTECTL_SETMODE, (unsigned long)&mode);
+      trace_dump_set_overwrite(owmode);
+
+      return index;
+    }
+
+  /* If no parameter, display current trace mode setting. */
+
+  printf("Task trace mode:\n");
+  printf(" Trace                   : %s\n",
+         (mode.flag & NOTE_FILTER_MODE_FLAG_ENABLE) ?
+          "enabled" : "disabled");
+
+#ifdef CONFIG_DRIVER_NOTERAM
+  printf(" Overwrite               : %s\n",
+         owmode ? "on  (+o)" : "off (-o)");
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+  ioctl(notectlfd, NOTECTL_GETSYSCALLFILTER,
+        (unsigned long)&filter_syscall);
+  for (count = i = 0; i < SYS_nsyscalls; i++)
+    {
+      if (NOTE_FILTER_SYSCALLMASK_ISSET(i, &filter_syscall))
+        {
+          count++;
+        }
+    }
+
+  printf(" Syscall trace           : %s\n",
+         mode.flag & NOTE_FILTER_MODE_FLAG_SYSCALL ?
+          "on  (+s)" : "off (-s)");
+  if (mode.flag & NOTE_FILTER_MODE_FLAG_SYSCALL)
+    {
+      printf("  Filtered Syscalls      : %d\n", count);
+    }
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+  ioctl(notectlfd, NOTECTL_GETIRQFILTER, (unsigned long)&filter_irq);
+  for (count = i = 0; i < NR_IRQS; i++)
+    {
+      if (NOTE_FILTER_IRQMASK_ISSET(i, &filter_irq))
+        {
+          count++;
+        }
+    }
+
+  printf(" IRQ trace               : %s\n",
+         mode.flag & NOTE_FILTER_MODE_FLAG_IRQ ?
+          "on  (+i)" : "off (-i)");
+  if (mode.flag & NOTE_FILTER_MODE_FLAG_IRQ)
+    {
+      printf("  Filtered IRQs          : %d\n", count);
+    }
+#endif
+
+  return index;
+}
+
+/****************************************************************************
+ * Name: trace_cmd_syscall
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+static int trace_cmd_syscall(int index, int argc, FAR char **argv,
+                             int notectlfd)
+{
+  bool enable;
+  bool modified = false;
+  int syscallno;
+  FAR struct note_filter_syscall_s filter_syscall;
+  int n;
+  int count;
+
+  /* Usage: trace syscall [{+|-}<syscallname>...] */
+
+  /* Get current syscall filter setting */
+
+  ioctl(notectlfd, NOTECTL_GETSYSCALLFILTER,
+        (unsigned long)&filter_syscall);
+
+  /* Parse the setting parameters */
+
+  while (index < argc)
+    {
+      if (argv[index][0] != '-' && argv[index][0] != '+')
+        {
+          break;
+        }
+
+      enable = (argv[index][0] == '+');
+
+      /* Check whether the given pattern matches for each syscall names */
+
+      for (syscallno = 0; syscallno < SYS_nsyscalls; syscallno++)
+        {
+          if (!match(&argv[index][1], g_funcnames[syscallno]))
+            {
+              continue;
+            }
+
+          /* If matches, update the masked syscall number list */
+
+          if (enable)
+            {
+              NOTE_FILTER_SYSCALLMASK_SET(syscallno, &filter_syscall);
+            }
+          else
+            {
+              NOTE_FILTER_SYSCALLMASK_CLR(syscallno, &filter_syscall);
+            }
+        }
+
+      index++;
+      modified = true;
+    }
+
+  if (modified)
+    {
+      /* Update current syscall filter setting */
+
+      ioctl(notectlfd, NOTECTL_SETSYSCALLFILTER,
+            (unsigned long)&filter_syscall);
+    }
+  else
+    {
+      /* If no parameter, display current setting. */
+
+      for (count = n = 0; n < SYS_nsyscalls; n++)
+        {
+          if (NOTE_FILTER_SYSCALLMASK_ISSET(n, &filter_syscall))
+            {
+              count++;
+            }
+        }
+
+      printf("Filtered Syscalls: %d\n", count);
+
+      for (n = 0; n < SYS_nsyscalls; n++)
+        {
+          if (NOTE_FILTER_SYSCALLMASK_ISSET(n, &filter_syscall))
+            {
+              printf("  %s\n", g_funcnames[n]);
+            }
+        }
+    }
+
+  return index;
+}
+#endif
+
+/****************************************************************************
+ * Name: trace_cmd_irq
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+static int trace_cmd_irq(int index, int argc, FAR char **argv, int notectlfd)
+{
+  bool enable;
+  bool modified = false;
+  int irqno;
+  FAR char *endptr;
+  struct note_filter_irq_s filter_irq;
+  int n;
+  int count;
+
+  /* Usage: trace irq [{+|-}<irqnum>...] */
+
+  /* Get current irq filter setting */
+
+  ioctl(notectlfd, NOTECTL_GETIRQFILTER, (unsigned long)&filter_irq);
+
+  /* Parse the setting parameters */
+
+  while (index < argc)
+    {
+      if (argv[index][0] != '-' && argv[index][0] != '+')
+        {
+          break;
+        }
+
+      enable = (argv[index][0] == '+');
+
+      if (argv[index][1] == '*')
+        {
+          /* Mask or unmask all IRQs */
+
+          if (enable)
+            {
+              for (n = 0; n < NR_IRQS; n++)
+                {
+                  NOTE_FILTER_IRQMASK_SET(n, &filter_irq);
+                }
+            }
+          else
+            {
+              NOTE_FILTER_IRQMASK_ZERO(&filter_irq);
+            }
+        }
+      else
+        {
+          /* Get IRQ number */
+
+          irqno = strtoul(&argv[index][1], &endptr, 0);
+          if (endptr == &argv[index][1] || *endptr != '\0' ||
+              irqno >= NR_IRQS)
+            {
+              fprintf(stderr,
+                      "trace irq: invalid argument '%s'\n", argv[index]);
+              return ERROR;
+            }
+
+          /* Update the masked IRQ number list */
+
+          if (enable)
+            {
+              NOTE_FILTER_IRQMASK_SET(irqno, &filter_irq);
+            }
+          else
+            {
+              NOTE_FILTER_IRQMASK_CLR(irqno, &filter_irq);
+            }
+        }
+
+      index++;
+      modified = true;
+    }
+
+  if (modified)
+    {
+      /* Update current irq filter setting */
+
+      ioctl(notectlfd, NOTECTL_SETIRQFILTER, (unsigned long)&filter_irq);
+    }
+  else
+    {
+      /* If no parameter, display current setting. */
+
+      for (count = n = 0; n < NR_IRQS; n++)
+        {
+          if (NOTE_FILTER_IRQMASK_ISSET(n, &filter_irq))
+            {
+              count++;
+            }
+        }
+
+      printf("Filtered IRQs: %d\n", count);
+
+      for (n = 0; n < NR_IRQS; n++)
+        {
+          if (NOTE_FILTER_IRQMASK_ISSET(n, &filter_irq))
+            {
+              printf("  %d\n", n);
+            }
+        }
+    }
+
+  return index;
+}
+#endif
+
+/****************************************************************************
+ * Name: show_usage
+ ****************************************************************************/
+
+static void show_usage(void)
+{
+  fprintf(stderr,
+          "\nUsage: trace <subcommand>...\n"
+          "Subcommand:\n"
+          "  start [-c][<duration>]          :"
+                                " Start task tracing\n"
+          "  stop                            :"
+                                " Stop task tracing\n"
+#ifdef CONFIG_SYSTEM_SYSTEM
+          "  cmd [-c] <command> [<args>...]  :"
+                                " Get the trace while running <command>\n"
+#endif
+#ifdef CONFIG_DRIVER_NOTERAM
+          "  dump [-c][<filename>]           :"
+                                " Output the trace result\n"
+#endif
+          "  mode [{+|-}{o|s|i}...]          :"
+                                " Set task trace options\n"
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+          "  syscall [{+|-}<syscallname>...] :"
+                                " Configure syscall trace filter\n"
+#endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+          "  irq [{+|-}<irqnum>...]          :"
+                                " Configure IRQ trace filter\n"
+#endif
+         );
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int notectlfd;
+  int exitcode = EXIT_FAILURE;
+  int i;
+
+  /* Open note control device */
+
+  notectlfd = open("/dev/notectl", 0);
+  if (notectlfd < 0)
+    {
+      fprintf(stderr,
+              "trace: cannot open /dev/notectl\n");
+      goto errout;
+    }
+
+  if (argc == 1)
+    {
+      /* No arguments - show current mode */
+
+      trace_cmd_mode(0, 0, NULL, notectlfd);
+      goto exit_with_close;
+    }
+
+  /* Parse command line arguments */
+
+  i = 1;
+  while (i < argc)
+    {
+      if (strcmp(argv[i], "start") == 0)
+        {
+          i = trace_cmd_start(i + 1, argc, argv, notectlfd);
+        }
+      else if (strcmp(argv[i], "stop") == 0)
+        {
+          i++;
+          notectl_enable(false, notectlfd);
+        }
+#ifdef CONFIG_DRIVER_NOTERAM
+      else if (strcmp(argv[i], "dump") == 0)
+        {
+          i = trace_cmd_dump(i + 1, argc, argv, notectlfd);
+        }
+#endif
+#ifdef CONFIG_SYSTEM_SYSTEM
+      else if (strcmp(argv[i], "cmd") == 0)
+        {
+          i = trace_cmd_cmd(i + 1, argc, argv, notectlfd);
+        }
+#endif
+      else if (strcmp(argv[i], "mode") == 0)
+        {
+          i = trace_cmd_mode(i + 1, argc, argv, notectlfd);
+        }
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+      else if (strcmp(argv[i], "syscall") == 0)
+        {
+          i = trace_cmd_syscall(i + 1, argc, argv, notectlfd);
+        }
+#endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+      else if (strcmp(argv[i], "irq") == 0)
+        {
+          i = trace_cmd_irq(i + 1, argc, argv, notectlfd);
+        }
+#endif
+      else
+        {
+          show_usage();
+          goto errout_with_close;
+        }
+
+      if (i < 0)
+        {
+          goto errout_with_close;
+        }
+    }
+
+exit_with_close:
+  exitcode = EXIT_SUCCESS;
+
+  /* Close note */
+
+errout_with_close:
+  close(notectlfd);
+
+errout:
+  return exitcode;
+}

--- a/system/trace/trace.h
+++ b/system/trace/trace.h
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * apps/system/trace/trace.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_TRACE_TRACE_H
+#define __APPS_SYSTEM_TRACE_TRACE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVER_NOTERAM
+
+/****************************************************************************
+ * Name: trace_dump
+ *
+ * Description:
+ *   Read notes and dump trace results.
+ *
+ ****************************************************************************/
+
+int trace_dump(FAR FILE *out);
+
+/****************************************************************************
+ * Name: trace_dump_clear
+ *
+ * Description:
+ *   Clear all contents of the buffer
+ *
+ ****************************************************************************/
+
+void trace_dump_clear(void);
+
+/****************************************************************************
+ * Name: trace_dump_get_overwrite
+ *
+ * Description:
+ *   Get overwrite mode
+ *
+ ****************************************************************************/
+
+bool trace_dump_get_overwrite(void);
+
+/****************************************************************************
+ * Name: trace_dump_set_overwrite
+ *
+ * Description:
+ *   Set overwrite mode
+ *
+ ****************************************************************************/
+
+void trace_dump_set_overwrite(bool mode);
+
+#else /* CONFIG_DRIVER_NOTERAM */
+
+#define trace_dump(out)
+#define trace_dump_clear()
+#define trace_dump_get_overwrite()      0
+#define trace_dump_set_overwrite(mode)  (void)(mode)
+
+#endif /* CONFIG_DRIVER_NOTERAM */
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPS_SYSTEM_TRACE_TRACE_H */

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -1,0 +1,656 @@
+/****************************************************************************
+ * apps/system/trace/trace_dump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <nuttx/sched_note.h>
+#include <nuttx/note/noteram_driver.h>
+
+#include "trace.h"
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+#  ifdef CONFIG_LIB_SYSCALL
+#    include <syscall.h>
+#  else
+#    define CONFIG_LIB_SYSCALL
+#    include <syscall.h>
+#    undef CONFIG_LIB_SYSCALL
+#  endif
+#endif
+
+#ifdef CONFIG_SMP
+#  define NCPUS CONFIG_SMP_NCPUS
+#else
+#  define NCPUS 1
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Renumber idle task PIDs
+ *  In NuttX, PID number less than NCPUS are idle tasks.
+ *  In Linux, there is only one idle task of PID 0.
+ */
+
+#define get_pid(pid)  ((pid) < NCPUS ? 0 : (pid))
+
+#define get_task_state(s) ((s) <= LAST_READY_TO_RUN_STATE ? 'R' : 'S')
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* The structure to hold the context data of trace dump */
+
+struct trace_dump_cpu_context_s
+{
+  int intr_nest;          /* Interrupt nest level */
+  bool pendingswitch;     /* sched_switch pending flag */
+  int current_state;      /* Task state of the current line */
+  pid_t current_pid;      /* Task PID of the current line */
+  pid_t next_pid;         /* Task PID of the next line */
+};
+
+struct trace_dump_task_context_s
+{
+  FAR struct trace_dump_task_context_s *next;
+  pid_t pid;                              /* Task PID */
+  int syscall_nest;                       /* Syscall nest level */
+  char name[CONFIG_TASK_NAME_SIZE + 1];   /* Task name (with NUL terminator) */
+};
+
+struct trace_dump_context_s
+{
+  struct trace_dump_cpu_context_s cpu[NCPUS];
+  FAR struct trace_dump_task_context_s *task;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: note_ioctl
+ ****************************************************************************/
+
+static void note_ioctl(int cmd, unsigned long arg)
+{
+  int notefd;
+
+  notefd = open("/dev/note", O_RDONLY);
+  if (notefd < 0)
+    {
+      fprintf(stderr,
+             "trace: cannot open /dev/note\n");
+      return;
+    }
+
+  ioctl(notefd, cmd, arg);
+  close(notefd);
+}
+
+/****************************************************************************
+ * Name: trace_dump_init_context
+ ****************************************************************************/
+
+static void trace_dump_init_context(FAR struct trace_dump_context_s *ctx)
+{
+  int cpu;
+
+  /* Initialize the trace dump context */
+
+  for (cpu = 0; cpu < NCPUS; cpu++)
+    {
+      ctx->cpu[cpu].intr_nest = 0;
+      ctx->cpu[cpu].pendingswitch = false;
+      ctx->cpu[cpu].current_state = TSTATE_TASK_RUNNING;
+      ctx->cpu[cpu].current_pid = cpu;    /* Idle task */
+      ctx->cpu[cpu].next_pid = cpu;
+    }
+
+  ctx->task = NULL;
+}
+
+/****************************************************************************
+ * Name: trace_dump_fini_context
+ ****************************************************************************/
+
+static void trace_dump_fini_context(FAR struct trace_dump_context_s *ctx)
+{
+  FAR struct trace_dump_task_context_s *tctx;
+  FAR struct trace_dump_task_context_s *ntctx;
+
+  /* Finalize the trace dump context */
+
+  tctx = ctx->task;
+  ctx->task = NULL;
+  while (tctx != NULL)
+    {
+      ntctx = tctx->next;
+      free(tctx);
+      tctx = ntctx;
+    }
+}
+
+/****************************************************************************
+ * Name: copy_task_name
+ ****************************************************************************/
+
+#if CONFIG_TASK_NAME_SIZE > 0
+static void copy_task_name(FAR char *dst, FAR const char *src)
+{
+  char c;
+  int i;
+
+  /* Replace space to underline
+   * Text trace data format cannot use a space as a task name.
+   */
+
+  for (i = 0; i < CONFIG_TASK_NAME_SIZE; i++)
+    {
+      c = *src++;
+      if (c == '\0')
+        {
+          break;
+        }
+
+      *dst++ = (c == ' ') ? '_' : c;
+    }
+
+  *dst = '\0';
+}
+#endif
+
+/****************************************************************************
+ * Name: get_task_context
+ ****************************************************************************/
+
+FAR static struct trace_dump_task_context_s *get_task_context(pid_t pid,
+                                      FAR struct trace_dump_context_s *ctx)
+{
+  FAR struct trace_dump_task_context_s **tctxp;
+  tctxp = &ctx->task;
+  while (*tctxp != NULL)
+    {
+      if ((*tctxp)->pid == pid)
+        {
+          return *tctxp;
+        }
+
+      tctxp = &((*tctxp)->next);
+    }
+
+  /* Create new trace dump task context */
+
+  *tctxp = (FAR struct trace_dump_task_context_s *)
+           malloc(sizeof(struct trace_dump_task_context_s));
+  if (*tctxp != NULL)
+    {
+      (*tctxp)->next = NULL;
+      (*tctxp)->pid = pid;
+      (*tctxp)->syscall_nest = 0;
+      (*tctxp)->name[0] = '\0';
+    }
+
+  return *tctxp;
+}
+
+/****************************************************************************
+ * Name: get_task_name
+ ****************************************************************************/
+
+static const char *get_task_name(pid_t pid,
+                                 FAR struct trace_dump_context_s *ctx)
+{
+  FAR struct trace_dump_task_context_s *tctx;
+
+  tctx = get_task_context(pid, ctx);
+  if (tctx != NULL && tctx->name[0] != '\0')
+    {
+      return tctx->name;
+    }
+
+  return "<noname>";
+}
+
+/****************************************************************************
+ * Name: trace_dump_header
+ ****************************************************************************/
+
+static void trace_dump_header(FAR FILE *out,
+                              FAR struct note_common_s *note,
+                              FAR struct trace_dump_context_s *ctx)
+{
+  pid_t pid;
+  uint32_t systime = note->nc_systime[0] +
+                     (note->nc_systime[1] << 8) +
+                     (note->nc_systime[2] << 16) +
+                     (note->nc_systime[3] << 24);
+#ifdef CONFIG_SMP
+  int cpu = note->nc_cpu;
+#else
+  int cpu = 0;
+#endif
+
+  pid = ctx->cpu[cpu].current_pid;
+
+  fprintf(out, "%8s-%-3u [%d] %3u.%09u: ",
+          get_task_name(pid, ctx), get_pid(pid), cpu,
+          systime / (1000 * 1000 / CONFIG_USEC_PER_TICK),
+          (systime % (1000 * 1000 / CONFIG_USEC_PER_TICK))
+            * CONFIG_USEC_PER_TICK * 1000);
+}
+
+/****************************************************************************
+ * Name: trace_dump_sched_switch
+ ****************************************************************************/
+
+static void trace_dump_sched_switch(FAR FILE *out,
+                                    FAR struct note_common_s *note,
+                                    FAR struct trace_dump_context_s *ctx)
+{
+  FAR struct trace_dump_cpu_context_s *cctx;
+  pid_t current_pid;
+  pid_t next_pid;
+#ifdef CONFIG_SMP
+  int cpu = note->nc_cpu;
+#else
+  int cpu = 0;
+#endif
+
+  cctx = &ctx->cpu[cpu];
+  current_pid = cctx->current_pid;
+  next_pid = cctx->next_pid;
+
+  fprintf(out, "sched_switch: "
+               "prev_comm=%s prev_pid=%u prev_state=%c ==> "
+               "next_comm=%s next_pid=%u\n",
+          get_task_name(current_pid, ctx), get_pid(current_pid),
+          get_task_state(cctx->current_state),
+          get_task_name(next_pid, ctx), get_pid(next_pid));
+
+  cctx->current_pid = cctx->next_pid;
+  cctx->pendingswitch = false;
+}
+
+/****************************************************************************
+ * Name: trace_dump_one
+ ****************************************************************************/
+
+static int trace_dump_one(FAR FILE *out,
+                          FAR uint8_t *p,
+                          FAR struct trace_dump_context_s *ctx)
+{
+  FAR struct note_common_s *note = (FAR struct note_common_s *)p;
+  FAR struct trace_dump_cpu_context_s *cctx;
+  pid_t pid;
+#ifdef CONFIG_SMP
+  int cpu = note->nc_cpu;
+#else
+  int cpu = 0;
+#endif
+
+  cctx = &ctx->cpu[cpu];
+  pid = note->nc_pid[0] + (note->nc_pid[1] << 8);
+
+  if (note->nc_type != NOTE_START &&
+      note->nc_type != NOTE_STOP &&
+      note->nc_type != NOTE_RESUME
+#ifdef CONFIG_SMP
+      && !(note->nc_type >= NOTE_CPU_START &&
+           note->nc_type <= NOTE_CPU_RESUMED)
+#endif
+     )
+    {
+      cctx->current_pid = pid;
+    }
+
+  /* Output one note */
+
+  switch (note->nc_type)
+    {
+      case NOTE_START:
+        {
+#if CONFIG_TASK_NAME_SIZE > 0
+          FAR struct note_start_s *nst = (FAR struct note_start_s *)p;
+          FAR struct trace_dump_task_context_s *tctx;
+
+          tctx = get_task_context(pid, ctx);
+          if (tctx != NULL)
+            {
+              copy_task_name(tctx->name, nst->nst_name);
+            }
+#endif
+
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "sched_wakeup_new: comm=%s pid=%d target_cpu=%d\n",
+                  get_task_name(pid, ctx), get_pid(pid), cpu);
+        }
+        break;
+
+      case NOTE_STOP:
+        {
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "sched_switch: "
+                       "prev_comm=%s prev_pid=%u prev_state=%c ==> "
+                       "next_comm=%s next_pid=%u\n",
+                  get_task_name(pid, ctx), get_pid(pid), 'X',
+                  get_task_name(cctx->current_pid, ctx),
+                  get_pid(cctx->current_pid));
+        }
+        break;
+
+      case NOTE_SUSPEND:
+        {
+          FAR struct note_suspend_s *nsu = (FAR struct note_suspend_s *)p;
+
+          /* This note informs the task to be suspended.
+           * Preserve the information for the succeeding NOTE_RESUME.
+           */
+
+          cctx->current_state = nsu->nsu_state;
+        }
+        break;
+
+      case NOTE_RESUME:
+        {
+          /* This note informs the task to be resumed.
+           * The task switch timing depends on the running context.
+           */
+
+          cctx->next_pid = pid;
+
+          if (cctx->intr_nest == 0)
+            {
+              /* If not in the interrupt context, the task switch is
+               * executed immediately.
+               */
+
+              trace_dump_header(out, note, ctx);
+              trace_dump_sched_switch(out, note, ctx);
+            }
+          else
+            {
+              /* If in the interrupt context, the task switch is postponed
+               * until leaving the interrupt handler.
+               */
+
+              trace_dump_header(out, note, ctx);
+              fprintf(out, "sched_waking: comm=%s pid=%d target_cpu=%d\n",
+                      get_task_name(cctx->next_pid, ctx),
+                      get_pid(cctx->next_pid), cpu);
+              cctx->pendingswitch = true;
+            }
+        }
+        break;
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+      case NOTE_SYSCALL_ENTER:
+        {
+          FAR struct note_syscall_enter_s *nsc;
+          FAR struct trace_dump_task_context_s *tctx;
+
+          /* Exclude the case of syscall issued by an interrupt handler and
+           * nested syscalls to correct tracecompass display.
+           */
+
+          if (cctx->intr_nest > 0)
+            {
+              break;
+            }
+
+          tctx = get_task_context(pid, ctx);
+          if (tctx == NULL)
+            {
+              break;
+            }
+
+          tctx->syscall_nest++;
+          if (tctx->syscall_nest > 1)
+            {
+              break;
+            }
+
+          nsc = (FAR struct note_syscall_enter_s *)p;
+          if (nsc->nsc_nr < CONFIG_SYS_RESERVED ||
+              nsc->nsc_nr >= SYS_maxsyscall)
+            {
+              break;
+            }
+
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "sys_%s()\n",
+                  g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED]);
+        }
+        break;
+
+      case NOTE_SYSCALL_LEAVE:
+        {
+          FAR struct note_syscall_leave_s *nsc;
+          FAR struct trace_dump_task_context_s *tctx;
+
+          /* Exclude the case of syscall issued by an interrupt handler and
+           * nested syscalls to correct tracecompass display.
+           */
+
+          if (cctx->intr_nest > 0)
+            {
+              break;
+            }
+
+          tctx = get_task_context(pid, ctx);
+          if (tctx == NULL)
+            {
+              break;
+            }
+
+          tctx->syscall_nest--;
+          if (tctx->syscall_nest > 0)
+            {
+              break;
+            }
+
+          tctx->syscall_nest = 0;
+
+          nsc = (FAR struct note_syscall_leave_s *)p;
+          if (nsc->nsc_nr < CONFIG_SYS_RESERVED ||
+              nsc->nsc_nr >= SYS_maxsyscall)
+            {
+              break;
+            }
+
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "sys_%s -> 0x%x\n",
+                  g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED],
+                  nsc->nsc_result);
+        }
+        break;
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+      case NOTE_IRQ_ENTER:
+        {
+          FAR struct note_irqhandler_s *nih;
+
+          nih = (FAR struct note_irqhandler_s *)p;
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "irq_handler_entry: irq=%u\n",
+                  nih->nih_irq);
+          cctx->intr_nest++;
+        }
+        break;
+
+      case NOTE_IRQ_LEAVE:
+        {
+          FAR struct note_irqhandler_s *nih;
+
+          nih = (FAR struct note_irqhandler_s *)p;
+          trace_dump_header(out, note, ctx);
+          fprintf(out, "irq_handler_exit: irq=%u\n",
+                  nih->nih_irq);
+          cctx->intr_nest--;
+
+          if (cctx->intr_nest <= 0)
+            {
+              cctx->intr_nest = 0;
+              if (cctx->pendingswitch)
+                {
+                  /* If the pending task switch exists, it is executed here */
+
+                  trace_dump_header(out, note, ctx);
+                  trace_dump_sched_switch(out, note, ctx);
+                }
+            }
+        }
+        break;
+#endif
+
+      default:
+        break;
+    }
+
+  /* Return the length of the processed note */
+
+  return note->nc_length;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: trace_dump
+ *
+ * Description:
+ *   Read notes and dump trace results.
+ *
+ ****************************************************************************/
+
+int trace_dump(FAR FILE *out)
+{
+  struct trace_dump_context_s ctx;
+  uint8_t tracedata[UCHAR_MAX];
+  FAR uint8_t *p;
+  int size;
+  int ret;
+  int fd;
+
+  /* Open note for read */
+
+  fd = open("/dev/note", O_RDONLY);
+  if (fd < 0)
+    {
+      fprintf(stderr,
+              "trace: cannot open /dev/note\n");
+      return ERROR;
+    }
+
+  trace_dump_init_context(&ctx);
+
+  /* Read and output all notes */
+
+  while (1)
+    {
+      ret = read(fd, tracedata, sizeof tracedata);
+      if (ret <= 0)
+        {
+          break;
+        }
+
+      p = tracedata;
+      do
+        {
+          size = trace_dump_one(out, p, &ctx);
+          p += size;
+          ret -= size;
+        }
+      while (ret > 0);
+    }
+
+  trace_dump_fini_context(&ctx);
+
+  /* Close note */
+
+  close(fd);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: trace_dump_clear
+ *
+ * Description:
+ *   Clear all contents of the buffer
+ *
+ ****************************************************************************/
+
+void trace_dump_clear(void)
+{
+  note_ioctl(NOTERAM_CLEAR, 0);
+}
+
+/****************************************************************************
+ * Name: trace_dump_get_overwrite
+ *
+ * Description:
+ *   Get overwrite mode
+ *
+ ****************************************************************************/
+
+bool trace_dump_get_overwrite(void)
+{
+  unsigned int mode = 0;
+
+  note_ioctl(NOTERAM_GETMODE, (unsigned long)&mode);
+
+  return mode == NOTERAM_MODE_OVERWRITE_ENABLE;
+}
+
+/****************************************************************************
+ * Name: trace_dump_set_overwrite
+ *
+ * Description:
+ *   Set overwrite mode
+ *
+ ****************************************************************************/
+
+void trace_dump_set_overwrite(bool enable)
+{
+  unsigned int mode;
+
+  mode = enable ? NOTERAM_MODE_OVERWRITE_ENABLE :
+                  NOTERAM_MODE_OVERWRITE_DISABLE;
+
+  note_ioctl(NOTERAM_SETMODE, (unsigned long)&mode);
+}


### PR DESCRIPTION
## Summary
This PR adds "trace" command for task trace.

- Currently the documentation is available at https://github.com/YuuichiNakamura/nuttx-task-tracer-doc/blob/master/NuttXTaskTracer.md 
- rst version will be prepared later.

## Impact
- "trace" command is added as built-in apps. It is available only when the related kernel configurations are enabled.

## Testing
Tested by spresense:nsh by changing the following configurations.
```
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y
CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER=y
CONFIG_DRIVER_NOTE=y
CONFIG_DRIVER_NOTERAM=y
CONFIG_DRIVER_NOTECTL=y
CONFIG_SYSTEM_TRACE=y
CONFIG_SYSTEM_SYSTEM=y
```
Then "trace" command is added as built-in apps.
```
nsh> trace cmd usleep 1000
nsh> trace dump
```
This can get the following results:
```
<noname>-1   [0]   7.640000000: sys_ioctl -> 0
<noname>-1   [0]   7.640000000: sys_close()
<noname>-1   [0]   7.640000000: sys_close -> 0
<noname>-1   [0]   7.640000000: sys_sched_lock()
<noname>-1   [0]   7.640000000: sys_sched_lock -> 0
<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo()
<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo -> 0
<noname>-1   [0]   7.640000000: sys_sched_unlock()
<noname>-1   [0]   7.640000000: sys_sched_unlock -> 0
<noname>-1   [0]   7.640000000: sys_clock_nanosleep()
<noname>-1   [0]   7.640000000: sched_switch: prev_comm=<noname> prev_pid=1 prev_state=S ==> next_comm=<noname> next_pid=0
<noname>-0   [0]   7.640000000: irq_handler_entry: irq=11
<noname>-0   [0]   7.640000000: irq_handler_exit: irq=11
<noname>-0   [0]   7.640000000: irq_handler_entry: irq=15
<noname>-0   [0]   7.650000000: irq_handler_exit: irq=15
<noname>-0   [0]   7.650000000: irq_handler_entry: irq=15
<noname>-0   [0]   7.660000000: sched_waking: comm=<noname> pid=1 target_cpu=0
<noname>-1   [0]   7.660000000: irq_handler_exit: irq=15
<noname>-1   [0]   7.660000000: sched_switch: prev_comm=<noname> prev_pid=1 prev_state=R ==> next_comm=<noname> next_pid=1
<noname>-1   [0]   7.660000000: sys_clock_nanosleep -> 0
```

