### PR TITLE
system/readline: check the control ascii only to support multi-languages 

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -733,11 +733,11 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           return nch;
         }
 
-      /* Otherwise, check if the character is printable and, if so, put the
-       * character in the line buffer
+      /* Otherwise, put the character in the line buffer if the
+       * character is not a control byte
        */
 
-      else if (isprint(ch))
+      else if (!iscntrl(ch & 0xff))
         {
           buf[nch++] = ch;
 


### PR DESCRIPTION
## Summary

system/readline: check the control ascii only to support multi-languages 

## Impact

## Testing

```
nsh> echo hello world
hello world
nsh> echo こんにちは
こんにちは
nsh> echo 你好
你好
```

