### PR TITLE
examples/mld: Fix undefined reference to `mld_catfile'

### DIFF
--- a/examples/mld/mld_main.c
+++ b/examples/mld/mld_main.c
@@ -251,7 +251,7 @@ void mld_catfile(FAR const char *filepath, FAR char **iobuffer)
 #ifdef HAVE_PROC_NET_STATS
 #  define mld_dumpstats(iobuffer) mld_catfile(PROCFS_MLD_PATH, iobuffer)
 #else
-#  define mld_dumpstats(iobuffer) mld_catfile(PROCFS_MLD_PATH, iobuffer)
+#  define mld_dumpstats(iobuffer)
 #endif
 
 #ifdef HAVE_PROC_NET_ROUTE


### PR DESCRIPTION
## Summary

## Impact

## Testing

