### PR TITLE
netutils : iperf: Fix compile warnings with Arm GCC 9.3.1

### DIFF
--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -208,8 +208,10 @@ static void iperf_report_task(void *arg)
   while (!s_iperf_ctrl.finish)
     {
       sleep(interval);
-      printf("%4d-%4d sec,  %.2f Mbits/sec\n", cur, cur + interval,
-        (double)((s_iperf_ctrl.total_len - last_len) * 8) / interval / 1e6);
+      printf("%4" PRId32 "-%4" PRId32 " sec,  %.2f Mbits/sec\n",
+             cur, cur + interval,
+             (double)((s_iperf_ctrl.total_len - last_len) * 8) /
+             interval / 1e6);
       cur += interval;
       last_len = s_iperf_ctrl.total_len;
       if (cur >= time)
@@ -220,7 +222,7 @@ static void iperf_report_task(void *arg)
 
   if (cur != 0)
     {
-      printf("%4d-%4d sec,  %.2f Mbits/sec\n", 0, time,
+      printf("%4d-%4" PRId32 " sec,  %.2f Mbits/sec\n", 0, time,
             (double)(s_iperf_ctrl.total_len * 8) / cur / 1e6);
     }
 

--- a/netutils/iperf/iperf_main.c
+++ b/netutils/iperf/iperf_main.c
@@ -215,8 +215,10 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-  printf("\n mode=%s-%s sip=%d.%d.%d.%d:%d,\
-         dip=%d.%d.%d.%d:%d, interval=%d, time=%d\n",
+  printf("\n mode=%s-%s "
+         "sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+         "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d, "
+         "interval=%" PRId32 ", time=%" PRId32 " \n",
          cfg.flag & IPERF_FLAG_TCP ?"tcp":"udp",
          cfg.flag & IPERF_FLAG_SERVER ?"server":"client",
          cfg.sip & 0xff, (cfg.sip >> 8) & 0xff, (cfg.sip >> 16) & 0xff,


### PR DESCRIPTION
## Summary

- This commit fixes compile warnings with Arm GCC 9.3.1

## Impact

- None

## Testing

- Tested with lm3s6965-ek:discover
- NOTE: need to add the following configs
  +CONFIG_EXAMPLES_IPERF=y
  +CONFIG_EXAMPLES_IPERFTEST_DEVNAME="eth0"
