### PR TITLE
interpreters/wamr: This requires CLOCK_MONOTONIC to build

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -6,6 +6,7 @@
 config INTERPRETERS_WAMR
 	tristate "Webassembly Micro Runtime"
 	default n
+	select CLOCK_MONOTONIC
 
 if INTERPRETERS_WAMR
 


### PR DESCRIPTION
## Summary
just be explicit about a prerequisite
## Impact

## Testing
sim build on macos. (with some other patches)
