### PR TITLE
examples/cctye: change std::isascii to isascii

### DIFF
--- a/examples/cctype/cctype_main.cxx
+++ b/examples/cctype/cctype_main.cxx
@@ -61,7 +61,7 @@ extern "C"
           int lower = std::tolower(i);
           std::printf("%3d %c %d %d %d %d %d %d %d %d %d %d %d %d %d %c %c\n",
                       i, std::isprint(i) ? i : '.',
-                      std::isspace(i), std::isascii(i), std::isprint(i), std::isgraph(i),
+                      std::isspace(i), isascii(i)     , std::isprint(i), std::isgraph(i),
                       std::iscntrl(i), std::islower(i), std::isupper(i), std::isalpha(i),
                       std::isblank(i), std::isdigit(i), std::isalnum(i), std::ispunct(i),
                       std::isxdigit(i),


### PR DESCRIPTION
## Summary
since isascii isn't a standard defined function and then
may not exist in all cctype header file(e.g. libc++):
```
cctype_main.cxx: In function 'int cctype_main(int, char**)':
cctype_main.cxx:64:45: error: 'isascii' is not a member of 'std'; did you mean 'isascii'?
   64 |                       std::isspace(i), std::isascii(i), std::isprint(i), std::isgraph(i),
      |                                             ^~~~~~~
```

## Impact

## Testing

