### PR TITLE
fix build bread if CONFIG_AUDIO_MULTI_SESSION enabled

### DIFF
--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -534,7 +534,7 @@ err_out:
           if (pbuffers[x] != NULL)
             {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-              buf_desc.session = pplayer->session;
+              buf_desc.session = precorder->session;
 #endif
               buf_desc.u.buffer = pbuffers[x];
               ioctl(precorder->dev_fd,


### PR DESCRIPTION

Change-Id: I785f44a4381965df700000cbd33faeb2d2e24f6e
Signed-off-by: danguanghua <danguanghua@xiaomi.com>

## Summary

## Impact

## Testing

