### PR TITLE
webclient: Report unexpected connection loss as an explicit error

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -896,6 +896,13 @@ int webclient_perform(FAR struct webclient_context *ctx)
             }
           else if (ws->datend == 0)
             {
+              if (ws->state != WEBCLIENT_STATE_DATA)
+                {
+                  nerr("Connection lost unexpectedly\n");
+                  ret = -ECONNABORTED;
+                  goto errout_with_errno;
+                }
+
               ninfo("Connection lost\n");
               break;
             }


### PR DESCRIPTION
## Summary
webclient: Report unexpected connection loss as an explicit error
Otherwise, it can end up with mysterious results in user apps.

## Impact

## Testing
tested with a local app
