### PR TITLE
[BACKPORT #425] Remove all fclose with stdin, stdout and stder

### DIFF
--- a/examples/nxterm/nxterm_main.c
+++ b/examples/nxterm/nxterm_main.c
@@ -391,9 +391,6 @@ int main(int argc, FAR char *argv[])
   fflush(stdout);
   fflush(stderr);
 
-  fclose(stdout);
-  fclose(stderr);
-
   dup2(fd, 1);
   dup2(fd, 2);
 

--- a/graphics/nxwm/src/cnxterm.cxx
+++ b/graphics/nxwm/src/cnxterm.cxx
@@ -504,22 +504,10 @@ int CNxTerm::nxterm(int argc, char *argv[])
   std::fflush(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  std::fclose(stdin);
-#endif
-  std::fclose(stdout);
-  std::fclose(stderr);
-
-#ifdef CONFIG_NXTERM_NXKBDIN
   std::dup2(fd, 0);
 #endif
   std::dup2(fd, 1);
   std::dup2(fd, 2);
-
-#ifdef CONFIG_NXTERM_NXKBDIN
-  std::fdopen(0, "r");
-#endif
-  std::fdopen(1, "w");
-  std::fdopen(2, "w");
 
   // And we can close our original driver file descriptor
 

--- a/graphics/twm4nx/apps/cnxterm.cxx
+++ b/graphics/twm4nx/apps/cnxterm.cxx
@@ -418,22 +418,10 @@ int CNxTerm::nxterm(int argc, char *argv[])
   std::fflush(stderr);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  std::fclose(stdin);
-#endif
-  std::fclose(stdout);
-  std::fclose(stderr);
-
-#ifdef CONFIG_NXTERM_NXKBDIN
   std::dup2(fd, 0);
 #endif
   std::dup2(fd, 1);
   std::dup2(fd, 2);
-
-#ifdef CONFIG_NXTERM_NXKBDIN
-  std::fdopen(0, "r");
-#endif
-  std::fdopen(1, "w");
-  std::fdopen(2, "w");
 
   // And we can close our original driver file descriptor
 

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -78,9 +78,9 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
       return -ENODEV;
     }
 
-  /* Close stderr: we only close stderr if we opened the alternative one */
+  /* Flush stderr: we only flush stderr if we opened the alternative one */
 
-  fclose(stderr);
+  fflush(stderr);
 
   /* Associate the new opened file descriptor to stderr */
 
@@ -101,9 +101,9 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
       return -ENODEV;
     }
 
-  /* Close stdout: we only close stdout if we opened the alternative one */
+  /* Flush stdout: we only flush stdout if we opened the alternative one */
 
-  fclose(stdout);
+  fflush(stdout);
 
   /* Associate the new opened file descriptor to stdout */
 
@@ -122,7 +122,6 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
   pstate->cn_errstream = fdopen(pstate->cn_errfd, "a");
   if (!pstate->cn_errstream)
     {
-      close(pstate->cn_errfd);
       free(pstate);
       return -EIO;
     }
@@ -133,7 +132,6 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
   pstate->cn_outstream = fdopen(pstate->cn_outfd, "a");
   if (!pstate->cn_outstream)
     {
-      close(pstate->cn_outfd);
       free(pstate);
       return -EIO;
     }
@@ -202,10 +200,6 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
     }
   while (fd < 0);
 
-  /* Close stdin: we only closed stdin if we opened the alternative one */
-
-  fclose(stdin);
-
   /* Okay.. we have successfully opened the input device.  Did
    * we just re-open fd 0?
    */
@@ -225,7 +219,6 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
       pstate->cn_constream = fdopen(pstate->cn_confd, "r+");
       if (!pstate->cn_constream)
         {
-          close(pstate->cn_confd);
           free(pstate);
           return -EIO;
         }

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -77,31 +77,16 @@
 
 static void nsh_configstdio(int fd)
 {
-  /* Make sure the stdin, stdout, and stderr are closed */
+  /* Make sure the stdout, and stderr are flushed */
 
-  fclose(stdin);
-  fclose(stdout);
-  fclose(stderr);
+  fflush(stdout);
+  fflush(stderr);
 
   /* Dup the fd to create standard fd 0-2 */
 
   dup2(fd, 0);
   dup2(fd, 1);
   dup2(fd, 2);
-
-  /* fdopen to get the stdin, stdout and stderr streams. The following logic
-   * depends on the fact that the library layer will allocate FILEs in order.
-   * And since we closed stdin, stdout, and stderr above, that is what we
-   * should get.
-   *
-   * fd = 0 is stdin  (read-only)
-   * fd = 1 is stdout (write-only, append)
-   * fd = 2 is stderr (write-only, append)
-   */
-
-  fdopen(0, "r");
-  fdopen(1, "a");
-  fdopen(2, "a");
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Backports #425 
## Impact

## Testing

