### PR TITLE
lvgl: use malloc/free for memory handling and "tickless" tick interface

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -90,54 +90,6 @@ void lv_demo_widgets(void);
  ****************************************************************************/
 
 /****************************************************************************
- * Name: tick_func
- *
- * Description:
- *   Calls lv_tick_inc(...) every 5ms.
- *
- * Input Parameters:
- *   data
- *
- * Returned Value:
- *   NULL
- *
- ****************************************************************************/
-
-static FAR void *tick_func(void *data)
-{
-  static long last_ms;
-  long    ms;
-  struct timespec spec;
-
-  while (1)
-    {
-      long diff;
-
-      /* Calculate how much time elapsed */
-
-      clock_gettime(CLOCK_REALTIME, &spec);
-      ms = (long)spec.tv_nsec / 1000000;
-      diff = ms - last_ms;
-
-      /* Handle overflow */
-
-      if (diff < 0)
-        {
-          diff = 1000 + diff;
-        }
-
-      lv_tick_inc(diff);
-      usleep(5000);
-
-      last_ms = ms;
-    }
-
-  /* Never will reach here */
-
-  return NULL;
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -157,7 +109,6 @@ static FAR void *tick_func(void *data)
 int main(int argc, FAR char *argv[])
 {
   lv_disp_drv_t disp_drv;
-  pthread_t tick_thread;
 
   lv_disp_buf_t disp_buf;
   static lv_color_t buf[DISPLAY_BUFFER_SIZE];
@@ -213,10 +164,6 @@ int main(int argc, FAR char *argv[])
   disp_drv.flush_cb = fbdev_flush;
   disp_drv.buffer = &disp_buf;
   lv_disp_drv_register(&disp_drv);
-
-  /* Tick interface initialization */
-
-  pthread_create(&tick_thread, NULL, tick_func, NULL);
 
   /* Touchpad Initialization */
 

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -51,6 +51,8 @@ LVGL_DIR_NAME = lvgl
 -include ./lvgl/src/lv_draw/lv_draw.mk
 -include ./lvgl/src/lv_gpu/lv_gpu.mk
 
+CSRCS += lv_tick_interface.c
+
 # Set up build configuration and environment
 
 WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}

--- a/graphics/lvgl/lv_conf.h
+++ b/graphics/lvgl/lv_conf.h
@@ -149,7 +149,7 @@ typedef int16_t lv_coord_t;
  * `lv_mem_alloc` and `lv_mem_free`
  */
 
-#define LV_MEM_CUSTOM      0
+#define LV_MEM_CUSTOM      1
 #if LV_MEM_CUSTOM == 0
 
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB) */
@@ -423,10 +423,10 @@ typedef void * lv_img_decoder_user_data_t;
  * It removes the need to manually update the tick with `lv_tick_inc`)
  */
 
-#define LV_TICK_CUSTOM     0
+#define LV_TICK_CUSTOM     1
 #if LV_TICK_CUSTOM == 1
-#define LV_TICK_CUSTOM_INCLUDE  "something.h"       /* Header for the sys time function */
-#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /* Expression evaluating to current systime in ms */
+#define LV_TICK_CUSTOM_INCLUDE  "lv_tick_interface.h"       /* Header for the sys time function */
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (lv_tick_interface())  /* Expression evaluating to current systime in ms */
 #endif   /* LV_TICK_CUSTOM */
 
 typedef void * lv_disp_drv_user_data_t;             /* Type of user data in the display driver */

--- a/graphics/lvgl/lv_tick_interface.c
+++ b/graphics/lvgl/lv_tick_interface.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * graphics/lvgl/lv_tick_interface.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include "lv_tick_interface.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uint32_t lv_tick_interface(void)
+{
+  static bool first_time = true;
+  static struct timeval t0;
+
+  if (first_time)
+    {
+      gettimeofday(&t0, NULL);
+      first_time = false;
+      return 0;
+    }
+  else
+    {
+      struct timeval t;
+      struct timeval delta;
+
+      gettimeofday(&t, NULL);
+      timersub(&t, &t0, &delta);
+      return delta.tv_sec * 1000 + delta.tv_usec / 1000;
+    }
+}

--- a/graphics/lvgl/lv_tick_interface.h
+++ b/graphics/lvgl/lv_tick_interface.h
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * graphics/lvgl/lv_tick_interface.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __LV_TICK_INTERFACE_H__
+#define __LV_TICK_INTERFACE_H__
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/time.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+uint32_t lv_tick_interface(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __LV_TICK_INTERFACE_H__


### PR DESCRIPTION
## Summary

This makes LVGL use malloc/free to handle its memory (instead of
their own memory handling) and supports a tick interface by which
LVGL can ask NuttX the elapsed time, instead of having to periodically
"tick" LVGL internal time in a thread.

## Impact

Improves integration with LVGL

## Testing

Sim with X11 framebuffer

