### PR TITLE
[BACKPORT #439] Update gs2200m daemon

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1129,7 +1129,6 @@ static int accept_request(int fd, FAR struct gs2200m_s *priv,
   struct gs2200m_accept_msg amsg;
   FAR struct usock_s *usock;
   FAR struct usock_s *new_usock = NULL;
-  struct sockaddr_in ep_addr;
   int ret = 0;
   int16_t usockid; /* usockid for new client */
 
@@ -1170,6 +1169,7 @@ static int accept_request(int fd, FAR struct gs2200m_s *priv,
 
   new_usock->cid   = amsg.cid;
   new_usock->state = CONNECTED;
+  new_usock->raddr = amsg.addr;
 
 prepare:
 
@@ -1182,8 +1182,8 @@ prepare:
 
   if (0 == ret)
     {
-      resp.reqack.result = 2; /* ep_addr + usock */
-      resp.valuelen_nontrunc = sizeof(ep_addr);
+      resp.reqack.result = 2; /* new_usock->raddr + usock */
+      resp.valuelen_nontrunc = sizeof(new_usock->raddr);
       resp.valuelen = resp.valuelen_nontrunc;
     }
   else
@@ -1205,11 +1205,7 @@ prepare:
     {
       /* Send address (value) */
 
-      /* TODO: ep_addr should be set */
-
-      memset(&ep_addr, 0, sizeof(ep_addr));
-
-      ret = _write_to_usock(fd, &ep_addr, resp.valuelen);
+      ret = _write_to_usock(fd, &new_usock->raddr, resp.valuelen);
 
       if (0 > ret)
         {

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1412,14 +1412,87 @@ err_out:
 }
 
 /****************************************************************************
- * Name: getsockname_request
+ * Name: getpeername_request
  ****************************************************************************/
 
 static int getpeername_request(int fd, FAR struct gs2200m_s *priv,
                                FAR void *hdrbuf)
 {
-  DEBUGASSERT(false);
-  return -ENOSYS;
+  FAR struct usrsock_request_getpeername_s *req = hdrbuf;
+  struct usrsock_message_datareq_ack_s resp;
+  FAR struct usock_s *usock;
+  int ret = 0;
+
+  DEBUGASSERT(priv);
+  DEBUGASSERT(req);
+
+  gs2200m_printf("%s: called **** \n", __func__);
+
+  /* Check if this socket exists. */
+
+  usock = gs2200m_socket_get(priv, req->usockid);
+
+  if (!usock)
+    {
+      ret = -EBADFD;
+      goto prepare;
+    }
+
+  if (CONNECTED != usock->state)
+    {
+      ret = -ENOTCONN;
+    }
+
+prepare:
+
+  /* Prepare response. */
+
+  memset(&resp, 0, sizeof(resp));
+  resp.reqack.xid = req->head.xid;
+  resp.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
+  resp.reqack.head.flags = 0;
+  resp.reqack.result = ret;
+
+  if (0 == ret)
+    {
+      resp.valuelen_nontrunc = sizeof(usock->raddr);
+      resp.valuelen = resp.valuelen_nontrunc;
+
+      if (resp.valuelen > req->max_addrlen)
+        {
+          resp.valuelen = req->max_addrlen;
+        }
+    }
+  else
+    {
+      resp.valuelen_nontrunc = 0;
+      resp.valuelen = 0;
+    }
+
+  /* Send response. */
+
+  ret = _write_to_usock(fd, &resp, sizeof(resp));
+
+  if (0 > ret)
+    {
+      goto err_out;
+    }
+
+  if (resp.valuelen > 0)
+    {
+      /* Send address (value) */
+
+      ret = _write_to_usock(fd, &usock->raddr, resp.valuelen);
+
+      if (0 > ret)
+        {
+          goto err_out;
+        }
+    }
+
+err_out:
+  gs2200m_printf("%s: end \n", __func__);
+  return ret;
 }
 
 /****************************************************************************

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1513,6 +1513,7 @@ static int ioctl_request(int fd, FAR struct gs2200m_s *priv,
 
   switch (req->cmd)
     {
+      case SIOCGIFADDR:
       case SIOCGIFHWADDR:
         getreq = true;
         break;

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -77,9 +77,11 @@ enum sock_state_e
 
 struct usock_s
 {
-  int8_t  type;
-  char    cid;
+  int8_t   type;
+  char     cid;
   enum sock_state_e state;
+  uint16_t lport;           /* local port */
+  struct sockaddr_in raddr; /* remote addr */
 };
 
 struct gs2200m_s
@@ -581,6 +583,35 @@ static int connect_request(int fd, FAR struct gs2200m_s *priv,
       goto prepare;
     }
 
+  memset(&cmsg, 0, sizeof(cmsg));
+
+  /* Check if this socket is already connected. */
+
+  if (BOUND == usock->state)
+    {
+      if (usock->type == SOCK_STREAM)
+        {
+          ret = -EISCONN;
+          goto prepare;
+        }
+      else
+        {
+          /* Firstly, close the socket */
+
+          struct gs2200m_close_msg clmsg;
+          memset(&clmsg, 0, sizeof(clmsg));
+          clmsg.cid = usock->cid;
+
+          ioctl(priv->gsfd, GS2200M_IOC_CLOSE, (unsigned long)&clmsg);
+
+          /* Copy the local port info */
+
+          cmsg.lport = usock->lport;
+
+          usock->state = OPENED;
+        }
+    }
+
   /* Check if address size ok. */
 
   if (req->addrlen > sizeof(addr))
@@ -622,6 +653,7 @@ static int connect_request(int fd, FAR struct gs2200m_s *priv,
     {
       usock->cid   = cmsg.cid;
       usock->state = CONNECTED;
+      usock->raddr = addr;
     }
   else
     {
@@ -704,26 +736,41 @@ static int sendto_request(int fd, FAR struct gs2200m_s *priv,
       goto prepare;
     }
 
+  memset(&smsg, 0, sizeof(smsg));
+
   smsg.is_tcp = (usock->type == SOCK_STREAM) ? true : false;
 
   /* For UDP, addlen must be provided */
 
-  if (usock->type == SOCK_DGRAM && CONNECTED != usock->state)
+  if (usock->type == SOCK_DGRAM)
     {
-      if (req->addrlen == 0)
+      if (CONNECTED != usock->state)
         {
-          ret = -EINVAL;
-          goto prepare;
+          if (req->addrlen == 0)
+            {
+              ret = -EINVAL;
+              goto prepare;
+            }
+
+          /* In UDP case, read the address. */
+
+          rlen = read(fd, &smsg.addr, sizeof(smsg.addr));
+
+          if (rlen < 0 || rlen < req->addrlen)
+            {
+              ret = -EFAULT;
+              goto prepare;
+            }
         }
-
-      /* In UDP case, read the address. */
-
-      rlen = read(fd, &smsg.addr, sizeof(smsg.addr));
-
-      if (rlen < 0 || rlen < req->addrlen)
+      else if (CONNECTED == usock->state)
         {
-          ret = -EFAULT;
-          goto prepare;
+          /* Copy remote address */
+
+          smsg.addr = usock->raddr;
+        }
+      else
+        {
+          ASSERT(false);
         }
 
       gs2200m_printf("%s: addr: %s:%d",
@@ -1007,7 +1054,8 @@ static int bind_request(int fd, FAR struct gs2200m_s *priv,
 
   if (0 == ret)
     {
-      usock->cid = bmsg.cid;
+      usock->cid   = bmsg.cid;
+      usock->lport = ntohs(addr.sin_port);
       usock->state = BOUND;
     }
 


### PR DESCRIPTION
## Summary
Backport of #439

    This PR updates the gs2200m daemon and consists of the following 4 commits
    commit 1: wireless: gs2200m: Fix to handle UDP connect() with bind()
        This commit fixes to handle UDP connect() with bind() to local port
        NOTE: GS2200M does not support TCP connect() with bind to local port
    commit 2: wireless: gs2200m: Fix to handle address info in accept()
        This commit fixes to handle address info in accept()
    commit 3: wireless: gs2200m: Implement getpeername_request()
        This commit adds getperrname_request() to gs2200m_main.c
    commit 4: wireless: gs2200m: Add support for ioctl(fd, SIOCGIFADDR, ...)
        This commit adds support for ioctl(fd, SIOCGIFADDR, ...) to gs2200m_main.c


