### PR TITLE
examples: Add fxos8700cq sensor test

### DIFF
--- a/examples/fxos8700cq_test/Kconfig
+++ b/examples/fxos8700cq_test/Kconfig
@@ -1,0 +1,51 @@
+#############################################################################
+#
+# examples/fxos8700cq_test/Kconfig
+# fxos8700cq motion sensor sample app
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#############################################################################
+
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_FXOS8700CQ
+	bool "FXOS8700CQ motion sensor example"
+	default n
+	select SENSORS_FXOS8700CQ
+	---help---
+		Enable the motion sensor example
+
+if EXAMPLES_FXOS8700CQ
+
+config EXAMPLES_FXOS8700CQ_PROGNAME
+	string "Program name"
+	default "fxos8700cq"
+	---help---
+		This is the name of the program that will be use when the NSH ELF
+		program is installed.
+
+config EXAMPLES_FXOS8700CQ_PRIORITY
+	int "fxos8700cq task priority"
+	default 100
+
+config EXAMPLES_FXOS8700CQ_STACKSIZE
+	int "fxos8700cq stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/fxos8700cq_test/Make.defs
+++ b/examples/fxos8700cq_test/Make.defs
@@ -1,0 +1,25 @@
+#############################################################################
+#
+# examples/fxos8700cq_test/Make.defs
+# fxos8700cq motion sensor sample app
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_FXOS8700CQ),y)
+CONFIGURED_APPS += examples/fxos8700cq_test
+endif

--- a/examples/fxos8700cq_test/Makefile
+++ b/examples/fxos8700cq_test/Makefile
@@ -1,0 +1,38 @@
+#############################################################################
+#
+# examples/fxos8700cq/Makefile
+# fxos8700cq motion sensor sample app
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#############################################################################
+
+include $(APPDIR)/Make.defs
+-include $(SDKDIR)/Make.defs
+
+# fxos8700cq built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_FXOS8700CQ_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_FXOS8700CQ_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_FXOS8700CQ_STACKSIZE)
+
+# fxos8700cq Example
+
+ASRCS =
+CSRCS =
+MAINSRC = fxos8700cq_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/fxos8700cq_test/fxos8700cq_main.c
+++ b/examples/fxos8700cq_test/fxos8700cq_main.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * examples/fxos8700cq/fxos8700cq_main.c
+ * fxos8700cq motion sensor sample application
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+#include <nuttx/sensors/fxos8700cq.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef ACC_DEVPATH
+#define ACC_DEVPATH "/dev/accel0"
+#endif
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * fxos8700cq_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+
+  fxos8700cq_data data;
+  uint32_t prev;
+
+  fd = open(ACC_DEVPATH, O_RDONLY);
+  if (fd < 0)
+    {
+      printf("Device %s open failure. %d\n", ACC_DEVPATH, fd);
+
+      return -1;
+    }
+
+  while (true)
+    {
+      int ret;
+
+      ret = read(fd, &data, sizeof(fxos8700cq_data));
+      if (ret != sizeof(fxos8700cq_data))
+        {
+           fprintf(stderr, "Read failed : %d/%d@%d\n",
+                   ret, sizeof(fxos8700cq_data), fd);
+           break;
+        }
+      printf("{ accel: [%d, %d, %d], magn: [%d, %d, %d] }\n",
+             data.accel.x, data.accel.y, data.accel.z,
+             data.magn.x, data.magn.y, data.magn.z
+          );
+      fflush(stdout);
+      usleep(1000 / 25);
+    }
+
+  close(fd);
+
+  return 0;
+}


### PR DESCRIPTION
It was tested on NXP FRDM-64F:

    nsh> fxos8700cq
    { accel: [2174, 555, -752], magn: [0, 0, 0] }
    { accel: [-300, 547, 1951], magn: [55, -188, 276] }

Change-Id: If5180ce69913cf096e04db7772f3f9dd63f853bd
Bug: https://github.com/apache/incubator-nuttx/issues/1988
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

