### PR TITLE
Fix cu can't receive ctrl+c, usrsock_rpmsg: fix can't wake ppoll when no SIGUSR1_ACTION

### DIFF
--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -839,6 +839,7 @@ int main(int argc, char *argv[])
   pthread_mutex_init(&priv->mutex, NULL);
   pthread_cond_init(&priv->cond, NULL);
 
+  signal(SIGUSR1, SIG_IGN);
   sigprocmask(SIG_SETMASK, NULL, &sigmask);
   sigaddset(&sigmask, SIGUSR1);
   sigprocmask(SIG_SETMASK, &sigmask, NULL);

--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -61,8 +61,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef SIGKILL
-#  define SIGKILL 9
+#ifndef CONFIG_SIG_INT
+#  define SIGINT 10
+#else
+#  define SIGINT CONFIG_SIG_INT
 #endif
 
 /****************************************************************************
@@ -311,7 +313,7 @@ int main(int argc, FAR char *argv[])
 
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sigint;
-  sigaction(SIGKILL, &sa, NULL);
+  sigaction(SIGINT, &sa, NULL);
 
   optind = 0;   /* global that needs to be reset in FLAT mode */
   while ((option = getopt(argc, argv, "l:s:cefhor?")) != ERROR)


### PR DESCRIPTION
## Summary

system/cu/cu_main.c: ctrlC will send SIGINT/SIGSTP

usrsock_rpmsg: fix can't wake ppoll when no ACTION,
no matter open/close CONFIG_SIGUSR1_ACTION, usrsock always do,
unmask SIGUSR1, set action to NULL.

## Impact

## Testing

