### PR TITLE
wireless/wapi: do not associate with essid/bssid at same time

### DIFF
--- a/wireless/wapi/src/driver_wext.c
+++ b/wireless/wapi/src/driver_wext.c
@@ -315,8 +315,7 @@ int wpa_driver_wext_associate(FAR struct wpa_wconfig_s *wconfig)
           goto close_socket;
         }
     }
-
-  if (wconfig->bssid)
+  else if (wconfig->bssid)
     {
       ret = wapi_set_ap(sockfd, wconfig->ifname,
                         (FAR const struct ether_addr *)wconfig->bssid);


### PR DESCRIPTION
## Summary

wireless/wapi: do not associate with essid/bssid at same time

bssid is a associate trigger point of connection in some drivers.

## Impact

wapi save/reconnect
CONFIG_NETINIT

## Testing

wapi save/reconnect
CONFIG_NETINIT
