### PR TITLE
Fixed coding std issues

### DIFF
--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -108,8 +108,8 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     {
       /* The application was successfully started with pre-emption disabled.
        * In the simplest cases, the application will not have run because the
-       * the scheduler is locked.  But in the case where I/O was redirected, a
-       * proxy task ran and broke our lock.  As result, the application may
+       * the scheduler is locked.  But in the case where I/O was redirected,
+       * a proxy task ran and broke our lock.  As result, the application may
        * have aso ran if its priority was higher than than the priority of
        * this thread.
        *
@@ -149,10 +149,10 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
            * and if the application has not yet run, it will now be able to
            * do so.
            *
-           * Also, if CONFIG_SCHED_HAVE_PARENT is defined waitpid() might fail
-           * even if task is still active:  If the I/O was re-directed by a
-           * proxy task, then the ask is a child of the proxy, and not this
-           * task.  waitpid() fails with ECHILD in either case.
+           * Also, if CONFIG_SCHED_HAVE_PARENT is defined waitpid() might
+           * fail even if task is still active:  If the I/O was re-directed
+           * by a proxy task, then the ask is a child of the proxy, and not
+           * this task. waitpid() fails with ECHILD in either case.
            *
            * NOTE: WUNTRACED does nothing in the default case, but in the
            * case the where CONFIG_SIG_SIGSTOP_ACTION=y, the built-in app
@@ -164,12 +164,13 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
           if (ret < 0)
             {
               /* If the child thread does not exist, waitpid() will return
-               * the error ECHLD.  Since we know that the task was successfully
-               * started, this must be one of the cases described above; we
-               * have to assume that the task already exit'ed.  In this case,
-               * we have no idea if the application ran successfully or not
-               * (because NuttX does not retain exit status of child tasks).
-               * Let's assume that is did run successfully.
+               * the error ECHLD.  Since we know that the task was
+               * successfully started, this must be one of the cases
+               * described above; we have to assume that the task already
+               * exit'ed. In this case, we have no idea if the application
+               * ran successfully or not (because NuttX does not retain exit
+               * status of child tasks). Let's assume that is did run
+               * successfully.
                */
 
               int errcode = errno;
@@ -189,16 +190,16 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
           else
             {
               /* We can't return the exact status (nsh has nowhere to put it)
-               * so just pass back zero/nonzero in a fashion that doesn't look
-               * like an error.
+               * so just pass back zero/nonzero in a fashion that doesn't
+               * look like an error.
                */
 
               ret = (rc == 0) ? OK : 1;
 
-             /* TODO:  Set the environment variable '?' to a string corresponding
-              * to WEXITSTATUS(rc) so that $? will expand to the exit status of
-              * the most recently executed task.
-              */
+              /* TODO:  Set the environment variable '?' to a string
+               * corresponding to WEXITSTATUS(rc) so that $? will expand to
+               * the exit status of the most recently executed task.
+               */
             }
 
           ioctl(stdout->fs_fd, TIOCSCTTY, -1);
@@ -212,13 +213,13 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
        *
        * - CONFIG_SCHED_WAITPID is not selected meaning that all commands
        *   have to be run in background, or
-       * - CONFIG_SCHED_WAITPID and CONFIG_NSH_DISABLEBG are both selected, but the
-       *   user requested to run the command in background.
+       * - CONFIG_SCHED_WAITPID and CONFIG_NSH_DISABLEBG are both selected,
+       *   but the user requested to run the command in background.
        *
        * NOTE that the case of a) CONFIG_SCHED_WAITPID is not selected and
-       * b) CONFIG_NSH_DISABLEBG selected cannot be supported.  In that event, all
-       * commands will have to run in background.  The waitpid() API must be
-       * available to support running the command in foreground.
+       * b) CONFIG_NSH_DISABLEBG selected cannot be supported.  In that
+       * event, all commands will have to run in background.  The waitpid()
+       * API must be available to support running the command in foreground.
        */
 
 #if !defined(CONFIG_SCHED_WAITPID) || !defined(CONFIG_NSH_DISABLEBG)

--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -120,9 +120,10 @@ static int dd_write(FAR struct dd_s *dd)
       nbytes = write(dd->outfd, buffer, dd->sectsize - written);
       if (nbytes < 0)
         {
-           FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
-           nsh_error(vtbl, g_fmtcmdfailed, g_dd, "write", NSH_ERRNO_OF(-nbytes));
-           return ERROR;
+          FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
+          nsh_error(vtbl, g_fmtcmdfailed, g_dd, "write",
+                    NSH_ERRNO_OF(-nbytes));
+          return ERROR;
         }
 
       written += nbytes;
@@ -148,9 +149,10 @@ static int dd_read(FAR struct dd_s *dd)
       nbytes = read(dd->infd, buffer, dd->sectsize - dd->nbytes);
       if (nbytes < 0)
         {
-           FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
-           nsh_error(vtbl, g_fmtcmdfailed, g_dd, "read", NSH_ERRNO_OF(-nbytes));
-           return ERROR;
+          FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
+          nsh_error(vtbl, g_fmtcmdfailed, g_dd, "read",
+                    NSH_ERRNO_OF(-nbytes));
+          return ERROR;
         }
 
       dd->nbytes += nbytes;

--- a/nshlib/nsh_modcmds.c
+++ b/nshlib/nsh_modcmds.c
@@ -62,6 +62,7 @@ int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   FAR void *handle;
 
   /* Usage: insmod <filepath> <modulename> */
+
   /* Install the module  */
 
   handle = insmod(argv[1], argv[2]);
@@ -84,6 +85,7 @@ int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   int ret;
 
   /* Usage: rmmod <modulename> */
+
   /* Get the module handle associated with the name */
 
   handle = modhandle(argv[1]);
@@ -115,6 +117,7 @@ int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   FILE *stream;
 
   /* Usage: lsmod */
+
   /* Open /proc/modules */
 
   stream = fopen("/proc/modules", "r");

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -273,7 +273,6 @@ static void nsh_parse_statusline(FAR char *line,
 #ifndef CONFIG_NSH_DISABLE_PS
 static int ps_callback(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
                        FAR struct dirent *entryp, FAR void *pvarg)
-
 {
   struct nsh_taskstatus_s status;
   FAR char *filepath;

--- a/nshlib/nsh_romfsetc.c
+++ b/nshlib/nsh_romfsetc.c
@@ -119,9 +119,11 @@ int nsh_romfsetc(void)
         CONFIG_NSH_ROMFSMOUNTPT, MOUNT_DEVNAME);
 
 #if defined(CONFIG_NSH_CROMFSETC)
-  ret = mount(MOUNT_DEVNAME, CONFIG_NSH_ROMFSMOUNTPT, "cromfs", MS_RDONLY, NULL);
+  ret = mount(MOUNT_DEVNAME, CONFIG_NSH_ROMFSMOUNTPT, "cromfs", MS_RDONLY,
+              NULL);
 #else
-  ret = mount(MOUNT_DEVNAME, CONFIG_NSH_ROMFSMOUNTPT, "romfs", MS_RDONLY, NULL);
+  ret = mount(MOUNT_DEVNAME, CONFIG_NSH_ROMFSMOUNTPT, "romfs", MS_RDONLY,
+              NULL);
 #endif
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

Fixed NuttX coding std violations in the following files -

- nsh_builtin.c
- nsh_ddcmd.c
- nsh_modcmds.c
- nsh_proccmds.c
- nsh_romfsetc.c

## Impact

No impact on functionality. Changes are meant for conformance with NuttX coding guidelines.

## Testing

Does NOT add/modify any functionality. Should build & run normally.