### PR TITLE
system: adb: Fix compile issues in adb_main.c

### DIFF
--- a/system/adb/adb_main.c
+++ b/system/adb/adb_main.c
@@ -24,8 +24,8 @@
 
 #include "adb.h"
 
-#ifdef CONFIG_ADBD_BOARD_INIT
-#include <sys/boardctl.h>
+#if defined(CONFIG_ADBD_BOARD_INIT) || defined (CONFIG_BOARDCTL_RESET)
+#  include <sys/boardctl.h>
 #endif
 
 #ifdef CONFIG_ADBD_NET_INIT


### PR DESCRIPTION
## Summary

- This commit fixes compile issues for the following condition
- CONFIG_ADBD_BOARD_INIT=n && CONFIG_BOARDCTL_RESET=y

## Impact

- adb only

## Testing

- Tested with stm32f4discovery:adb (not pushed yet)
