### PR TITLE
webclient: Fix a use of uninitialized variable

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -777,8 +777,8 @@ int webclient_perform(FAR struct webclient_context *ctx)
                   /* Could not resolve host (or malformed IP address) */
 
                   nwarn("WARNING: Failed to resolve hostname\n");
-                  ret = -EHOSTUNREACH;
-                  goto errout_with_errno;
+                  free(ws);
+                  return -EHOSTUNREACH;
                 }
 
               server_address = (const struct sockaddr *)&server_in;


### PR DESCRIPTION
## Summary
Detected by clang static analyzer.
## Impact

## Testing
* the static analyzer complaint disappeared.
* not really tested this specific "Failed to resolve hostname" path.
