### PR TITLE
graphics/nxwm/src/chexcalculator.cxx: Fix typos

### DIFF
--- a/graphics/nxwm/src/chexcalculator.cxx
+++ b/graphics/nxwm/src/chexcalculator.cxx
@@ -673,11 +673,11 @@ void CHexCalculator::updateText(void)
 
   if (m_hexMode)
     {
-      std::snprintf(buffer, 24, "%16" PRI64X, m_accum);
+      std::snprintf(buffer, 24, "%16" PRIX64, m_accum);
     }
   else
     {
-      std::snprintf(buffer, 24, "%" PRI64d, m_accum);
+      std::snprintf(buffer, 24, "%" PRId64, m_accum);
     }
 
   // setText will perform the redraw as well


### PR DESCRIPTION
Typos in the following change:

    commit c48e65414b1fe1172029d6f041d615fa438cb320
    Author: YAMAMOTO Takashi <yamamoto@midokura.com>
    Date:   Mon Nov 16 14:16:46 2020 +0900

        graphics/nxwm/src/chexcalculator.cxx: Fix printf format warnings

## Summary

## Impact

## Testing

