### PR TITLE
Remove deprecated usage of set-env in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           command: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
 
       - name: Export NuttX Repo SHA
-        run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+        run:  echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Refresh Git Credentials
         uses: actions/checkout@v2
         with:
@@ -189,7 +189,7 @@ jobs:
           key: ${{ runner.os }}-tools-${{ hashFiles('./sources/testing/cibuild.sh') }}
 
       - name: Export NuttX Repo SHA
-        run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+        run:  echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Refresh Git Credentials
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Summary
Remove deprecated usage of set-env in GitHub Actions workflow
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## Impact

## Testing
CI
