### PR TITLE
crypto: Initial support for Mbed TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,23 @@ A: Here are three:
       Use of the name `apps/external` is suggested because that name is included
       in the `.gitignore` file and will save you some nuisance when working with
       GIT.
+
+# Export restrictions
+
+This distribution includes cryptographic software. The country in which you
+currently reside may have restrictions on the import, possession, use, and/or
+re-export to another country, of encryption software. BEFORE using any encryption
+software, please check your country's laws, regulations and policies concerning
+the import, possession, or use, and re-export of encryption software, to see if
+this is permitted. See <http://www.wassenaar.org/> for more information.
+
+The U.S. Government Department of Commerce, Bureau of Industry and Security (BIS),
+has classified this software as Export Commodity Control Number (ECCN) 5D002.C.1,
+which includes information security software using or performing cryptographic
+functions with asymmetric algorithms. The form and manner of this Apache Software
+Foundation distribution makes it eligible for export under the License Exception ENC
+Technology Software Unrestricted (TSU) exception (see the BIS Export Administration
+Regulations, Section 740.13) for both object code and source code.
+
+The following provides more details on the included cryptographic software:
+https://tls.mbed.org/supported-ssl-ciphersuites.

--- a/crypto/mbedtls/.gitignore
+++ b/crypto/mbedtls/.gitignore
@@ -1,0 +1,2 @@
+/mbedtls
+/*.zip

--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -1,0 +1,80 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig CRYPTO_MBEDTLS
+	bool "Mbed TLS Cryptography Library"
+	default n
+	---help---
+		Enable support for Mbed TLS.
+
+if CRYPTO_MBEDTLS
+
+config MBEDTLS_VERSION
+	string "MBEDTLS Version"
+	default "2.25.0"
+
+menuconfig MBEDTLS_APPS
+	tristate "Mbed TLS Applications"
+	default n
+	---help---
+		Enable Mbed TLS Applications
+
+if MBEDTLS_APPS
+
+config MBEDTLS_DEFAULT_TASK_STACKSIZE
+	int "Mbed TLS app default stack size"
+	default 8192
+
+config MBEDTLS_APP_BENCHMARK
+	bool "Mbed TLS benchmark"
+	default n
+	---help---
+		Enable the Mbed TLS self test
+
+if MBEDTLS_APP_BENCHMARK
+
+config MBEDTLS_APP_BENCHMARK_PROGNAME
+	string "Program name"
+	default "mbedbenchmark"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config MBEDTLS_APP_BENCHMARK_PRIORITY
+	int "Benchmark task priority"
+	default 100
+
+config MBEDTLS_APP_BENCHMARK_STACKSIZE
+	int "Benchmark stack size"
+	default MBEDTLS_DEFAULT_TASK_STACKSIZE
+endif
+
+config MBEDTLS_APP_SELFTEST
+	bool "Mbed TLS Self Test"
+	default n
+	---help---
+		Enable the Mbed TLS self test
+
+if MBEDTLS_APP_SELFTEST
+
+config MBEDTLS_APP_SELFTEST_PROGNAME
+	string "Program name"
+	default "mbedselftest"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config MBEDTLS_APP_SELFTEST_PRIORITY
+	int "Self test task priority"
+	default 100
+
+config MBEDTLS_APP_SELFTEST_STACKSIZE
+	int "Self test stack size"
+	default MBEDTLS_DEFAULT_TASK_STACKSIZE
+endif
+
+endif
+
+endif # CRYPTO_MBEDTLS

--- a/crypto/mbedtls/Make.defs
+++ b/crypto/mbedtls/Make.defs
@@ -1,0 +1,36 @@
+############################################################################
+# apps/crypto/mbedtls/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_CRYPTO_MBEDTLS),y)
+CONFIGURED_APPS += $(APPDIR)/crypto/mbedtls
+
+# Allows `<mbedtls/<>.h>` import.
+
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/mbedtls/mbedtls/include}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/mbedtls/mbedtls/include}
+
+CFLAGS += ${shell $(DEFINE) "$(CC)" MBEDTLS_CONFIG_FILE='"<crypto/mbedtls_config.h>"'}
+CXXFLAGS += ${shell $(DEFINE) "$(CC)" MBEDTLS_CONFIG_FILE='"<crypto/mbedtls_config.h>"'}
+
+ifneq ($(CONFIG_MBEDTLS_APPS),)
+CONFIGURED_APPS += $(APPDIR)/crypto/mbedtls/
+endif
+
+endif

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -1,0 +1,85 @@
+############################################################################
+# apps/crypto/mbedtls/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Mbed TLS crypto library
+
+# Set up build configuration and environment
+
+MBEDTLS_URL ?= "https://github.com/ARMmbed/mbedtls/archive"
+
+MBEDTLS_VERSION = $(patsubst "%",%,$(strip $(CONFIG_MBEDTLS_VERSION)))
+MBEDTLS_ZIP = v$(MBEDTLS_VERSION).zip
+
+MBEDTLS_UNPACKNAME = mbedtls
+UNPACK ?= unzip -q -o
+
+MBEDTLS_UNPACKLIBDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)library
+MBEDTLS_UNPACKPROGDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)programs
+
+# This lets Mbed TLS better use some of the POSIX features we have
+CFLAGS += ${shell $(DEFINE) "$(CC)" __unix__}
+
+CSRCS = $(wildcard $(MBEDTLS_UNPACKLIBDIR)$(DELIM)*.c)
+
+$(MBEDTLS_ZIP):
+	@echo "Downloading: $(MBEDTLS_URL)/$(MBEDTLS_ZIP)"
+	$(Q) curl -O -L $(MBEDTLS_URL)/$(MBEDTLS_ZIP)
+
+$(MBEDTLS_UNPACKNAME): $(MBEDTLS_ZIP)
+	@echo "Unpacking: $(MBEDTLS_ZIP) -> $(MBEDTLS_UNPACKNAME)"
+	$(Q) $(UNPACK) $(MBEDTLS_ZIP)
+	$(Q) mv	mbedtls-$(MBEDTLS_VERSION) $(MBEDTLS_UNPACKNAME)
+	$(Q) touch $(MBEDTLS_UNPACKNAME)
+
+context:: $(MBEDTLS_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(MBEDTLS_UNPACKNAME))
+	$(call DELFILE, $(MBEDTLS_ZIP))
+
+# Configuration Applications
+
+ifneq ($(CONFIG_MBEDTLS_APPS),)
+
+MODULE = $(CONFIG_MBEDTLS_APPS)
+
+ifeq ($(CONFIG_MBEDTLS_APP_BENCHMARK),y)
+
+PROGNAME  += $(CONFIG_MBEDTLS_APP_BENCHMARK_PROGNAME)
+PRIORITY  += $(CONFIG_MBEDTLS_APP_BENCHMARK_PRIORITY)
+STACKSIZE += $(CONFIG_MBEDTLS_APP_BENCHMARK_STACKSIZE)
+
+MAINSRC += $(MBEDTLS_UNPACKPROGDIR)/test/benchmark.c
+endif
+
+ifeq ($(CONFIG_MBEDTLS_APP_SELFTEST),y)
+
+PROGNAME  += $(CONFIG_MBEDTLS_APP_SELFTEST_PROGNAME)
+PRIORITY  += $(CONFIG_MBEDTLS_APP_SELFTEST_PRIORITY)
+STACKSIZE += $(CONFIG_MBEDTLS_APP_SELFTEST_STACKSIZE)
+
+MAINSRC += $(MBEDTLS_UNPACKPROGDIR)/test/selftest.c
+endif
+
+endif
+
+include $(APPDIR)/Application.mk

--- a/include/crypto/mbedtls_config.h
+++ b/include/crypto/mbedtls_config.h
@@ -1,0 +1,87 @@
+/****************************************************************************
+ * apps/include/crypto/mbedtls_config.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_INCLUDE_CRYPTO_MBEDTLS_CONFIG_H
+#define __APPS_INCLUDE_CRYPTO_MBEDTLS_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* System support */
+#define MBEDTLS_HAVE_TIME
+
+/* Debug */
+#define MBEDTLS_SELF_TEST
+#define MBEDTLS_TIMING_C
+
+/* Feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_1
+
+/* Modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+
+#ifdef CONFIG_NET
+#define MBEDTLS_NET_C
+#endif
+
+#define MBEDTLS_OID_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_CERTS_C
+#define MBEDTLS_PEM_PARSE_C
+
+#define MBEDTLS_FS_IO
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "mbedtls/check_config.h"
+
+#endif /* __APPS_INCLUDE_CRYPTO_MBEDTLS_CONFIG_H */


### PR DESCRIPTION
## Summary
~~**DRAFT**~~
Add initial support for Mbed TLS in NuttX
~~__This is not really ready for review, but I wanted to get this out there to make sure I am not duplicating work__~~
[Ready for review](https://github.com/apache/incubator-nuttx-apps/pull/566#event-5178283381)

 TODO:
- [x] Download an build Mbed TLS
- [x] Add support for generating the needed config header via Kconfig system (https://github.com/apache/incubator-nuttx-apps/issues/877)
- [x] Support basic entropy and crypto primitives

x509 and hardware driver support is out of scope for this PR

## Testing
So far it is able to generate data from the entropy api with /dev/urandom configured.