### PR TITLE
examples/i2schar: Fix the compile error

### DIFF
--- a/examples/i2schar/i2schar_main.c
+++ b/examples/i2schar/i2schar_main.c
@@ -115,10 +115,10 @@ static void i2schar_help(FAR struct i2schar_state_s *i2schar)
          "Default: %d Current: %d\n",
          CONFIG_EXAMPLES_I2SCHAR_TXBUFFERS, i2schar->txcount);
 #endif
-#ifdef CONFIG_EXAMPLES_I2SCHAR_TX
+#ifdef CONFIG_EXAMPLES_I2SCHAR_RX
   printf("  [-r count] selects the number of audio buffers to receive.  "
          "Default: %d Current: %d\n",
-         CONFIG_EXAMPLES_I2SCHAR_RXBUFFERS, i2schar->txcount);
+         CONFIG_EXAMPLES_I2SCHAR_RXBUFFERS, i2schar->rxcount);
 #endif
   printf("  [-h] shows this message and exits\n");
 }
@@ -188,6 +188,7 @@ static void parse_args(FAR struct i2schar_state_s *i2schar,
             index += nargs;
             break;
 
+#ifdef CONFIG_EXAMPLES_I2SCHAR_RX
           case 'r':
             nargs = arg_decimal(&argv[index], &value);
             if (value < 0)
@@ -199,7 +200,9 @@ static void parse_args(FAR struct i2schar_state_s *i2schar,
             i2schar->rxcount = (uint32_t)value;
             index += nargs;
             break;
+#endif
 
+#ifdef CONFIG_EXAMPLES_I2SCHAR_TX
           case 't':
             nargs = arg_decimal(&argv[index], &value);
             if (value < 0)
@@ -211,6 +214,7 @@ static void parse_args(FAR struct i2schar_state_s *i2schar,
             i2schar->txcount = (uint32_t)value;
             index += nargs;
             break;
+#endif
 
           case 'h':
             i2schar_help(i2schar);
@@ -248,6 +252,8 @@ int main(int argc, FAR char *argv[])
 #endif
   int ret;
 
+  UNUSED(ret);
+
   /* Check if we have initialized */
 
   if (!g_i2schar.initialized)
@@ -272,7 +278,8 @@ int main(int argc, FAR char *argv[])
 
 #ifdef CONFIG_EXAMPLES_I2SCHAR_TX
       g_i2schar.txcount = CONFIG_EXAMPLES_I2SCHAR_TXBUFFERS;
-#else
+#endif
+#ifdef CONFIG_EXAMPLES_I2SCHAR_RX
       g_i2schar.rxcount = CONFIG_EXAMPLES_I2SCHAR_RXBUFFERS;
 #endif
 


### PR DESCRIPTION
## Summary
2schar_main.c: In function 'parse_args':
i2schar_main.c:199:20: error: 'struct i2schar_state_s' has no member named 'rxcount'
  199 |             i2schar->rxcount = (uint32_t)value;
      |                    ^~
i2schar_main.c:211:20: error: 'struct i2schar_state_s' has no member named 'txcount'
  211 |             i2schar->txcount = (uint32_t)value;
      |                    ^~
i2schar_main.c: In function 'i2schar_main':
i2schar_main.c:276:16: error: 'struct i2schar_state_s' has no member named 'rxcount'
  276 |       g_i2schar.rxcount = CONFIG_EXAMPLES_I2SCHAR_RXBUFFERS;
      |                ^

## Impact

## Testing

