### PR TITLE
Fix for sim:mount selftest failure

### DIFF
--- a/examples/mount/mount_main.c
+++ b/examples/mount/mount_main.c
@@ -761,11 +761,11 @@ int main(int argc, FAR char *argv[])
 
       /* Try rename() on the root directory. Should fail with EXDEV */
 
-      fail_rename(g_target, g_testdir4, EXDEV);
+      fail_rename(g_mntdir, g_testdir4, EXDEV);
 
-      /* Try rename() to an existing directory.  Should fail with EEXIST */
+      /* Try rename() to an existing directory.  Should fail with ENOENT */
 
-      fail_rename(g_testdir2, g_testdir3, EEXIST);
+      fail_rename(g_testdir4, g_testdir3, ENOENT);
 
       /* Try rename() to a non-existing directory.  Should succeed */
 


### PR DESCRIPTION
## Summary

Fix for NuttX [issue # 2089](https://github.com/apache/incubator-nuttx/issues/2089).

## Impact

Ideally, this should fix the selftest issue for sim:mount configuration. Selftest should now complete without any errors.

Changed g_target to g_mntdir as g_target and g_testdir4 are on the same filesystem, a prerequisite for EXDEV.

`fail_rename(g_mntdir, g_testdir4, EXDEV);`

Also, changed error type `EEXIST` to `ENOENT` for the second `fail_rename()` call.

## Testing

To be tested for sim:mount configuration. Ideally, the test should now run without any issues.