### PR TITLE
examples/webserver: Allow exit when run as a NSH built-in app

### DIFF
--- a/examples/webserver/webserver_main.c
+++ b/examples/webserver/webserver_main.c
@@ -197,6 +197,7 @@ int main(int argc, FAR char *argv[])
   httpd_listen();
 #endif
 
+#ifndef CONFIG_NSH_NETINIT
   /* We are running standalone (as opposed to a NSH built-in app). Therefore
    * we should not exit after httpd failure.
    */
@@ -207,6 +208,24 @@ int main(int argc, FAR char *argv[])
       printf("webserver_main: Still running\n");
       fflush(stdout);
     }
+
+#else /* CONFIG_NSH_NETINIT */
+  /* We are running as a NSH built-in app.  Therefore we should exit.  This
+   * allows to 'kill -9' the webserver app, assuming it was started as a
+   * background process.  For example:
+   *
+   *    nsh> webserver &
+   *    webserver [6:100]
+   *    nsh> Starting webserver
+   *
+   *    nsh> kill -9 6
+   *    nsh> webserver_main: Exiting
+   */
+
+  printf("webserver_main: Exiting\n");
+  fflush(stdout);
+
+#endif /* CONFIG_NSH_NETINIT */
 
   return 0;
 }

--- a/examples/webserver/webserver_main.c
+++ b/examples/webserver/webserver_main.c
@@ -110,7 +110,7 @@ int main(int argc, FAR char *argv[])
   void *handle;
 #endif
 
-/* Many embedded network interfaces must have a software assigned MAC */
+  /* Many embedded network interfaces must have a software assigned MAC */
 
 #ifdef CONFIG_EXAMPLES_WEBSERVER_NOMAC
   mac[0] = 0x00;
@@ -156,34 +156,35 @@ int main(int argc, FAR char *argv[])
 
   handle = dhcpc_open("eth0", &mac, IFHWADDRLEN);
 
-  /* Get an IP address.  Note:  there is no logic here for renewing the address in this
-   * example.  The address should be renewed in ds.lease_time/2 seconds.
+  /* Get an IP address.  Note:  there is no logic here for renewing the
+   * address in this example.  The address should be renewed in
+   * ds.lease_time/2 seconds.
    */
 
   printf("Getting IP address\n");
   if (handle)
     {
-        struct dhcpc_state ds;
-        dhcpc_request(handle, &ds);
-        netlib_set_ipv4addr("eth0", &ds.ipaddr);
+      struct dhcpc_state ds;
+      dhcpc_request(handle, &ds);
+      netlib_set_ipv4addr("eth0", &ds.ipaddr);
 
-        if (ds.netmask.s_addr != 0)
-          {
-            netlib_set_ipv4netmask("eth0", &ds.netmask);
-          }
+      if (ds.netmask.s_addr != 0)
+        {
+          netlib_set_ipv4netmask("eth0", &ds.netmask);
+        }
 
-        if (ds.default_router.s_addr != 0)
-          {
-            netlib_set_dripv4addr("eth0", &ds.default_router);
-          }
+      if (ds.default_router.s_addr != 0)
+        {
+          netlib_set_dripv4addr("eth0", &ds.default_router);
+        }
 
-        if (ds.dnsaddr.s_addr != 0)
-          {
-            netlib_set_ipv4dnsaddr(&ds.dnsaddr);
-          }
+      if (ds.dnsaddr.s_addr != 0)
+        {
+          netlib_set_ipv4dnsaddr(&ds.dnsaddr);
+        }
 
-        dhcpc_close(handle);
-        printf("IP: %s\n", inet_ntoa(ds.ipaddr));
+      dhcpc_close(handle);
+      printf("IP: %s\n", inet_ntoa(ds.ipaddr));
     }
 #endif
 #endif /* CONFIG_NSH_NETINIT */


### PR DESCRIPTION
## Summary

Prior to this change, the webserver program would _never_ terminate, even when running as a NSH built-in app.  For example:

```
nsh> webserver &
webserver [6:100]
nsh> Starting webserver

nsh> kill -9 6
nsh> webserver_main: Still running
nsh> webserver_main: Still running
nsh> webserver_main: Still running
nsh> webserver_main: Still running
```

The message "Still running" would be printed forever, every 3 seconds. Despite printing "Still running," httpd has terminated and the process is doing nothing. This was done because webserver can be a standalone app which must never terminate.

This PR preserves the above behavior when built as a standalone program that must never terminate, but makes it possible to terminate the app normally when built as a NSH built-in app:

```
nsh> webserver &
webserver [6:100]
nsh> Starting webserver

nsh> kill -9 6
nsh> webserver_main: Exiting
```

## Impact

Allows the expected outcome when 'kill -9' the webserver.

## Testing

Ran on custom hardware.
nxstyle.
