### PR TITLE
netcat: Fix a buffer overflow

### DIFF
--- a/netutils/netcat/netcat_main.c
+++ b/netutils/netcat/netcat_main.c
@@ -99,8 +99,7 @@ int netcat_server(int argc, char * argv[])
       while (0 < avail)
         {
           avail = recv(conn, buf, capacity, 0);
-          buf[avail] = 0;
-          fprintf(fout, "%s", buf);
+          fwrite(buf, avail, 1, fout);
           int status = fflush(fout);
           if (0 != status)
             {


### PR DESCRIPTION

## Summary
The buffer doesn't have the space for the terminating NUL.
Fix it by replacing it with fwrite, as there seems to be little reason
to use fprintf and NUL-terminated string in the first place.

## Impact

## Testing
tested on esp32-devkitc
