### PR TITLE
wireless/wapi: add set country code support

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -700,6 +700,17 @@ int wapi_scan_coll(int sock, FAR const char *ifname,
 void wapi_scan_coll_free(FAR struct wapi_list_s *aps);
 
 /****************************************************************************
+ * Name: wapi_set_country
+ *
+ * Description:
+ *    Set the country code
+ *
+ ****************************************************************************/
+
+int wapi_set_country(int sock, FAR const char *ifname,
+                     FAR const char *country);
+
+/****************************************************************************
  * Name: wapi_get_sensitivity
  *
  * Description:

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -96,6 +96,7 @@ static int wapi_bitrate_cmd      (int sock, int argc, FAR char **argv);
 static int wapi_txpower_cmd      (int sock, int argc, FAR char **argv);
 static int wapi_scan_results_cmd (int sock, int argc, FAR char **argv);
 static int wapi_scan_cmd         (int sock, int argc, FAR char **argv);
+static int wapi_country_cmd      (int sock, int argc, FAR char **argv);
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
 static int wapi_reconnect_cmd    (int sock, int argc, FAR char **argv);
 static int wapi_save_config_cmd  (int sock, int argc, FAR char **argv);
@@ -121,6 +122,7 @@ static const struct wapi_command_s g_wapi_commands[] =
   {"ap",           2, 2, wapi_ap_cmd},
   {"bitrate",      3, 3, wapi_bitrate_cmd},
   {"txpower",      3, 3, wapi_txpower_cmd},
+  {"country",      2, 2, wapi_country_cmd},
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
   {"reconnect",    1, 1, wapi_reconnect_cmd},
   {"save_config",  1, 1, wapi_save_config_cmd},
@@ -743,6 +745,22 @@ static int wapi_scan_cmd(int sock, int argc, FAR char **argv)
     }
 
   return wapi_scan_results_cmd(sock, 1, argv);
+}
+
+/****************************************************************************
+ * Name: wapi_country_cmd
+ *
+ * Description:
+ *  Set the country code
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static int wapi_country_cmd(int sock, int argc, FAR char **argv)
+{
+  return wapi_set_country(sock, argv[0], argv[1]);
 }
 
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -1394,6 +1394,40 @@ void wapi_scan_coll_free(FAR struct wapi_list_s *list)
 }
 
 /****************************************************************************
+ * Name: wapi_set_country
+ *
+ * Description:
+ *    Set the country code
+ *
+ ****************************************************************************/
+
+int wapi_set_country(int sock, FAR const char *ifname,
+                     FAR const char *country)
+{
+  struct iwreq wrq =
+  {
+  };
+
+  int ret;
+
+  /* Prepare request. */
+
+  wrq.u.data.pointer = (FAR void *)country;
+  wrq.u.data.length = 2;
+
+  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  ret = ioctl(sock, SIOCSIWCOUNTRY, (unsigned long)((uintptr_t)&wrq));
+  if (ret < 0)
+    {
+      int errcode = errno;
+      WAPI_IOCTL_STRERROR(SIOCSIWCOUNTRY, errcode);
+      ret = -errcode;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: wapi_get_sensitivity
  *
  * Description:


### PR DESCRIPTION
## Summary

wireless/wapi: add set country code support

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

wapi wlan0 country CN