### PR TITLE
nshlib: Remove fdopen for the stdin, stdout and stderr

### DIFF
--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -481,29 +481,6 @@ FAR struct console_stdio_s *nsh_newconsole(void)
       pstate->cn_vtbl.redirect    = nsh_consoleredirect;
       pstate->cn_vtbl.undirect    = nsh_consoleundirect;
 
-#if 0
-      /* (Re-) open the console input device */
-
-#ifdef CONFIG_NSH_ALTCONDEV
-      pstate->cn_confd            = open(CONFIG_NSH_ALTSTDIN, O_RDWR);
-      if (pstate->cn_confd < 0)
-        {
-          free(pstate);
-          return NULL;
-        }
-
-      /* Create a standard C stream on the console device */
-
-      pstate->cn_constream = fdopen(pstate->cn_confd, "r+");
-      if (!pstate->cn_constream)
-        {
-          close(pstate->cn_confd);
-          free(pstate);
-          return NULL;
-        }
-#endif
-#endif /* if 0 */
-
       /* Initialize the error stream */
 
       pstate->cn_errfd            = ERRFD(pstate);

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -87,17 +87,6 @@ static void nsh_configstdio(int fd)
   dup2(fd, 0);
   dup2(fd, 1);
   dup2(fd, 2);
-
-  /* fdopen to get the stdin, stdout and stderr streams.
-   *
-   * fd = 0 is stdin  (read-only)
-   * fd = 1 is stdout (write-only, append)
-   * fd = 2 is stderr (write-only, append)
-   */
-
-  fdopen(0, "r");
-  fdopen(1, "a");
-  fdopen(2, "a");
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
not really need since these file stream should be opened automatically.
Need work with https://github.com/apache/incubator-nuttx/pull/2540.
See the discussion here: #521

## Impact
Handle the usb console in a more standardized way

## Testing
Need tested with https://github.com/apache/incubator-nuttx/pull/2540
