### PR TITLE
nimble: fix wrong git ref name to use

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -9,7 +9,7 @@ config NIMBLE
 if NIMBLE
   config NIMBLE_REF
   string "Version"
-  default "nuttx"
+  default "master"
   ---help---
     Git ref name to use when downloading from nimBLE repo
 endif


### PR DESCRIPTION
## Summary

Last PR #528 missed a change, where the branch name to use is no longer "nuttx". For now "master" it is used until next stable release of nimBLE is available, where a tag name will be used instead.

## Impact

Allow building nimBLE

## Testing

sim:nimble (to be provided)

