### PR TITLE
wireless/wapi: add channel frequency set during associate

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -258,6 +258,8 @@ struct wpa_wconfig_s
                                   * IW_AUTH_CIPHER_CCMP */
   uint8_t alg;                   /* See enum wpa_alg_e above, e.g.
                                   * WPA_ALG_CCMP */
+  double freq;                   /* Channel frequency */
+  enum wapi_freq_flag_e flag;    /* Channel frequency flag */
   uint8_t ssidlen;               /* Length of the SSID */
   uint8_t phraselen;             /* Length of the passphrase */
   FAR const char *ifname;        /* E.g., "wlan0" */

--- a/wireless/wapi/src/driver_wext.c
+++ b/wireless/wapi/src/driver_wext.c
@@ -279,6 +279,18 @@ int wpa_driver_wext_associate(FAR struct wpa_wconfig_s *wconfig)
       goto close_socket;
     }
 
+  if (wconfig->freq)
+    {
+      ret = wapi_set_freq(sockfd, wconfig->ifname,
+                          wconfig->freq,
+                          wconfig->flag == WAPI_FREQ_FIXED ?
+                          IW_FREQ_FIXED : IW_FREQ_AUTO);
+      if (ret < 0)
+        {
+          nerr("WARNING: Fail set freq: %d\n", ret);
+        }
+    }
+
   if (wconfig->phraselen > 0)
     {
       ret = wpa_driver_wext_set_key_ext(sockfd, wconfig->ifname,
@@ -292,20 +304,25 @@ int wpa_driver_wext_associate(FAR struct wpa_wconfig_s *wconfig)
         }
     }
 
+  if (wconfig->ssid)
+    {
+      ret = wapi_set_essid(sockfd, wconfig->ifname,
+                           wconfig->ssid, WAPI_ESSID_ON);
+      if (ret < 0)
+        {
+          nerr("ERROR: Fail set ssid: %d\n", ret);
+          goto close_socket;
+        }
+    }
+
   if (wconfig->bssid)
     {
       ret = wapi_set_ap(sockfd, wconfig->ifname,
                         (FAR const struct ether_addr *)wconfig->bssid);
-    }
-  else
-    {
-      ret = wapi_set_essid(sockfd, wconfig->ifname, wconfig->ssid,
-                           WAPI_ESSID_ON);
-    }
-
-  if (ret < 0)
-    {
-      nerr("ERROR: Fail set ssid: %d\n", ret);
+      if (ret < 0)
+        {
+          nerr("ERROR: Fail set bssid: %d\n", ret);
+        }
     }
 
 close_socket:


### PR DESCRIPTION


## Summary

wireless/wapi: add channel frequency set during associate

## Impact

Therefore, the associate can support the connection of specified
channel if the scan results contain the multiple AP with same essids.

Change-Id: I4e657c52e638693e7ae19aea2a4fe8a431885547
Signed-off-by: chao.an <anchao@xiaomi.com>

## Testing

associate with specified channel frequency.