### PR TITLE
nimBLE integration application/library

### DIFF
--- a/wireless/bluetooth/nimble/.gitignore
+++ b/wireless/bluetooth/nimble/.gitignore
@@ -1,0 +1,2 @@
+/mynewt-nimble
+/*.tar.gz

--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -1,0 +1,15 @@
+config NIMBLE
+  bool "Apache nimBLE (BLE host-layer)"
+  default n
+  depends on !WIRELESS_BLUETOOTH_HOST
+  ---help---
+    Enable Apache nimBLE Bluetooth Low Energy
+    host-layer stack. 
+
+if NIMBLE
+  config NIMBLE_REF
+  string "Version"
+  default "nuttx"
+  ---help---
+    Git ref name to use when downloading from nimBLE repo
+endif

--- a/wireless/bluetooth/nimble/Make.defs
+++ b/wireless/bluetooth/nimble/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/wireless/bluetooth/nimble/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_NIMBLE),)
+CONFIGURED_APPS += $(APPDIR)/wireless/bluetooth/nimble
+endif

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -1,0 +1,47 @@
+############################################################################
+# apps/wireless/bluetooth/nimble/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PRIORITY  = 255
+STACKSIZE = 16384
+
+NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/mynewt-nimble
+
+-include $(NIMBLE_ROOT)/porting/examples/nuttx/Make.defs
+
+NIMBLE_TAR := $(CONFIG_NIMBLE_REF).tar.gz
+NIMBLE_URL := https://github.com/v01d/mynewt-nimble/archive/$(NIMBLE_TAR)
+
+$(NIMBLE_TAR):
+	wget $(NIMBLE_URL) -O $(NIMBLE_TAR)
+
+$(NIMBLE_ROOT): $(NIMBLE_TAR)
+	tar zxf $(NIMBLE_TAR)
+	mv mynewt-nimble-$(CONFIG_NIMBLE_REF) mynewt-nimble 
+
+context:: $(NIMBLE_ROOT)
+
+distclean::
+	$(call CLEAN,$(NIMBLE_TAR))
+	$(call DELDIR,$(NIMBLE_ROOT))
+
+           
+include $(APPDIR)/Application.mk

--- a/wireless/bluetooth/nimble/README.md
+++ b/wireless/bluetooth/nimble/README.md
@@ -1,0 +1,75 @@
+# nimBLE for NuttX
+
+This application will build nimBLE stack (host-only) as a library/application
+in NuttX.
+
+# Porting Layer
+
+nimBLE supports being built as part of different OS, not only their mynewt
+RTOS. A porting layer was written for NuttX, which was mostly a copy of
+the Linux porting layer.
+
+## Modifying the porting layer
+
+NuttX is supported in nimBLE by adding an entry in the porting layer
+used to support different OSs. However, nimBLE supports each OS
+by generating a configuration header (`syscfg.h`) from YAML configuration
+files. If you want to modify the porting layer and change its configuration
+you will need to regenerate this header. This process is a bit involved since
+nimBLE uses its own `newt` build tool to do so and also somewhat assumes it will
+be built for their mynewt OS, so it actually may fail to build completely but
+it will still get to generate the required files.
+
+So, first is to get the newt tool:
+
+  $ cd apps/nimble
+  $ git clone https://github.com/apache/mynewt-newt
+  $ cd mynewt-newt
+
+At the moment, you will probably require unstable version
+instead of a release so select a known working:
+
+  $ git checkout 0fcf17566c40
+  $ ./build.sh
+
+There should be now a `newt` binary under `mynewt-newt/newt`.
+Extend your path so that it is visible:
+
+  $ export PATH=mynewt-newt/newt:$PATH
+
+Now, create a `newt` project:
+
+  $ newt new foo
+
+We want latest master version of mynewt OS and stack, so edit
+`foo/project.yml` and change the `vers` variable to `0.0.0`. Now
+do
+
+  $ cd foo/
+  $ newt upgrade
+
+Under `foo/repos` there will be a clone of both mynewt and nimble
+repo. Since this app already downloads nimble repo outside of `foo`,
+you can delete `foo/repos/apache-mynewt-nimble` and simply make a
+link to the `mynewt-nimble` directory, so that you can work on the
+nimBLE code directly.
+
+Now you can make any changes to the `yml` files such as 
+`porting/targets/nuttx/syscfg.yml`. Finally, you can build with:
+
+  $ newt build @apache-mynewt-nimble/porting/targets/nuttx
+
+This will most likely fail to complete but the generated headers
+should be there. So now copy them to the appropriate location in
+the `nuttx` target directory:
+
+  $ cd foo/
+  $ cp bin/@apache-mynewt-nimble/porting/targets/nuttx/generated/include/logcfg/logcfg.h \
+	repos/apache-mynewt-nimble/porting/examples/nuttx/include/logcfg
+  $ cp bin/@apache-mynewt-nimble/porting/targets/nuttx/generated/include/syscfg/syscfg.h \
+	repos/apache-mynewt-nimble/porting/examples/nuttx/include/syscfg 
+
+If these changes are done to fix a problem with NuttX porting layer in nimBLE, you
+should open a pull-request to nimBLE repository to include the updated header files.
+It is recommended to mention the issue in NuttX mailing list first to ensure the change
+is needed.


### PR DESCRIPTION
## Summary

This PR adds support for nimBLE host-layer stack for NuttX, for when NuttX's own stack is disabled. This will build a `nimble` app, which is an example shipped with nimBLE which includes a simple GATT server. An application wishing to use the stack need to add the appropriate include path.

At the moment this points to my fork of nimBLE, which is currently awaiting merge upstream. Once it is accepted upstream, I will create another PR to point to the official repo.

## Impact

Add application.

## Testing

Developed own application using nimBLE on top of to-be-upstream nRF52 link-layer. Also tested on sim build, using bthcisock config. A nimBLE specific config will be added in separate PR on main repo for others to test.

