### PR TITLE
examples/romfs: Add ldir(soft link) into check

### DIFF
--- a/examples/romfs/romfs_main.c
+++ b/examples/romfs/romfs_main.c
@@ -153,6 +153,7 @@ static const char g_subdirfilecontent[]  = "File in subdirectory\n";
 
 static struct node_s g_adir;
 static struct node_s g_afile;
+static struct node_s g_ldir;
 static struct node_s g_hfile;
 
 static struct node_s g_anotherfile;
@@ -183,13 +184,21 @@ static void connectem(void)
   g_adir.size                  = 0;
   g_adir.u.child               = &g_anotherfile;
 
-  g_afile.peer                 = &g_hfile;
+  g_afile.peer                 = &g_ldir;
   g_afile.directory            = false;
   g_afile.found                = false;
   g_afile.name                 = "afile.txt";
   g_afile.mode                 = FILE_MODE;
   g_afile.size                 = strlen(g_afilecontent);
   g_afile.u.filecontent        = g_afilecontent;
+
+  g_ldir.peer                  = &g_hfile;
+  g_ldir.directory             = true;
+  g_ldir.found                 = false;
+  g_ldir.name                  = "ldir";
+  g_ldir.mode                  = DIRECTORY_MODE;
+  g_ldir.size                  = 0;
+  g_ldir.u.child               = &g_subdirfile;
 
   g_hfile.peer                 = NULL;
   g_hfile.directory            = false; /* Actually a hard link */
@@ -416,7 +425,7 @@ static void readdirectories(const char *path, struct node_s *entry)
               printf("Continuing directory: %s\n", path);
             }
         }
-      else
+      else if (!DIRENT_ISLINK(direntry->d_type))
         {
           printf("  FILE: %s/\n", fullpath);
           if (node->directory)


### PR DESCRIPTION
## Summary
since romfs can return the soft link with the kernel change:

commit 67ef70d460db4695b950208d861ff47d4a40bdb3
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon Jul 6 00:34:32 2020 +0800

    vfs/dirread: Should return the same file type as lstat

    by extend the possible value of d_type for the special file

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Impact
Pass the test now

## Testing

