### PR TITLE
examples/pty_test: Fix the hardcode uart device path

### DIFF
--- a/examples/pty_test/pty_test.c
+++ b/examples/pty_test/pty_test.c
@@ -311,7 +311,7 @@ int main(int argc, FAR char *argv[])
 
   /* Open the second serial port to create a new console there */
 
-  termpair.fd_uart = open("/dev/console", O_RDWR);
+  termpair.fd_uart = open(CONFIG_EXAMPLES_PTYTEST_SERIALDEV, O_RDWR);
   if (termpair.fd_uart < 0)
     {
 #ifdef CONFIG_EXAMPLES_PTYTEST_WAIT_CONNECTED


### PR DESCRIPTION
## Summary
should be CONFIG_EXAMPLES_PTYTEST_SERIALDEV, regression in commit:
```
commit 6ddbffd2000fb62c71914c6f57c93f2e7d1f50e8
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Sun Jan 3 23:50:50 2021 -0800

    examples/pty_test: Remove O_NONBLOCK from open

    to avoid the log storm:
    ERROR Failed to read from serial: 11
    ERROR Failed to read from serial: 11
    ERROR Failed to read from serial: 11
    ERROR Failed to read from serial: 11
    ERROR Failed to read from serial: 11
    ...
```

## Impact
pty test can open CONFIG_EXAMPLES_PTYTEST_SERIALDEV, instead the hardcode /dev/console

## Testing

