### PR TITLE
system/adb: fix shell issue and add reboot feature

### DIFF
--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -22,7 +22,7 @@ include $(APPDIR)/Make.defs
 
 ADB_DIR := $(APPDIR)/system/adb
 CONFIG_ADBD_URL ?= "https://github.com/spiriou/microADB.git"
-CONFIG_ADBD_VERSION ?= bbd1e74bd795aa2fc53eae2b76bff993d6ccaa37
+CONFIG_ADBD_VERSION ?= b7025c67b866925d1e64c016a844a6a3392557a4
 
 ADB_UNPACKNAME := microADB
 ADB_UNPACKDIR := $(ADB_DIR)/$(ADB_UNPACKNAME)

--- a/system/adb/adb_main.c
+++ b/system/adb/adb_main.c
@@ -46,6 +46,15 @@ void adb_log_impl(FAR const char *func, int line, FAR const char *fmt, ...)
   va_end(ap);
 }
 
+void adb_reboot_impl(const char *target)
+{
+#ifdef CONFIG_BOARDCTL_RESET
+  boardctl(BOARDIOC_RESET, 0);
+#else
+  adb_log("reboot not implemented\n");
+#endif
+}
+
 int main(int argc, FAR char **argv)
 {
   UNUSED(argc);

--- a/system/adb/shell_service.c
+++ b/system/adb/shell_service.c
@@ -199,11 +199,14 @@ adb_service_t * shell_service(adb_client_t *client, const char *params)
   ret = shell_pipe_exec(argv, &service->pipe,
                         exec_on_data_available);
 
-  /* TODO check return code */
-
-  assert(ret == 0);
-
   free(argv);
+
+  if (ret)
+    {
+      adb_log("failed to setup shell pipe %d\n", ret);
+      free(service);
+      return NULL;
+    }
 
   return &service->service;
 }


### PR DESCRIPTION
## Summary

- Fix memory leak due to stdout pipe endpoint not closed
- Add support for "adb reboot [target]" command

## Impact

## Testing

