### PR TITLE
examples/pwm: fix help message

### DIFF
--- a/examples/pwm/pwm_main.c
+++ b/examples/pwm/pwm_main.c
@@ -202,6 +202,7 @@ static void pwm_help(FAR struct pwm_state_s *pwm)
     {
       printf(" %d", pwm->channels[i]);
     }
+
   printf("\n");
 
   printf("  [[-d duty1] [[-d duty2] ...]] "
@@ -217,6 +218,7 @@ static void pwm_help(FAR struct pwm_state_s *pwm)
     {
       printf(" %d %%", pwm->duties[i]);
     }
+
   printf("\n");
 #else
   printf("  [-d duty] selects the pulse duty as a percentage.  "

--- a/examples/pwm/pwm_main.c
+++ b/examples/pwm/pwm_main.c
@@ -192,30 +192,32 @@ static void pwm_help(FAR struct pwm_state_s *pwm)
   printf("  [[-c channel1] [[-c channel2] ...]] "
          "selects the channel number for each channel.  ");
   printf("Default:");
-  for (i = 0; i < CONFIG_PWM_MULTICHAN; i++)
+  for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       printf(" %d", channels[i]);
     }
 
-  printf("Current:");
-  for (i = 0; i < CONFIG_PWM_MULTICHAN; i++)
+  printf(" Current:");
+  for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       printf(" %d", pwm->channels[i]);
     }
+  printf("\n");
 
   printf("  [[-d duty1] [[-d duty2] ...]] "
          "selects the pulse duty as a percentage.  ");
   printf("Default:");
-  for (i = 0; i < CONFIG_PWM_MULTICHAN; i++)
+  for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       printf(" %d %%", duties[i]);
     }
 
-  printf("Current:");
-  for (i = 0; i < CONFIG_PWM_MULTICHAN; i++)
+  printf(" Current:");
+  for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       printf(" %d %%", pwm->duties[i]);
     }
+  printf("\n");
 #else
   printf("  [-d duty] selects the pulse duty as a percentage.  "
          "Default: %d %% Current: %d %%\n",


### PR DESCRIPTION
## Summary
- Fix bug for multiple PWM outputs (CONFIG_PWM_MULTICHAN). Wrong define
was in use and only the information about the first channel was shown.
- Fix formatting (a few line breaks and spaces missing).

## Impact
Only the help message modified. It was very confusing before because only one channel was shown, but it shouldn't impact anything else.

## Testing
Built and tested.

Thanks!

