### PR TITLE
Add support in printf command to send 8-32 bits value

### DIFF
--- a/nshlib/nsh_printf.c
+++ b/nshlib/nsh_printf.c
@@ -63,6 +63,8 @@ int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 {
   FAR char *fmt;
   char ch;
+  uint32_t value;
+  int len;
   int i;
 
   /* parse each argument, detecting the right action to take
@@ -84,7 +86,25 @@ int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
             {
               case 'x':
                 fmt++;
-                nsh_output(vtbl, "%c", strtol(fmt, NULL, 16));
+                value = strtoul(fmt, NULL, 16);
+                len = strnlen(fmt, 10);
+
+                if (len >= 7)
+                  {
+                    nsh_output(vtbl, "%c%c%c%c", value & 0xff,
+                                                 (value & 0xff00) >> 8,
+                                                 (value & 0xff0000) >> 16,
+                                                 (value & 0xff000000) >> 24);
+                  }
+                else if (len >= 3)
+                    {
+                      nsh_output(vtbl, "%c%c", value & 0xff,
+                                               (value & 0xff00) >> 8);
+                    }
+                  else if (len >= 1)
+                      {
+                        nsh_output(vtbl, "%c", value & 0xff);
+                      }
                 break;
 
               case 'n':


### PR DESCRIPTION
## Summary
A NuttX user reported that the command to turn ON/OFF the userleds from nsh wasn't working:

nsh> printf \x01 > /dev/userleds

It is described in this video tutorial: https://www.youtube.com/watch?v=GzX9okqfxX4&t=150s

After some investigation I discovered that the issue was caused by this modification:
https://github.com/apache/incubator-nuttx/commit/7a18ebe45980a80370b7afaa4b4d0be703402318

## Impact
Now users will be able to use the printf command again to control the LEDs, but they will need to send 32-bit instead of 8-bit:

nsh> printf \x00000001 > /dev/userleds

## Testing
stm32f103-minimum board
