### PR TITLE
system: enable O_CLOEXEC when openning audio device

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -310,7 +310,7 @@ static int nxplayer_opendevice(FAR struct nxplayer_s *pplayer, int format,
 
       /* Device supports the format.  Open the device file. */
 
-      pplayer->dev_fd = open(pplayer->prefdevice, O_RDWR);
+      pplayer->dev_fd = open(pplayer->prefdevice, O_RDWR | O_CLOEXEC);
       if (pplayer->dev_fd == -1)
         {
           int errcode = errno;
@@ -380,7 +380,7 @@ static int nxplayer_opendevice(FAR struct nxplayer_s *pplayer, int format,
           snprintf(path,  sizeof(path), "/dev/audio/%s", pdevice->d_name);
 #endif /* CONFIG_AUDIO_CUSTOM_DEV_PATH */
 
-          if ((pplayer->dev_fd = open(path, O_RDWR)) != -1)
+          if ((pplayer->dev_fd = open(path, O_RDWR | O_CLOEXEC)) != -1)
             {
               /* We have the device file open.  Now issue an AUDIO ioctls to
                * get the capabilities
@@ -2367,7 +2367,7 @@ int nxplayer_systemreset(FAR struct nxplayer_s *pplayer)
 #else
       snprintf(path,  sizeof(path), "/dev/audio/%s", pdevice->d_name);
 #endif
-      if ((pplayer->dev_fd = open(path, O_RDWR)) != -1)
+      if ((pplayer->dev_fd = open(path, O_RDWR | O_CLOEXEC)) != -1)
         {
           /* We have the device file open.  Now issue an
            * AUDIO ioctls to perform a HW reset

--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -88,7 +88,7 @@ static int nxrecorder_opendevice(FAR struct nxrecorder_s *precorder)
 
       /* Device supports the format.  Open the device file. */
 
-      precorder->dev_fd = open(precorder->device, O_RDWR);
+      precorder->dev_fd = open(precorder->device, O_RDWR | O_CLOEXEC);
       if (precorder->dev_fd == -1)
         {
           int errcode = errno;


### PR DESCRIPTION
to avoid multiple open operations of audio_open

Change-Id: Id283def4811c71f3c0bd38dc1a480afce303c4c3
Signed-off-by: danguanghua <danguanghua@xiaomi.com>

## Summary

## Impact

## Testing

