### PR TITLE
webclient: Add AF_LOCAL support

### DIFF
--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -186,18 +186,22 @@ struct webclient_context
 {
   /* request parameters
    *
-   *   method       - HTTP method like "GET", "POST".
-   *                  The default value is "GET".
-   *   url          - A pointer to a string containing the full URL.
-   *                  (e.g., http://www.nutt.org/index.html, or
-   *                   http://192.168.23.1:80/index.html)
-   *   headers      - An array of pointers to the extra headers.
-   *   nheaders     - The number of elements in the "headers" array.
-   *   bodylen      - The size of the request body.
+   *   method           - HTTP method like "GET", "POST".
+   *                      The default value is "GET".
+   *   url              - A pointer to a string containing the full URL.
+   *                      (e.g., http://www.nutt.org/index.html, or
+   *                       http://192.168.23.1:80/index.html)
+   *   unix_socket_path - If not NULL, the path to an AF_LOCAL socket.
+   *   headers          - An array of pointers to the extra headers.
+   *   nheaders         - The number of elements in the "headers" array.
+   *   bodylen          - The size of the request body.
    */
 
   FAR const char *method;
   FAR const char *url;
+#if defined(CONFIG_WEBCLIENT_NET_LOCAL)
+  FAR const char *unix_socket_path;
+#endif
   FAR const char * FAR const *headers;
   unsigned int nheaders;
   size_t bodylen;

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -982,7 +982,11 @@ int webclient_perform(FAR struct webclient_context *ctx)
                    * received file.
                    */
 
-                  if (ctx->sink_callback)
+                  if (ws->offset == ws->datend)
+                    {
+                      /* We don't have data to give to the client yet. */
+                    }
+                  else if (ctx->sink_callback)
                     {
                       ret = ctx->sink_callback(&ws->buffer, ws->offset,
                                                ws->datend, &ws->buflen,


### PR DESCRIPTION
## Summary
webclient: Add AF_LOCAL support
## Impact

## Testing
AF_LOCAL part:
Tested against Docker Engine socket on macOS and Linux. (with a ported version of webclient)
Only build-tested for NuttX.

"webclient: Don't call the sink callback if no data is available" part:
Tested with a local app (only with TCP on NuttX)
