### PR TITLE
Fix for file naming issue for sim:nxffs configuration

### DIFF
--- a/testing/nxffs/nxffs_main.c
+++ b/testing/nxffs/nxffs_main.c
@@ -205,7 +205,7 @@ static inline char nxffs_randchar(void)
   int value = rand() % 63;
   if (value == 0)
     {
-      return '/';
+      return '0';
     }
   else if (value <= 10)
     {


### PR DESCRIPTION
## Summary
Fix for the file naming issue in `sim:nxffs` configuration. Without this change, it generates file names like below -

`File name: /mnt/nxffs/EVwni/b4A/BqjDc42RCtKvjJ6DInifZ0tME26XGRXWl5ZAE`

of which the filename part is `EVwni/b4A/BqjDc42RCtKvjJ6DInifZ0tME26XGRXWl5ZAE` which is pretty confusing.

## Impact

No impact on functionality. This fix does NOT resolve [issue # 2092](https://github.com/apache/incubator-nuttx/issues/2092), though it could be a step in the right direction.

## Testing

No impact on functionality.