### PR TITLE
Fix for nuttx issue 1883

### DIFF
--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -84,7 +84,18 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
   fd = open(filepath, O_RDONLY);
   if (fd < 0)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
+      if (strncmp(filepath, CONFIG_NSH_PROC_MOUNTPOINT,
+                  strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
+        {
+          nsh_error(vtbl,
+                    "nsh: %s: Could not open %s (is procfs mounted?): %d\n",
+                    cmd, filepath, NSH_ERRNO);
+        }
+      else
+        {
+          nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
+        }
+
       return ERROR;
     }
 
@@ -319,7 +330,18 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     {
       /* Failed to open the directory */
 
-      nsh_error(vtbl, g_fmtnosuch, cmd, "directory", dirpath);
+      if (strncmp(dirpath, CONFIG_NSH_PROC_MOUNTPOINT,
+                  strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
+        {
+          nsh_error(vtbl,
+                    "nsh: %s: Could not open %s (is procfs mounted?): %d\n",
+                    cmd, dirpath, NSH_ERRNO);
+        }
+      else
+        {
+          nsh_error(vtbl, g_fmtnosuch, cmd, "directory", dirpath);
+        }
+
       return ERROR;
     }
 

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -84,6 +84,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
   fd = open(filepath, O_RDONLY);
   if (fd < 0)
     {
+#if defined(CONFIG_NSH_PROC_MOUNTPOINT)
       if (strncmp(filepath, CONFIG_NSH_PROC_MOUNTPOINT,
                   strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
         {
@@ -92,6 +93,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                     cmd, filepath, NSH_ERRNO);
         }
       else
+#endif
         {
           nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
         }
@@ -330,6 +332,7 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     {
       /* Failed to open the directory */
 
+#if defined(CONFIG_NSH_PROC_MOUNTPOINT)
       if (strncmp(dirpath, CONFIG_NSH_PROC_MOUNTPOINT,
                   strlen(CONFIG_NSH_PROC_MOUNTPOINT)) == 0)
         {
@@ -338,6 +341,7 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                     cmd, dirpath, NSH_ERRNO);
         }
       else
+#endif
         {
           nsh_error(vtbl, g_fmtnosuch, cmd, "directory", dirpath);
         }

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -391,7 +391,9 @@ static int nsh_foreach_netdev(nsh_netdev_callback_t callback,
   dir = opendir(CONFIG_NSH_PROC_MOUNTPOINT "/net");
   if (dir == NULL)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, cmd, "opendir", NSH_ERRNO);
+      nsh_error(vtbl,
+                "nsh: %s: Could not open %s/net (is procfs mounted?): %d\n",
+                cmd, CONFIG_NSH_PROC_MOUNTPOINT, NSH_ERRNO);
       return ERROR;
     }
 


### PR DESCRIPTION
## Summary

Fix for nuttx [issue # 1883](https://github.com/apache/incubator-nuttx/issues/1883). When proc file-system is not mounted, running ifconfig should give output as "ifconfig: procfs is not mounted" instead of "ifconfig: opendir failed: 20".

Addressed review comments from @v01d & @xiaoxiang781216. For more details, please refer to [pull request 443](https://github.com/apache/incubator-nuttx-apps/pull/443). Based on the discussion, the error message should now be "**Could not open <dir/file name> (is procfs mounted?)**" at all relevant places.

## Impact

When proc file-system is not mounted, running ifconfig should give output as "ifconfig: procfs is not mounted" instead of "ifconfig: opendir failed: 20".

## Testing

Should be built and tested against relevant h/w platforms.
__Since I don't have necessary h/w platform yet, couldn't test functionality on real hardware by (un/re)mounting procfs.__

**P.S.** I shall send a separate pull request dealing with coding standards related issues in **nsh_fsutils.c.**