### PR TITLE
nimble: point to upstream, improve Makefile

### DIFF
--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -23,25 +23,31 @@ include $(APPDIR)/Make.defs
 PRIORITY  = 255
 STACKSIZE = 16384
 
-NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/mynewt-nimble
+NIMBLE_UNPACKDIR = mynewt-nimble
+NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/$(NIMBLE_UNPACKDIR)
 
 -include $(NIMBLE_ROOT)/porting/examples/nuttx/Make.defs
 
+CONFIG_NIMBLE_REF := $(patsubst "%",%,$(strip $(CONFIG_NIMBLE_REF)))
 NIMBLE_TAR := $(CONFIG_NIMBLE_REF).tar.gz
-NIMBLE_URL := https://github.com/v01d/mynewt-nimble/archive/$(NIMBLE_TAR)
+NIMBLE_URL := https://github.com/apache/mynewt-nimble/archive/$(NIMBLE_TAR)
 
 $(NIMBLE_TAR):
 	wget $(NIMBLE_URL) -O $(NIMBLE_TAR)
 
-$(NIMBLE_ROOT): $(NIMBLE_TAR)
-	tar zxf $(NIMBLE_TAR)
-	mv mynewt-nimble-$(CONFIG_NIMBLE_REF) mynewt-nimble
+$(NIMBLE_UNPACKDIR): $(NIMBLE_TAR)
+	$(Q) tar zxf $(NIMBLE_TAR)
+	$(Q) mv mynewt-nimble-$(CONFIG_NIMBLE_REF) $(NIMBLE_UNPACKDIR)
+	$(Q) touch $(NIMBLE_UNPACKDIR)
 
-context:: $(NIMBLE_ROOT)
+context:: $(NIMBLE_UNPACKDIR)
 
 distclean::
-	$(call CLEAN,$(NIMBLE_TAR))
-	$(call DELDIR,$(NIMBLE_ROOT))
+	$(call DELFILE,$(NIMBLE_TAR))
+	$(call DELDIR,$(NIMBLE_UNPACKDIR))
 
+# nimBLE assumes this flag since it expects undefined macros to be zero value
+
+CFLAGS += -Wno-undef
 
 include $(APPDIR)/Application.mk

--- a/wireless/bluetooth/nimble/README.md
+++ b/wireless/bluetooth/nimble/README.md
@@ -29,7 +29,7 @@ So, first is to get the newt tool:
 At the moment, you will probably require unstable version
 instead of a release so select a known working:
 
-  $ git checkout 0fcf17566c40
+  $ git checkout c14c47bb683d
   $ ./build.sh
 
 There should be now a `newt` binary under `mynewt-newt/newt`.


### PR DESCRIPTION
## Summary

Since NuttX is now officially supported in nimBLE (https://github.com/apache/mynewt-nimble/pull/878) this makes the Makefile
point to official repo instead of my fork. I also fixed some issues with handling of the downloaded tarball.

Once this is merged, I will refresh https://github.com/apache/incubator-nuttx/pull/2129 which will complete integration of nimBLE into NuttX.

## Impact

fix/update nimBLE app

## Testing

sim:nimble (to be provided)