### PR TITLE
Fixed coding std violations in nsh_fsutils.h

### DIFF
--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -89,7 +89,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     }
 
   buffer = (FAR char *)malloc(IOBUFFERSIZE);
-  if(buffer == NULL)
+  if (buffer == NULL)
     {
       close(fd);
       nsh_error(vtbl, g_fmtcmdfailed, cmd, "malloc", NSH_ERRNO);
@@ -98,7 +98,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
   /* And just dump it byte for byte into stdout */
 
-  for (;;)
+  for (; ; )
     {
       int nbytesread = read(fd, buffer, IOBUFFERSIZE);
 
@@ -116,7 +116,8 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
             }
           else
             {
-              nsh_error(vtbl, g_fmtcmdfailed, cmd, "read", NSH_ERRNO_OF(errval));
+              nsh_error(vtbl, g_fmtcmdfailed, cmd, "read",
+                        NSH_ERRNO_OF(errval));
             }
 
           ret = ERROR;
@@ -131,7 +132,8 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
           while (nbyteswritten < nbytesread)
             {
-              ssize_t n = nsh_write(vtbl, buffer + nbyteswritten, nbytesread - nbyteswritten);
+              ssize_t n = nsh_write(vtbl, buffer + nbyteswritten,
+                                    nbytesread - nbyteswritten);
               if (n < 0)
                 {
                   int errcode = errno;
@@ -166,18 +168,18 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
         }
     }
 
-   /* NOTE that the following NSH prompt may appear on the same line as file
-    * content.  The IEEE Std requires that "The standard output shall
-    * contain the sequence of bytes read from the input files. Nothing else
-    * shall be written to the standard output." Reference:
-    * https://pubs.opengroup.org/onlinepubs/009695399/utilities/cat.html.
-    */
+  /* NOTE that the following NSH prompt may appear on the same line as file
+   * content.  The IEEE Std requires that "The standard output shall
+   * contain the sequence of bytes read from the input files. Nothing else
+   * shall be written to the standard output." Reference:
+   * https://pubs.opengroup.org/onlinepubs/009695399/utilities/cat.html.
+   */
 
-   /* Close the input file and return the result */
+  /* Close the input file and return the result */
 
-   close(fd);
-   free(buffer);
-   return ret;
+  close(fd);
+  free(buffer);
+  return ret;
 }
 #endif
 


### PR DESCRIPTION
## Summary

Fixed for Nuttx coding standards violations in nsh_fsutils.h as reported in [pull request # 446](https://github.com/apache/incubator-nuttx-apps/pull/446) and [here](https://github.com/apache/incubator-nuttx-apps/pull/446/checks?check_run_id=1320354396).

## Impact

Fixed for Nuttx coding standards violations in nsh_fsutils.h.

## Testing

Should build and run normally without affecting any functionality.