### PR TITLE
fxos8700cq: Select SENSORS if used

### DIFF
--- a/examples/fxos8700cq_test/Kconfig
+++ b/examples/fxos8700cq_test/Kconfig
@@ -27,6 +27,7 @@
 config EXAMPLES_FXOS8700CQ
 	bool "FXOS8700CQ motion sensor example"
 	default n
+	select SENSORS
 	select SENSORS_FXOS8700CQ
 	---help---
 		Enable the motion sensor example


### PR DESCRIPTION
SENSORS_FXOS8700CQ needs SENSORS for linking

Change-Id: Ie0f1ba57517f27fa7697b6c8cf7a1f6558107732
Bug: https://github.com/apache/incubator-nuttx/pull/1999
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

