### PR TITLE
libuv/adb: add gitignore files

### DIFF
--- a/system/adb/.gitignore
+++ b/system/adb/.gitignore
@@ -1,0 +1,1 @@
+microADB

--- a/system/libuv/.gitignore
+++ b/system/libuv/.gitignore
@@ -1,1 +1,3 @@
 /Kconfig
+libuv-*
+*.zip


### PR DESCRIPTION
## Summary

Add missing gitignore files for libuv and adb builds

## Impact

## Testing

