### PR TITLE
Change all 'Nuttx' to 'NuttX'

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ A: Here are three:
       custom apps directory as necessary.
 
       This is documented in `NuttX/boards/README.txt` and
-      `nuttx/Documentation/NuttxPortingGuide.html` (Online at
-      https://bitbucket.org/nuttx/nuttx/src/master/Documentation/NuttxPortingGuide.html#apndxconfigs
+      `nuttx/Documentation/NuttXPortingGuide.html` (Online at
+      https://bitbucket.org/nuttx/nuttx/src/master/Documentation/NuttXPortingGuide.html#apndxconfigs
       under _Build options_). And in the `apps/README.txt` file.
 
    3) If you like the random collection of stuff in the `apps/` directory but

--- a/examples/README.md
+++ b/examples/README.md
@@ -279,7 +279,7 @@ Example Configuration:
 
 ## `dsptest` DSP
 
-This is a Unit Test for the Nuttx DSP library. It use Unity testing framework.
+This is a Unit Test for the NuttX DSP library. It use Unity testing framework.
 
 Dependencies:
 

--- a/graphics/nxwidgets/ChangeLog.txt
+++ b/graphics/nxwidgets/ChangeLog.txt
@@ -647,5 +647,5 @@
 * Fix a dependency in Kconfig:  CONFIG_NXWIDGET_SERVERINIT is definitely
   supported in the PROTECTED and KERNEL build modes (2018-01-18).
 
-After Nuttx-7.26, the NxWidgets repository was merged into the apps/
+After NuttX-7.26, the NxWidgets repository was merged into the apps/
 repository.  See the apps/ChangeLot.txt for changes since that time.

--- a/graphics/nxwm/ChangeLog.txt
+++ b/graphics/nxwm/ChangeLog.txt
@@ -647,5 +647,5 @@
 * Fix a dependency in Kconfig:  CONFIG_NXWIDGET_SERVERINIT is definitely
   supported in the PROTECTED and KERNEL build modes (2018-01-18).
 
-After Nuttx-7.26, the NxWidgets repository was merged into the apps/
+After NuttX-7.26, the NxWidgets repository was merged into the apps/
 repository.  See the apps/ChangeLot.txt for changes since that time.

--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -4,7 +4,7 @@
  *   Copyright (C) 2017, 2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Adapted for Nuttx from WAPI:
+ * Adapted for NuttX from WAPI:
  *
  *   Copyright (c) 2010, Volkan YAZICI <volkan.yazici@gmail.com>
  *   All rights reserved.

--- a/netutils/netlib/netlib_ipv6netmask2prefix.c
+++ b/netutils/netlib/netlib_ipv6netmask2prefix.c
@@ -117,7 +117,7 @@ static uint8_t netlib_msbits8(uint8_t byval)
 
 static inline uint8_t netlib_msbits16(uint16_t hword)
 {
-   uint8_t ones;
+  uint8_t ones;
 
   /* Look at the MS byte of the 16-bit value */
 

--- a/netutils/netlib/netlib_ipv6netmask2prefix.c
+++ b/netutils/netlib/netlib_ipv6netmask2prefix.c
@@ -142,7 +142,7 @@ static inline uint8_t netlib_msbits16(uint16_t hword)
  * Name: netlib_ipv6netmask2prefix
  *
  * Description:
- *   Convert a 128-bit netmask to a prefix length.  The Nuttx IPv6
+ *   Convert a 128-bit netmask to a prefix length.  The NuttX IPv6
  *   networking uses 128-bit network masks internally.  This function
  *   converts the IPv6 netmask to a prefix length.
  *

--- a/system/cu/Kconfig
+++ b/system/cu/Kconfig
@@ -16,7 +16,7 @@ menuconfig SYSTEM_CUTERM
 
 		This terminal might come in handy for other people that have e.g. GS
 		modems, GPS receivers or other devices with text based serial
-		communications attached to their Nuttx systems.
+		communications attached to their NuttX systems.
 
 if SYSTEM_CUTERM
 

--- a/system/nsh/Kconfig
+++ b/system/nsh/Kconfig
@@ -14,11 +14,11 @@ config SYSTEM_NSH
 if SYSTEM_NSH
 
 config SYSTEM_NSH_PRIORITY
-	int "Nuttx shell thread priority"
+	int "NuttX shell thread priority"
 	default 100
 
 config SYSTEM_NSH_STACKSIZE
-	int "Nuttx shell stack size"
+	int "NuttX shell stack size"
 	default DEFAULT_TASK_STACKSIZE
 
 config SYSTEM_NSH_SYMTAB

--- a/wireless/ieee802154/i8sak/i8sak.h
+++ b/wireless/ieee802154/i8sak/i8sak.h
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak.h
+++ b/wireless/ieee802154/i8sak/i8sak.h
@@ -58,6 +58,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #if !defined(CONFIG_IEEE802154_I8SAK_DEFAULT_EP_EADDR)
@@ -142,7 +143,8 @@ struct i8sak_s
   sem_t eventsem;  /* For synchronizing access to the event receiver list */
   sq_queue_t eventreceivers;
   sq_queue_t eventreceivers_free;
-  struct i8sak_eventreceiver_s eventreceiver_pool[CONFIG_I8SAK_NEVENTRECEIVERS];
+  struct i8sak_eventreceiver_s
+  eventreceiver_pool[CONFIG_I8SAK_NEVENTRECEIVERS];
 
   /* MAC related fields */
 
@@ -165,10 +167,10 @@ struct i8sak_s
   struct sockaddr_in6 ep_in6addr;
 #endif
 
-  /* For the Coordinator, we keep a Short Address that will be handed out next.
-   * After assigning the address to a device requesting association, this field
-   * is simply incremented.  This means short addresses will be assigned to
-   * associating devices in order.
+  /* For the Coordinator, we keep a Short Address that will be handed out
+   * next. After assigning the address to a device requesting association,
+   * this field is simply incremented.  This means short addresses will be
+   * assigned to associating devices in order.
    */
 
   uint8_t next_saddr[IEEE802154_SADDRSIZE];
@@ -220,18 +222,30 @@ void      i8sak_str2panid   (FAR const char *str, FAR uint8_t *panid);
 
 /* Command Functions. Alphabetical Order */
 
-void i8sak_acceptassoc_cmd (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_assoc_cmd       (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_blaster_cmd     (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_get_cmd         (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_poll_cmd        (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_regdump_cmd     (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_reset_cmd       (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_scan_cmd        (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_set_cmd         (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_sniffer_cmd     (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_startpan_cmd    (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
-void i8sak_tx_cmd          (FAR struct i8sak_s *i8sak, int argc, FAR char *argv[]);
+void i8sak_acceptassoc_cmd (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_assoc_cmd       (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_blaster_cmd     (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_get_cmd         (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_poll_cmd        (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_regdump_cmd     (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_reset_cmd       (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_scan_cmd        (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_set_cmd         (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_sniffer_cmd     (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_startpan_cmd    (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
+void i8sak_tx_cmd          (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
 
 /* Command background threads */
 
@@ -270,13 +284,17 @@ static inline void i8sak_update_ep_ip(FAR struct i8sak_s *i8sak)
   if (i8sak->ep_addr.mode == IEEE802154_ADDRMODE_EXTENDED)
     {
      i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[4] =
-        HTONS(((uint16_t)i8sak->ep_addr.eaddr[0] << 8 | (uint16_t)i8sak->ep_addr.eaddr[1]));
+        HTONS(((uint16_t)i8sak->ep_addr.eaddr[0] << 8) |
+              (uint16_t)i8sak->ep_addr.eaddr[1]);
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[5] =
-        HTONS(((uint16_t)i8sak->ep_addr.eaddr[2] << 8 | (uint16_t)i8sak->ep_addr.eaddr[3]));
+        HTONS(((uint16_t)i8sak->ep_addr.eaddr[2] << 8) |
+              (uint16_t)i8sak->ep_addr.eaddr[3]);
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[6] =
-        HTONS(((uint16_t)i8sak->ep_addr.eaddr[4] << 8 | (uint16_t)i8sak->ep_addr.eaddr[5]));
+        HTONS(((uint16_t)i8sak->ep_addr.eaddr[4] << 8) |
+              (uint16_t)i8sak->ep_addr.eaddr[5]);
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[7] =
-        HTONS(((uint16_t)i8sak->ep_addr.eaddr[6] << 8 | (uint16_t)i8sak->ep_addr.eaddr[7]));
+        HTONS(((uint16_t)i8sak->ep_addr.eaddr[6] << 8) |
+              (uint16_t)i8sak->ep_addr.eaddr[7]);
 
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[4] ^= HTONS(0x0200);
     }
@@ -286,7 +304,8 @@ static inline void i8sak_update_ep_ip(FAR struct i8sak_s *i8sak)
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[5] = HTONS(0x00ff);
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[6] = HTONS(0xfe00);
       i8sak->ep_in6addr.sin6_addr.in6_u.u6_addr16[7] =
-        ((uint16_t)i8sak->ep_addr.saddr[0] << 8 | (uint16_t)i8sak->ep_addr.saddr[1]);
+        ((uint16_t)i8sak->ep_addr.saddr[0] << 8 |
+         (uint16_t)i8sak->ep_addr.saddr[1]);
     }
 }
 #endif

--- a/wireless/ieee802154/i8sak/i8sak_assoc.c
+++ b/wireless/ieee802154/i8sak/i8sak_assoc.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_assoc.c
+++ b/wireless/ieee802154/i8sak/i8sak_assoc.c
@@ -63,7 +63,8 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void assoc_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg);
+static void assoc_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                          FAR void *arg);
 
 /****************************************************************************
  * Public Functions
@@ -139,19 +140,22 @@ void i8sak_assoc_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
             break;
 
           case 'p':
+
             /* Parse short address and put it into the i8sak instance */
 
             i8sak_str2panid(optarg, i8sak->ep_addr.panid);
             break;
 
           case 's':
+
             /* Parse short address and put it into the i8sak instance */
 
             i8sak_str2saddr(optarg, i8sak->ep_addr.saddr);
-            i8sak->ep_addr.mode= IEEE802154_ADDRMODE_SHORT;
+            i8sak->ep_addr.mode = IEEE802154_ADDRMODE_SHORT;
             break;
 
           case 'e':
+
             /* Parse extended address and put it into the i8sak instance */
 
             i8sak_str2eaddr(optarg, i8sak->ep_addr.eaddr);
@@ -159,12 +163,14 @@ void i8sak_assoc_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
             break;
 
           case 't':
+
             /* Parse wait time and set the parameter in the request */
 
             setreq.attrval.mac.resp_waittime = i8sak_str2luint8(optarg);
             break;
 
           case 'w':
+
             /* Wait and retry if we fail to associate */
 
             retry      = true;
@@ -194,7 +200,8 @@ void i8sak_assoc_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
       fd = open(i8sak->ifname, O_RDWR);
       if (fd < 0)
         {
-          fprintf(stderr, "ERROR: cannot open %s, errno=%d\n", i8sak->ifname, errno);
+          fprintf(stderr, "ERROR: cannot open %s, errno=%d\n",
+                  i8sak->ifname, errno);
           i8sak_cmd_error(i8sak);
         }
 
@@ -320,7 +327,8 @@ void i8sak_assoc_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
  * Private Functions
  ****************************************************************************/
 
-static void assoc_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg)
+static void assoc_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                          FAR void *arg)
 {
   FAR struct i8sak_s *i8sak = (FAR struct i8sak_s *)arg;
 

--- a/wireless/ieee802154/i8sak/i8sak_blaster.c
+++ b/wireless/ieee802154/i8sak/i8sak_blaster.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_blaster.c
+++ b/wireless/ieee802154/i8sak/i8sak_blaster.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
- /****************************************************************************
+/****************************************************************************
  * Included Files
  ****************************************************************************/
 
@@ -133,7 +133,8 @@ void i8sak_blaster_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
             break;
 
           case 'f': /* Inline change blaster frame */
-            i8sak->payload_len = i8sak_str2payload(optarg, &i8sak->payload[0]);
+            i8sak->payload_len = i8sak_str2payload(optarg,
+                                                   &i8sak->payload[0]);
             i8sak_blaster_start(i8sak);
             break;
 
@@ -172,7 +173,7 @@ pthread_addr_t i8sak_blaster_thread(pthread_addr_t arg)
 #ifdef CONFIG_NET_6LOWPAN
   if (i8sak->mode == I8SAK_MODE_NETIF)
     {
-      if (bind(i8sak->fd, (struct sockaddr*)&i8sak->ep_in6addr,
+      if (bind(i8sak->fd, (struct sockaddr *)&i8sak->ep_in6addr,
                sizeof(struct sockaddr_in6)) < 0)
         {
           fprintf(stderr, "ERROR: failure to bind sock: %d\n", errno);
@@ -183,7 +184,7 @@ pthread_addr_t i8sak_blaster_thread(pthread_addr_t arg)
 
   while (i8sak->blasterenabled)
     {
-      usleep(i8sak->blasterperiod*1000);
+      usleep(i8sak->blasterperiod * 1000);
 
       if (i8sak->mode == I8SAK_MODE_CHAR)
         {
@@ -198,7 +199,8 @@ pthread_addr_t i8sak_blaster_thread(pthread_addr_t arg)
           tx.meta.ranging = IEEE802154_NON_RANGING;
 
           tx.meta.srcmode = i8sak->addrmode;
-          memcpy(&tx.meta.destaddr, &i8sak->ep_addr, sizeof(struct ieee802154_addr_s));
+          memcpy(&tx.meta.destaddr, &i8sak->ep_addr,
+                 sizeof(struct ieee802154_addr_s));
 
           /* Each byte is represented by 2 chars */
 
@@ -211,7 +213,8 @@ pthread_addr_t i8sak_blaster_thread(pthread_addr_t arg)
       else if (i8sak->mode == I8SAK_MODE_NETIF)
         {
           sendto(i8sak->fd, i8sak->payload, i8sak->payload_len, 0,
-                 (struct sockaddr*)&i8sak->ep_in6addr, sizeof(struct sockaddr_in6));
+                 (struct sockaddr *)&i8sak->ep_in6addr,
+                 sizeof(struct sockaddr_in6));
         }
 #endif
     }

--- a/wireless/ieee802154/i8sak/i8sak_poll.c
+++ b/wireless/ieee802154/i8sak/i8sak_poll.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_poll.c
+++ b/wireless/ieee802154/i8sak/i8sak_poll.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
- /****************************************************************************
+/****************************************************************************
  * Included Files
  ****************************************************************************/
 
@@ -61,7 +61,8 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void poll_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg);
+static void poll_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                         FAR void *arg);
 
 /****************************************************************************
  * Public Functions
@@ -91,18 +92,22 @@ void i8sak_poll_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
                     "Usage: %s [-h]\n"
                     "    -h = this help menu\n"
                     , argv[0]);
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
             return;
           case ':':
             fprintf(stderr, "ERROR: missing argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
             i8sak_cmd_error(i8sak); /* This exits for us */
+
           case '?':
             fprintf(stderr, "ERROR: unknown argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -112,14 +117,15 @@ void i8sak_poll_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
   i8sak_requestdaemon(i8sak);
 
-  /* Register new oneshot callback for receiving the association notifications */
+  /* Register new callback for receiving the association notifications */
 
   memset(&eventfilter, 0, sizeof(struct i8sak_eventfilter_s));
   eventfilter.confevents.poll = true;
 
   i8sak_eventlistener_addreceiver(i8sak, poll_eventcb, &eventfilter, true);
 
-  memcpy(&pollreq.coordaddr, &i8sak->ep_addr, sizeof(struct ieee802154_addr_s));
+  memcpy(&pollreq.coordaddr, &i8sak->ep_addr,
+         sizeof(struct ieee802154_addr_s));
 
   if (pollreq.coordaddr.mode == IEEE802154_ADDRMODE_SHORT)
     {
@@ -135,7 +141,8 @@ void i8sak_poll_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
       fd = open(i8sak->ifname, O_RDWR);
       if (fd < 0)
         {
-          fprintf(stderr, "ERROR: cannot open %s, errno=%d\n", i8sak->ifname, errno);
+          fprintf(stderr, "ERROR: cannot open %s, errno=%d\n",
+                  i8sak->ifname, errno);
           i8sak_cmd_error(i8sak);
         }
 
@@ -157,7 +164,9 @@ void i8sak_poll_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
   close(fd);
 
-  /* Wait here, the event listener will notify us if the correct event occurs */
+  /* Wait here, the event listener will notify us if the correct event
+   * occurs
+   */
 
   ret = sem_wait(&i8sak->sigsem);
   if (ret != OK)
@@ -173,7 +182,8 @@ void i8sak_poll_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
  * Private Function
  ****************************************************************************/
 
-static void poll_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg)
+static void poll_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                         FAR void *arg)
 {
   FAR struct i8sak_s *i8sak = (FAR struct i8sak_s *)arg;
 

--- a/wireless/ieee802154/i8sak/i8sak_scan.c
+++ b/wireless/ieee802154/i8sak/i8sak_scan.c
@@ -6,7 +6,7 @@
  *   Copyright (C) 2017 Verge Inc. All rights reserved.
  *
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_scan.c
+++ b/wireless/ieee802154/i8sak/i8sak_scan.c
@@ -59,7 +59,8 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg);
+static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                         FAR void *arg);
 
 /****************************************************************************
  * Public Functions
@@ -119,6 +120,7 @@ void i8sak_scan_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
           case ':':
             fprintf(stderr, "ERROR: missing argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -126,6 +128,7 @@ void i8sak_scan_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
           case '?':
             fprintf(stderr, "ERROR: unknown argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -205,7 +208,8 @@ void i8sak_scan_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
  * Private Functions
  ****************************************************************************/
 
-static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg)
+static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                         FAR void *arg)
 {
   FAR struct i8sak_s *i8sak = (FAR struct i8sak_s *)arg;
   FAR struct ieee802154_scan_conf_s *scan = &primitive->u.scanconf;
@@ -234,7 +238,8 @@ static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void 
 
   printf("Scan results: \n");
 
-  if (scan->type == IEEE802154_SCANTYPE_ACTIVE || scan->type == IEEE802154_SCANTYPE_PASSIVE)
+  if (scan->type == IEEE802154_SCANTYPE_ACTIVE ||
+      scan->type == IEEE802154_SCANTYPE_PASSIVE)
     {
       /* Copy the results from the notification */
 
@@ -268,10 +273,11 @@ static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void 
     {
       /* Print the results out */
 
-      for (i=0; i < scan->numresults; i++)
+      for (i = 0; i < scan->numresults; i++)
         {
           printf("Result %d\n", i);
-          printf("    Channel: %u Energy: %d\n", scan->chlist[i], scan->edlist[i]);
+          printf("    Channel: %u Energy: %d\n",
+                 scan->chlist[i], scan->edlist[i]);
         }
     }
 

--- a/wireless/ieee802154/i8sak/i8sak_sniffer.c
+++ b/wireless/ieee802154/i8sak/i8sak_sniffer.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_sniffer.c
+++ b/wireless/ieee802154/i8sak/i8sak_sniffer.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
- /****************************************************************************
+/****************************************************************************
  * Included Files
  ****************************************************************************/
 
@@ -90,6 +90,7 @@ void i8sak_sniffer_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
                     "Usage: %s [-h|d]\n"
                     "    -h = this help menu\n"
                     , argv[0]);
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -103,6 +104,7 @@ void i8sak_sniffer_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
           case ':':
             fprintf(stderr, "ERROR: missing argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -110,6 +112,7 @@ void i8sak_sniffer_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
           case '?':
             fprintf(stderr, "ERROR: unknown argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
@@ -138,6 +141,7 @@ void i8sak_sniffer_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
         {
           printf("i8sak: turning on promiscuous mode.\n");
         }
+
       ieee802154_setpromisc(fd, true);
 
       /* Make sure receiver is always on while idle */
@@ -146,6 +150,7 @@ void i8sak_sniffer_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
         {
           printf("i8sak: setting receiveonidle.\n");
         }
+
       ieee802154_setrxonidle(fd, true);
     }
 #ifdef CONFIG_NET_6LOWPAN
@@ -218,7 +223,7 @@ pthread_addr_t i8sak_sniffer_thread(pthread_addr_t arg)
       memset(&addr.sin6_addr, 0, sizeof(struct in6_addr));
       addrlen           = sizeof(struct sockaddr_in6);
 
-      if (bind(i8sak->fd, (struct sockaddr*)&addr, addrlen) < 0)
+      if (bind(i8sak->fd, (struct sockaddr *)&addr, addrlen) < 0)
         {
           fprintf(stderr, "ERROR: failure to bind sock: %d\n", errno);
           exit(1);
@@ -230,7 +235,8 @@ pthread_addr_t i8sak_sniffer_thread(pthread_addr_t arg)
     {
       if (i8sak->mode == I8SAK_MODE_CHAR)
         {
-          ret = read(i8sak->fd, &frame, sizeof(struct mac802154dev_rxframe_s));
+          ret = read(i8sak->fd, &frame,
+                     sizeof(struct mac802154dev_rxframe_s));
           if (ret < 0)
             {
               continue;

--- a/wireless/ieee802154/i8sak/i8sak_startpan.c
+++ b/wireless/ieee802154/i8sak/i8sak_startpan.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_startpan.c
+++ b/wireless/ieee802154/i8sak/i8sak_startpan.c
@@ -68,7 +68,8 @@
  *   Start PAN and accept association requests
  ****************************************************************************/
 
-void i8sak_startpan_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
+void i8sak_startpan_cmd(FAR struct i8sak_s *i8sak,
+                        int argc, FAR char *argv[])
 {
   struct ieee802154_start_req_s startreq;
   bool beaconenabled = false;
@@ -88,21 +89,27 @@ void i8sak_startpan_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
                     "    -h = this help menu\n"
                     "    -b = start beacon-enabled PAN\n"
                     , argv[0]);
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
             return;
+
           case 'b':
             beaconenabled = true;
             break;
+
           case ':':
             fprintf(stderr, "ERROR: missing argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;
             i8sak_cmd_error(i8sak); /* This exits for us */
+
           case '?':
             fprintf(stderr, "ERROR: unknown argument\n");
+
             /* Must manually reset optind if we are going to exit early */
 
             optind = -1;

--- a/wireless/ieee802154/i8sak/i8sak_tx.c
+++ b/wireless/ieee802154/i8sak/i8sak_tx.c
@@ -8,7 +8,7 @@
  *
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *   Author: Anthony Merlino <anthony@vergeaero.com>
- *   Author: Gregory Nuttx <gnutt@nuttx.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/wireless/ieee802154/i8sak/i8sak_tx.c
+++ b/wireless/ieee802154/i8sak/i8sak_tx.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
- /****************************************************************************
+/****************************************************************************
  * Included Files
  ****************************************************************************/
 
@@ -62,7 +62,8 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void tx_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg);
+static void tx_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                       FAR void *arg);
 
 /****************************************************************************
  * Public Functions
@@ -186,9 +187,9 @@ void i8sak_tx_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
     }
   else
     {
-      /* We cannot send a frame as direct if we are the PAN coordinator. Maybe
-       * this should be the hook for sending payload in beacon? But for now,
-       * let's just throw an error.
+      /* We cannot send a frame as direct if we are the PAN coordinator.
+       * Maybe this should be the hook for sending payload in beacon? But
+       * for now, let's just throw an error.
        */
 
       if (devmode == IEEE802154_DEVMODE_PANCOORD)
@@ -203,7 +204,7 @@ void i8sak_tx_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
 
   i8sak_requestdaemon(i8sak);
 
-  /* Register new oneshot callback for receiving the association notifications */
+  /* Register new callback for receiving the association notifications */
 
   memset(&eventfilter, 0, sizeof(struct i8sak_eventfilter_s));
   eventfilter.confevents.data = true;
@@ -243,7 +244,8 @@ void i8sak_tx_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
       tx.meta.ranging = IEEE802154_NON_RANGING;
 
       tx.meta.srcmode = i8sak->addrmode;
-      memcpy(&tx.meta.destaddr, &i8sak->ep_addr, sizeof(struct ieee802154_addr_s));
+      memcpy(&tx.meta.destaddr, &i8sak->ep_addr,
+             sizeof(struct ieee802154_addr_s));
 
       /* Each byte is represented by 2 chars */
 
@@ -261,15 +263,14 @@ void i8sak_tx_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
       addr.sin6_port       = HTONS(0);
       memset(addr.sin6_addr.s6_addr, 0, sizeof(struct in6_addr));
 
-      if (bind(i8sak->fd, (struct sockaddr*)&addr, sizeof(struct sockaddr_in6)) < 0)
+      ret = bind(i8sak->fd, (struct sockaddr *)&addr,
+                 sizeof(struct sockaddr_in6));
+      if (ret >= 0)
         {
-          fprintf(stderr, "ERROR: failure to bind sock: %d\n", errno);
-          close(fd);
-          i8sak_cmd_error(i8sak);
+          ret = sendto(fd, i8sak->payload, i8sak->payload_len, 0,
+                      (struct sockaddr *)&i8sak->ep_in6addr,
+                      sizeof(struct sockaddr_in6));
         }
-
-      ret = sendto(fd, i8sak->payload, i8sak->payload_len, 0,
-                   (struct sockaddr*)&i8sak->ep_in6addr, sizeof(struct sockaddr_in6));
     }
 #endif
 
@@ -283,7 +284,8 @@ void i8sak_tx_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
   close(fd);
 }
 
-static void tx_eventcb(FAR struct ieee802154_primitive_s *primitive, FAR void *arg)
+static void tx_eventcb(FAR struct ieee802154_primitive_s *primitive,
+                       FAR void *arg)
 {
   FAR struct i8sak_s *i8sak = (FAR struct i8sak_s *)arg;
 

--- a/wireless/wapi/src/network.c
+++ b/wireless/wapi/src/network.c
@@ -10,10 +10,11 @@
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
- *  - Redistributions of  source code must  retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *  - Redistributions of  source code must  retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
  *
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of  conditions and the  following disclaimer in the
@@ -177,7 +178,8 @@ int wapi_get_ifup(int sock, FAR const char *ifname, FAR int *is_up)
   WAPI_VALIDATE_PTR(is_up);
 
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
-  if ((ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr))) >= 0)
+  ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
+  if (ret >= 0)
     {
       *is_up = (ifr.ifr_flags & IFF_UP) == IFF_UP;
     }
@@ -205,7 +207,8 @@ int wapi_set_ifup(int sock, FAR const char *ifname)
   int ret;
 
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
-  if ((ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr))) >= 0)
+  ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
+  if (ret >= 0)
     {
       ifr.ifr_flags |= (IFF_UP | IFF_RUNNING);
       ret = ioctl(sock, SIOCSIFFLAGS, (unsigned long)((uintptr_t)&ifr));
@@ -240,7 +243,8 @@ int wapi_set_ifdown(int sock, FAR const char *ifname)
   int ret;
 
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
-  if ((ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr))) >= 0)
+  ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
+  if (ret >= 0)
     {
       ifr.ifr_flags &= ~IFF_UP;
       ret = ioctl(sock, SIOCSIFFLAGS, (unsigned long)((uintptr_t)&ifr));

--- a/wireless/wapi/src/network.c
+++ b/wireless/wapi/src/network.c
@@ -4,7 +4,7 @@
  *   Copyright (C) 2011, 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Adapted for Nuttx from WAPI:
+ * Adapted for NuttX from WAPI:
  *
  *   Copyright (c) 2010, Volkan YAZICI <volkan.yazici@gmail.com>
  *   All rights reserved.

--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -4,7 +4,7 @@
  *   Copyright (C) 2011, 2017Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Adapted for Nuttx from WAPI:
+ * Adapted for NuttX from WAPI:
  *
  *   Copyright (c) 2010, Volkan YAZICI <volkan.yazici@gmail.com>
  *   All rights reserved.

--- a/wireless/wapi/src/util.h
+++ b/wireless/wapi/src/util.h
@@ -4,7 +4,7 @@
  *   Copyright (C) 2011, 2017Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Adapted for Nuttx from WAPI:
+ * Adapted for NuttX from WAPI:
  *
  *   Copyright (c) 2010, Volkan YAZICI <volkan.yazici@gmail.com>
  *   All rights reserved.

--- a/wireless/wapi/src/util.h
+++ b/wireless/wapi/src/util.h
@@ -10,10 +10,11 @@
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
- *  - Redistributions of  source code must  retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *  - Redistributions of  source code must  retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
  *
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of  conditions and the  following disclaimer in the

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -4,7 +4,7 @@
  *   Copyright (C) 2011, 2017, 2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Adapted for Nuttx from WAPI:
+ * Adapted for NuttX from WAPI:
  *
  *   Copyright (c) 2010, Volkan YAZICI <volkan.yazici@gmail.com>
  *   All rights reserved.


### PR DESCRIPTION
## Summary
Unify the naming convention. Please ignore the failse alarm:
```
apps/wireless/wapi/src/util.c:79:6: error: Mixed case identifier found
apps/wireless/wapi/src/util.c:106:9: error: Mixed case identifier found
```

## Impact
None.

## Testing

