### PR TITLE
nshlib: Fix nsh_usbconsole.c

### DIFF
--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -75,7 +75,7 @@
  *
  ****************************************************************************/
 
-static void nsh_configstdio(int fd, FAR struct console_stdio_s *pstate)
+static void nsh_configstdio(int fd)
 {
   /* Make sure the stdout, and stderr are flushed */
 
@@ -88,15 +88,16 @@ static void nsh_configstdio(int fd, FAR struct console_stdio_s *pstate)
   dup2(fd, 1);
   dup2(fd, 2);
 
-  /* Setup the stdout */
+  /* fdopen to get the stdin, stdout and stderr streams.
+   *
+   * fd = 0 is stdin  (read-only)
+   * fd = 1 is stdout (write-only, append)
+   * fd = 2 is stderr (write-only, append)
+   */
 
-  pstate->cn_outfd     = 1;
-  pstate->cn_outstream = fdopen(1, "a");
-
-  /* Setup the stderr */
-
-  pstate->cn_errfd     = 2;
-  pstate->cn_errstream = fdopen(2, "a");
+  fdopen(0, "r");
+  fdopen(1, "a");
+  fdopen(2, "a");
 }
 
 /****************************************************************************
@@ -107,7 +108,7 @@ static void nsh_configstdio(int fd, FAR struct console_stdio_s *pstate)
  *
  ****************************************************************************/
 
-static int nsh_nullstdio(FAR struct console_stdio_s *pstate)
+static int nsh_nullstdio(void)
 {
   int fd;
 
@@ -118,7 +119,7 @@ static int nsh_nullstdio(FAR struct console_stdio_s *pstate)
     {
       /* Configure standard I/O to use /dev/null */
 
-      nsh_configstdio(fd, pstate);
+      nsh_configstdio(fd);
 
       /* We can close the original file descriptor now (unless it was one of
        * 0-2)
@@ -224,7 +225,7 @@ restart:
 
   /* Configure standard I/O */
 
-  nsh_configstdio(fd, pstate);
+  nsh_configstdio(fd);
 
   /* We can close the original file descriptor (unless it was one of 0-2) */
 
@@ -306,7 +307,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
   /* Configure to use /dev/null if we do not have a valid console. */
 
 #ifndef CONFIG_DEV_CONSOLE
-  nsh_nullstdio(pstate);
+  nsh_nullstdio();
 #endif
 
   /* Execute the one-time start-up script (output may go to /dev/null) */
@@ -347,7 +348,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
        * valid console device.
        */
 
-      nsh_nullstdio(pstate);
+      nsh_nullstdio();
     }
 }
 


### PR DESCRIPTION
## Summary

- stdin/stdout/stderr are now preallocated in libc and fs_fd
  in file_struct are also initialized to -1
- So we need to call fdopen() for stdin again as we did before.
- Also, cn_outstream and cn_errstream are not needed to be set.
- See apps/nshlib/nsh_console.h as well

## Impact

- nsh_usbconsole.c only

## Testing

- Tested with stm32f4discovery:usbnsh
