### PR TITLE
wireless/wapi: add get sensitivity command 

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -97,6 +97,7 @@ static int wapi_txpower_cmd      (int sock, int argc, FAR char **argv);
 static int wapi_scan_results_cmd (int sock, int argc, FAR char **argv);
 static int wapi_scan_cmd         (int sock, int argc, FAR char **argv);
 static int wapi_country_cmd      (int sock, int argc, FAR char **argv);
+static int wapi_sense_cmd        (int sock, int argc, FAR char **argv);
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
 static int wapi_reconnect_cmd    (int sock, int argc, FAR char **argv);
 static int wapi_save_config_cmd  (int sock, int argc, FAR char **argv);
@@ -123,6 +124,7 @@ static const struct wapi_command_s g_wapi_commands[] =
   {"bitrate",      3, 3, wapi_bitrate_cmd},
   {"txpower",      3, 3, wapi_txpower_cmd},
   {"country",      2, 2, wapi_country_cmd},
+  {"sense",        1, 1, wapi_sense_cmd},
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
   {"reconnect",    1, 1, wapi_reconnect_cmd},
   {"save_config",  1, 1, wapi_save_config_cmd},
@@ -763,6 +765,31 @@ static int wapi_country_cmd(int sock, int argc, FAR char **argv)
   return wapi_set_country(sock, argv[0], argv[1]);
 }
 
+/****************************************************************************
+ * Name: wapi_sense_cmd
+ *
+ * Description:
+ *  Get the sensitivity(RSSI)
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static int wapi_sense_cmd(int sock, int argc, FAR char **argv)
+{
+  int sense;
+  int ret;
+
+  ret = wapi_get_sensitivity(sock, argv[0], &sense);
+  if (ret == 0)
+    {
+      printf("%d\n", sense);
+    }
+
+  return ret;
+}
+
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
 
 /****************************************************************************
@@ -937,6 +964,8 @@ static void wapi_showusage(FAR const char *progname, int exitcode)
                    progname);
   fprintf(stderr, "\t%s txpower      <ifname> <txpower>    <index/flag>\n",
                    progname);
+  fprintf(stderr, "\t%s country      <ifname> <country code>\n", progname);
+  fprintf(stderr, "\t%s sense        <ifname>\n", progname);
 #ifdef CONFIG_WIRELESS_WAPI_INITCONF
   fprintf(stderr, "\t%s reconnect    <ifname>\n", progname);
   fprintf(stderr, "\t%s save_config  <ifname>\n", progname);


### PR DESCRIPTION
## Summary

wireless/wapi: add get sensitivity command 

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

wapi sense wlan0

## Testing

ap> wapi sense wlan0
-128

