### PR TITLE
build.yml: Switch avr-mips-riscv-x86-xtensa.dat to other.dat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim, renesas]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, sim]
 
     steps:
       - name: Download Source Artifact
@@ -169,7 +169,7 @@ jobs:
     needs: Fetch-Source
     strategy:
       matrix:
-        boards: [arm-12, avr-mips-riscv-x86-xtensa, sim]
+        boards: [arm-12, other, sim]
     steps:
       - name: Download Source Artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
# Summary
To simplify the build list management

## Impact
No functional change

## Testing
Pass the automation build

