### PR TITLE
netinit: Make the default SSID and passphrase empty

### DIFF
--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -542,11 +542,11 @@ config NETINIT_WAPI_ALG
 
 config NETINIT_WAPI_SSID
 	string "SSID"
-	default "myApSSID"
+	default ""
 
 config NETINIT_WAPI_PASSPHRASE
 	string "Passprhase"
-	default "mySSIDpassphrase"
+	default ""
 
 endmenu # WAPI Configuration
 endif # NETUTILS_NETINIT


### PR DESCRIPTION
## Summary
* It doesn't make much sense to have the default values for
  these highly environment-dependent settings.

* netutils/netinit/netinit_associate.c calls wpa_driver_wext_associate
  if the SSID is not empty. Depending on the environment, it can take
  long to fail. It slows down the boot of some configurations
  considerably. eg. esp32-devkitc:wapi

## Impact

## Testing
esp32-devkitc:wapi (with some local patches)
