### PR TITLE
interpreters/wamr: Support latest snapshot for main branch

### DIFF
--- a/interpreters/wamr/.gitignore
+++ b/interpreters/wamr/.gitignore
@@ -1,2 +1,3 @@
-*.tar.gz
+*.zip
 wamr
+wasm-micro-runtime-*

--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -14,7 +14,7 @@ config INTERPRETERS_WAMR_VERSION
 	string "WAMR Version"
 	default "09-29-2020"
 	---help---
-	Version 09-29-2020 and later supported.
+	Version 09-29-2020 and later (include main) supported.
 
 config INTERPRETERS_WAMR_PRIORITY
 	int "Webassembly Micro Runtime priority"

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -22,7 +22,17 @@ include $(APPDIR)/Make.defs
 
 WAMR_VERSION  = $(patsubst "%",%,$(strip $(CONFIG_INTERPRETERS_WAMR_VERSION)))
 WAMR_UNPACK   = wamr
-WAMR_TARBALL  = WAMR-$(WAMR_VERSION).tar.gz
+
+# Tarball of main branch and tagged release have little difference
+# in name after unpack and URL
+
+ifeq ($(WAMR_VERSION), main)
+WAMR_VERSION_STUB  = 
+else
+WAMR_VERSION_STUB  = WAMR-
+endif
+
+WAMR_TARBALL  = $(WAMR_VERSION_STUB)$(WAMR_VERSION).zip
 WAMR_URL_BASE = https://github.com/bytecodealliance/wasm-micro-runtime/archive/
 WAMR_URL      = $(WAMR_URL_BASE)/$(WAMR_TARBALL)
 
@@ -32,7 +42,7 @@ VPATH += $(WAMR_UNPACK)/product-mini/platforms/nuttx
 
 MAINSRC = main.c
 
-PROGNAME  = iwamr
+PROGNAME  = iwasm
 PRIORITY  = $(CONFIG_INTERPRETERS_WAMR_PRIORITY)
 STACKSIZE = $(CONFIG_INTERPRETERS_WAMR_STACKSIZE)
 MODULE    = $(CONFIG_INTERPRETERS_WAMR)
@@ -43,8 +53,8 @@ $(WAMR_TARBALL):
 
 $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) echo "Unpacking $(WAMR_TARBALL) to $(WAMR_UNPACK)"
-	$(Q) tar xzvf $(WAMR_TARBALL)
-	$(Q) mv wasm-micro-runtime-WAMR-$(WAMR_VERSION) $(WAMR_UNPACK)
+	$(Q) unzip $(WAMR_TARBALL)
+	$(Q) mv wasm-micro-runtime-$(WAMR_VERSION_STUB)$(WAMR_VERSION) $(WAMR_UNPACK)
 
 context:: $(WAMR_UNPACK)
 


### PR DESCRIPTION
## Summary
Now supports specifying the version number of wamr as main.
## Impact
None
## Testing
Tested on stm32f429i-disco
