### PR TITLE
Changes for nuttx issue 1883

### DIFF
--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -839,6 +839,7 @@ int main(int argc, char *argv[])
   pthread_mutex_init(&priv->mutex, NULL);
   pthread_cond_init(&priv->cond, NULL);
 
+  signal(SIGUSR1, SIG_IGN);
   sigprocmask(SIG_SETMASK, NULL, &sigmask);
   sigaddset(&sigmask, SIGUSR1);
   sigprocmask(SIG_SETMASK, &sigmask, NULL);

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -84,7 +84,18 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
   fd = open(filepath, O_RDONLY);
   if (fd < 0)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
+      if (strncmp(filepath, CONFIG_NSH_PROC_MOUNTPOINT,
+                  strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
+        {
+          nsh_error(vtbl,
+                    "nsh: %s: Could not open %s (is procfs mounted?): %d\n",
+                    cmd, filepath, NSH_ERRNO);
+        }
+      else
+        {
+          nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
+        }
+
       return ERROR;
     }
 
@@ -319,7 +330,18 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     {
       /* Failed to open the directory */
 
-      nsh_error(vtbl, g_fmtnosuch, cmd, "directory", dirpath);
+      if (strncmp(dirpath, CONFIG_NSH_PROC_MOUNTPOINT,
+                  strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
+        {
+          nsh_error(vtbl,
+                    "nsh: %s: Could not open %s (is procfs mounted?): %d\n",
+                    cmd, dirpath, NSH_ERRNO);
+        }
+      else
+        {
+          nsh_error(vtbl, g_fmtnosuch, cmd, "directory", dirpath);
+        }
+
       return ERROR;
     }
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -391,7 +391,16 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
   dir = opendir(CONFIG_NSH_PROC_MOUNTPOINT "/net");
   if (dir == NULL)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, cmd, "opendir", NSH_ERRNO);
+      if (strncmp(cmd, "ifconfig", strlen("ifconfig")) == 0)
+        {
+          nsh_error(vtbl, "nsh: %s: %s: %d\n", cmd,
+                    "procfs is not mounted", NSH_ERRNO);
+        }
+      else
+        {
+          nsh_error(vtbl, g_fmtcmdfailed, cmd, "opendir", NSH_ERRNO);
+        }
+
       return ERROR;
     }
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -391,16 +391,9 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
   dir = opendir(CONFIG_NSH_PROC_MOUNTPOINT "/net");
   if (dir == NULL)
     {
-      if (strncmp(cmd, "ifconfig", strlen("ifconfig")) == 0)
-        {
-          nsh_error(vtbl, "nsh: %s: %s: %d\n", cmd,
-                    "procfs is not mounted", NSH_ERRNO);
-        }
-      else
-        {
-          nsh_error(vtbl, g_fmtcmdfailed, cmd, "opendir", NSH_ERRNO);
-        }
-
+      nsh_error(vtbl,
+                "%s: %s: Could not open %s/net (is procfs mounted?): %d\n",
+                "nsh", cmd, CONFIG_NSH_PROC_MOUNTPOINT, NSH_ERRNO);
       return ERROR;
     }
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -392,8 +392,8 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
   if (dir == NULL)
     {
       nsh_error(vtbl,
-                "%s: %s: Could not open %s/net (is procfs mounted?): %d\n",
-                "nsh", cmd, CONFIG_NSH_PROC_MOUNTPOINT, NSH_ERRNO);
+                "nsh: %s: Could not open %s/net (is procfs mounted?): %d\n",
+                cmd, CONFIG_NSH_PROC_MOUNTPOINT, NSH_ERRNO);
       return ERROR;
     }
 

--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -61,8 +61,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef SIGKILL
-#  define SIGKILL 9
+#ifndef CONFIG_SIG_INT
+#  define SIGINT 10
+#else
+#  define SIGINT CONFIG_SIG_INT
 #endif
 
 /****************************************************************************
@@ -311,7 +313,7 @@ int main(int argc, FAR char *argv[])
 
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sigint;
-  sigaction(SIGKILL, &sa, NULL);
+  sigaction(SIGINT, &sa, NULL);
 
   optind = 0;   /* global that needs to be reset in FLAT mode */
   while ((option = getopt(argc, argv, "l:s:cefhor?")) != ERROR)


### PR DESCRIPTION
## Summary

Fix for [nuttx issue # 1883](https://github.com/apache/incubator-nuttx/issues/1883). When proc file-system is not mounted, running `ifconfig` should give output as "ifconfig: procfs is not mounted" instead of "ifconfig: opendir failed: 20".

## Impact

When proc file-system is not mounted, running `ifconfig` should give output as "ifconfig: procfs is not mounted" instead of "ifconfig: opendir failed: 20".

## Testing

Should be built and tested against relevant h/w platforms.
Since I don't have necessary h/w platform yet, couldn't test functionality on real hardware by (un/re)mounting procfs.