### PR TITLE
LVGL: use NuttX's printf()

### DIFF
--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -86,8 +86,8 @@ endif
 
 MAINSRC = lvgldemo.c
 
-CFLAGS += ${shell $(DEFINE) "$(CC)" LV_LVGL_H_INCLUDE_SIMPLE}
-CXXFLAGS += ${shell $(DEFINE) "$(CC)" LV_LVGL_H_INCLUDE_SIMPLE}
+CFLAGS += ${shell $(DEFINE) "$(CC)" LV_LVGL_H_INCLUDE_SIMPLE} -Wno-format
+CXXFLAGS += ${shell $(DEFINE) "$(CC)" LV_LVGL_H_INCLUDE_SIMPLE} -Wno-format
 
 $(LVGL_EXAMPLES_TARBALL):
 	@echo "Downloading: $(LVGL_EXAMPLES_TARBALL)"

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -40,6 +40,10 @@ include $(APPDIR)/Make.defs
 LVGL_DIR = .
 LVGL_DIR_NAME = lvgl
 
+# Relax format check for LVGL to avoid errors on prinf() use
+
+CFLAGS += -Wno-format
+
 # LVGL Libraries
 
 -include ./lvgl/src/lv_core/lv_core.mk

--- a/graphics/lvgl/lv_conf.h
+++ b/graphics/lvgl/lv_conf.h
@@ -753,7 +753,7 @@ typedef void * lv_font_user_data_t;
 
 /* Change the built in (v)snprintf functions */
 
-#define LV_SPRINTF_CUSTOM   0
+#define LV_SPRINTF_CUSTOM   1
 #if LV_SPRINTF_CUSTOM
 #  define LV_SPRINTF_INCLUDE <stdio.h>
 #  define lv_snprintf     snprintf


### PR DESCRIPTION
## Summary

This makes LVGL use NuttX's printf facilities instead of its own

## Impact

LVGL

## Testing

Various LVGL configs
