### PR TITLE
system: nxplayer and nxrecorder shouldn't hardcode message length to 16

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -791,12 +791,12 @@ static void *nxplayer_playthread(pthread_addr_t pvarg)
 
   audinfo("Entry\n");
 
-  /* Query the audio device for it's preferred buffer size / qty */
+  /* Query the audio device for its preferred buffer size / qty */
 
   if ((ret = ioctl(pplayer->dev_fd, AUDIOIOC_GETBUFFERINFO,
           (unsigned long) &buf_info)) != OK)
     {
-      /* Driver doesn't report it's buffer size.  Use our default. */
+      /* Driver doesn't report its buffer size.  Use our default. */
 
       buf_info.buffer_size = CONFIG_AUDIO_BUFFER_NUMBYTES;
       buf_info.nbuffers = CONFIG_AUDIO_NUM_BUFFERS;
@@ -1797,6 +1797,7 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
   pthread_attr_t      tattr;
   FAR void           *value;
   struct audio_caps_desc_s cap_desc;
+  struct ap_buffer_info_s  buf_info;
 #ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
   char                path[128];
 #endif
@@ -1932,9 +1933,19 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
       ioctl(pplayer->dev_fd, AUDIOIOC_CONFIGURE, (unsigned long)&cap_desc);
     }
 
+  /* Query the audio device for its preferred buffer count */
+
+  if (ioctl(pplayer->dev_fd, AUDIOIOC_GETBUFFERINFO,
+            (unsigned long)&buf_info) != OK)
+    {
+      /* Driver doesn't report its buffer size.  Use our default. */
+
+      buf_info.nbuffers = CONFIG_AUDIO_NUM_BUFFERS;
+    }
+
   /* Create a message queue for the playthread */
 
-  attr.mq_maxmsg  = 16;
+  attr.mq_maxmsg  = buf_info.nbuffers + 8;
   attr.mq_msgsize = sizeof(struct audio_msg_s);
   attr.mq_curmsgs = 0;
   attr.mq_flags   = 0;

--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -242,12 +242,12 @@ static void *nxrecorder_recordthread(pthread_addr_t pvarg)
 
   audinfo("Entry\n");
 
-  /* Query the audio device for it's preferred buffer size / qty */
+  /* Query the audio device for its preferred buffer size / qty */
 
   if ((ret = ioctl(precorder->dev_fd, AUDIOIOC_GETBUFFERINFO,
           (unsigned long) &buf_info)) != OK)
     {
-      /* Driver doesn't report it's buffer size.  Use our default. */
+      /* Driver doesn't report its buffer size.  Use our default. */
 
       buf_info.buffer_size = CONFIG_AUDIO_BUFFER_NUMBYTES;
       buf_info.nbuffers = CONFIG_AUDIO_NUM_BUFFERS;
@@ -773,6 +773,7 @@ int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
   struct sched_param       sparam;
   pthread_attr_t           tattr;
   struct audio_caps_desc_s cap_desc;
+  struct ap_buffer_info_s  buf_info;
   FAR void                 *value;
   int                      ret;
 
@@ -844,9 +845,19 @@ int nxrecorder_recordraw(FAR struct nxrecorder_s *precorder,
       goto err_out;
     }
 
+  /* Query the audio device for its preferred buffer count */
+
+  if (ioctl(precorder->dev_fd, AUDIOIOC_GETBUFFERINFO,
+            (unsigned long)&buf_info) != OK)
+    {
+      /* Driver doesn't report its buffer size.  Use our default. */
+
+      buf_info.nbuffers = CONFIG_AUDIO_NUM_BUFFERS;
+    }
+
   /* Create a message queue for the recordthread */
 
-  attr.mq_maxmsg  = 16;
+  attr.mq_maxmsg  = buf_info.nbuffers + 8;
   attr.mq_msgsize = sizeof(struct audio_msg_s);
   attr.mq_curmsgs = 0;
   attr.mq_flags   = 0;


### PR DESCRIPTION
## Summary
the audio driver may config a very large buffer count,
so let's adjust the message queue length dynamically.

## Impact
Should no impact on the normal case.

## Testing

