### PR TITLE
Update gs2200m daemon

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1132,7 +1132,6 @@ static int accept_request(int fd, FAR struct gs2200m_s *priv,
   struct gs2200m_accept_msg amsg;
   FAR struct usock_s *usock;
   FAR struct usock_s *new_usock = NULL;
-  struct sockaddr_in ep_addr;
   int ret = 0;
   int16_t usockid; /* usockid for new client */
 
@@ -1173,6 +1172,7 @@ static int accept_request(int fd, FAR struct gs2200m_s *priv,
 
   new_usock->cid   = amsg.cid;
   new_usock->state = CONNECTED;
+  new_usock->raddr = amsg.addr;
 
 prepare:
 
@@ -1185,8 +1185,8 @@ prepare:
 
   if (0 == ret)
     {
-      resp.reqack.result = 2; /* ep_addr + usock */
-      resp.valuelen_nontrunc = sizeof(ep_addr);
+      resp.reqack.result = 2; /* new_usock->raddr + usock */
+      resp.valuelen_nontrunc = sizeof(new_usock->raddr);
       resp.valuelen = resp.valuelen_nontrunc;
     }
   else
@@ -1208,11 +1208,7 @@ prepare:
     {
       /* Send address (value) */
 
-      /* TODO: ep_addr should be set */
-
-      memset(&ep_addr, 0, sizeof(ep_addr));
-
-      ret = _write_to_usock(fd, &ep_addr, resp.valuelen);
+      ret = _write_to_usock(fd, &new_usock->raddr, resp.valuelen);
 
       if (0 > ret)
         {

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1516,6 +1516,7 @@ static int ioctl_request(int fd, FAR struct gs2200m_s *priv,
 
   switch (req->cmd)
     {
+      case SIOCGIFADDR:
       case SIOCGIFHWADDR:
         getreq = true;
         break;


### PR DESCRIPTION
## Summary

- This PR updates the gs2200m daemon and consists of the following 4 commits
- commit 1: wireless: gs2200m: Fix to handle UDP connect() with bind()
  - This commit fixes to handle UDP connect() with bind() to local port
  - NOTE: GS2200M does not support TCP connect() with bind to local port
- commit 2: wireless: gs2200m: Fix to handle address info in accept()
  - This commit fixes to handle address info in accept()
- commit 3: wireless: gs2200m: Implement getpeername_request()
  - This commit adds getperrname_request() to gs2200m_main.c
- commit 4: wireless: gs2200m: Add support for ioctl(fd, SIOCGIFADDR, ...)
  - This commit adds support for ioctl(fd, SIOCGIFADDR, ...) to gs2200m_main.c

## Impact

- All use cases which use accept() with gs2200m
- All use cases which use ioctl(fd, SIOCGIFADDR, ...) with gs2200m
- Please see https://github.com/apache/incubator-nuttx/pull/2083 as well

## Testing

- Tested with spresene:wifi
- Tested with telnet daemon
- Modify telnetd and add getpeername() to show a client address
- Tested with dhcpc
