### PR TITLE
Ftpd fixes

### DIFF
--- a/examples/ftpd/ftpd.h
+++ b/examples/ftpd/ftpd.h
@@ -36,7 +36,7 @@
 #define __APPS_EXAMPLES_FTPD_FTPD_H
 
 /****************************************************************************
- * Pre-processor Definitions
+ * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
@@ -48,7 +48,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* CONFIG_EXAMPLES_FTPD_PRIO - Priority of the FTP daemon.
  *   Default: SCHED_PRIORITY_DEFAULT
  * CONFIG_EXAMPLES_FTPD_STACKSIZE - Stack size allocated for the

--- a/examples/ftpd/ftpd_main.c
+++ b/examples/ftpd/ftpd_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/telnetd/shell.c
+ * examples/ftpd/ftpd_main.c
  *
  *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -90,6 +90,7 @@ struct ftpd_globals_s g_ftpdglob;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
 /****************************************************************************
  * Name: fptd_netinit
  ****************************************************************************/
@@ -102,7 +103,7 @@ static void fptd_netinit(void)
   uint8_t mac[IFHWADDRLEN];
 #endif
 
-/* Many embedded network interfaces must have a software assigned MAC */
+  /* Many embedded network interfaces must have a software assigned MAC */
 
 #ifdef CONFIG_EXAMPLES_FTPD_NOMAC
   mac[0] = 0x00;
@@ -152,8 +153,8 @@ static void ftpd_accounts(FTPD_SESSION handle)
     {
       account = &g_ftpdaccounts[i];
 
-      printf("%d. %s account: USER=%s PASSWORD=%s HOME=%s\n", i+1,
-            (account->flags & FTPD_ACCOUNTFLAG_SYSTEM) != 0 ? "Root" : "User",
+      printf("%d. %s account: USER=%s PASSWORD=%s HOME=%s\n", i + 1,
+            (account->flags & FTPD_ACCOUNTFLAG_SYSTEM) ? "Root" : "User",
             (!account->user) ? "(none)" : account->user,
             (!account->password) ? "(none)" : account->password,
             (!account->home) ? "(none)" : account->home);
@@ -214,7 +215,8 @@ int ftpd_daemon(int s_argc, char **s_argv)
 
       if (ret != -ETIMEDOUT)
         {
-          printf("FTP daemon [%d] ftpd_session returned %d\n", g_ftpdglob.pid, ret);
+          printf("FTP daemon [%d] ftpd_session returned %d\n",
+                 g_ftpdglob.pid, ret);
         }
     }
 
@@ -232,6 +234,7 @@ int ftpd_daemon(int s_argc, char **s_argv)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
 /****************************************************************************
  * Name: ftpd_main
  ****************************************************************************/
@@ -242,7 +245,6 @@ int main(int argc, FAR char *argv[])
 
   if (!g_ftpdglob.initialized)
     {
-
       /* Bring up the network */
 
       printf("Initializing the network\n");
@@ -263,6 +265,7 @@ int main(int argc, FAR char *argv[])
       printf("Waiting for FTP daemon [%d] to stop\n", g_ftpdglob.pid);
       return EXIT_FAILURE;
     }
+
   if (!g_ftpdglob.running)
     {
       printf("Starting the FTP daemon\n");
@@ -275,7 +278,7 @@ int main(int argc, FAR char *argv[])
           return EXIT_FAILURE;
         }
     }
-   else
+  else
     {
       printf("FTP daemon [%d] is running\n", g_ftpdglob.pid);
     }

--- a/netutils/ftpd/Makefile
+++ b/netutils/ftpd/Makefile
@@ -35,8 +35,6 @@
 
 include $(APPDIR)/Make.defs
 
-# Telnet daemon
-
 ifeq ($(CONFIG_NET_TCP),y)
 CSRCS = ftpd.c
 endif

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/n etutils/ftpd.c
+ * apps/netutils/ftpd.c
  *
  *   Copyright (C) 2012, 2015, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -1136,9 +1136,9 @@ static FAR struct ftpd_server_s *ftpd_openserver(int port,
 
   /* Initialize the server instance */
 
-    server->sd   = -1;
-    server->head = NULL;
-    server->tail = NULL;
+  server->sd   = -1;
+  server->head = NULL;
+  server->tail = NULL;
 
   /* Create the server listen socket */
 
@@ -1910,9 +1910,7 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
 
       if (cmdtype == 0)
         {
-          /* Read from the file.
-           * Read returns the error condition via errno.
-           */
+          /* Read from the file. */
 
           rdbytes = read(session->fd, session->data.buffer, wantsize);
           if (rdbytes < 0)
@@ -2384,7 +2382,7 @@ static int fptd_listscan(FAR struct ftpd_session_s *session, FAR char *path,
   if (!dir)
     {
       int errval = errno;
-      nerr("ERROR: dir() failed: %d\n", errval);
+      nerr("ERROR: opendir() failed: %d\n", errval);
       return -errval;
     }
 
@@ -3557,10 +3555,10 @@ static int ftpd_command_size(FAR struct ftpd_session_s *session)
           }
         else if (!S_ISREG(st.st_mode))
           {
-            ret = ftpd_response(session->cmd.sd, session->txtimeout,
-                                g_respfmt2, 550, ' ', session->param,
-                                ": not a regular file.");
             ret = -EPERM;
+            ftpd_response(session->cmd.sd, session->txtimeout,
+                          g_respfmt2, 550, ' ', session->param,
+                          ": not a regular file.");
             goto errout_with_abspath;
           }
 
@@ -3673,9 +3671,9 @@ static int ftpd_command_rnto(FAR struct ftpd_session_s *session)
 
   if (!session->renamefrom)
     {
-      return ftpd_response(session->cmd.sd, session->txtimeout,
-                           g_respfmt1, 550, ' ', "RNTO error !");
-      return ret;
+      ftpd_response(session->cmd.sd, session->txtimeout,
+                    g_respfmt1, 550, ' ', "RNTO error !");
+      return -EINVAL;
     }
 
   ret = ftpd_getpath(session, session->param, &abspath, NULL);

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -3191,7 +3191,7 @@ static int ftpd_command_pasv(FAR struct ftpd_session_s *session)
         {
           /* convert ipv6 to ipv4 */
 
-          in_addr in4addr;
+          struct in_addr in4addr;
 
           in4addr.s_addr = session->data.addr.in6.sin6_addr.s6_addr32[3];
 

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -4496,7 +4496,10 @@ void ftpd_close(FTPD_SESSION handle)
   DEBUGASSERT(handle);
 
   server = (struct ftpd_server_s *)handle;
-  ftpd_account_free(server->head);
+  if (server->head != NULL)
+    {
+      ftpd_account_free(server->head);
+    }
 
   if (server->sd >= 0)
     {

--- a/netutils/ftpd/ftpd.h
+++ b/netutils/ftpd/ftpd.h
@@ -50,6 +50,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* FPTD Definitions *********************************************************/
 
 #define FTPD_SESSIONFLAG_USER       (1 << 0)  /* Session has a user */
@@ -67,6 +68,7 @@
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
 /* This enumerates the type of each session */
 
 enum ftpd_sessiontype_e
@@ -92,7 +94,8 @@ union ftpd_sockaddr_u
   struct sockaddr            sa;
 #ifdef CONFIG_NET_IPv6
   struct sockaddr_in6        in6;
-#else
+#endif
+#ifdef CONFIG_NET_IPv4
   struct sockaddr_in         in4;
 #endif
 };
@@ -178,23 +181,4 @@ struct ftpd_protocol_s
   int value;
 };
 
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-#ifdef __cplusplus
-#define EXTERN extern "C"
-extern "C"
-{
-#else
-#define EXTERN extern
-#endif
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-#undef EXTERN
-#ifdef __cplusplus
-}
-#endif
 #endif /* __APPS_NETUTILS_FTPD_FTPD_H */


### PR DESCRIPTION
## Summary
- Fixes crash when ftpd_close() called before account setup
- Fixes compilation on dual-stack (both IPv4 and IPv6) systems
- Rename command RNTO return -EINVAL if no from path (This is just a minor thing, to correct original code that had superfluous return statement)
- nxstyle fixes

## Impact

## Testing

