### PR TITLE
wapi: Extend "WAPI_ESSID_DELAY_ON" flag to support customized connection behavior

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -126,7 +126,36 @@ enum wapi_route_target_e
 enum wapi_essid_flag_e
 {
   WAPI_ESSID_OFF,
-  WAPI_ESSID_ON
+  WAPI_ESSID_ON,
+
+/* Extended flag "WAPI_ESSID_DELAY_ON" instructs the driver
+ * to delay the connection behavior of essid, so that which can accept
+ * more accurate information before generating a connection.
+ *
+ * About flow of wapi command, drivers that support WAPI_ESSID_DELAY_ON
+ * semantics will have the following behavior changes:
+ *
+ * 1. Station mode without bssid set:
+ *
+ * $ ifup wlan0
+ * $ wapi mode wlan0 2
+ * $ wapi psk wlan0 12345678 3
+ * $ wapi essid wlan0 archer 1
+ * $ renew wlan0
+ *
+ * 2. Station mode with bssid set:
+ *
+ * $ ifup wlan0
+ * $ wapi mode wlan0 2
+ * $ wapi psk wlan0 12345678 3
+ * $ wapi essid wlan0 archer 2  <-- WAPI_ESSID_DELAY_ON will indicate the
+ * $                                driver delay the connection event late
+ * $                                to bssid set (SIOCSIWAP).
+ * $ wapi ap wlan0 ec:41:18:e0:76:7e
+ * $ renew wlan0
+ */
+
+  WAPI_ESSID_DELAY_ON
 };
 
 /* Supported operation modes. */

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -740,7 +740,7 @@ int wapi_set_essid(int sock, FAR const char *ifname, FAR const char *essid,
   wrq.u.essid.pointer = buf;
   wrq.u.essid.length =
     snprintf(buf, ((WAPI_ESSID_MAX_SIZE + 1) * sizeof(char)), "%s", essid);
-  wrq.u.essid.flags = (flag == WAPI_ESSID_ON);
+  wrq.u.essid.flags = flag;
 
   strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWESSID, (unsigned long)((uintptr_t)&wrq));


### PR DESCRIPTION
## Summary

wapi: Extend "WAPI_ESSID_DELAY_ON" flag to support customized connection behavior

The current essid setting(SIOCSIWESSID) are not satisfactory in case
of specified bssid connection, if there are multiple essids with same name,
we need additional bssid information to connect to the specified softap.
The extended flag "WAPI_ESSID_DELAY_ON" instructs the driver to delay the
connection behavior of essid, so that which can accept more accurate
information before generating a connection.

About flow of wapi command, drivers that support WAPI_ESSID_DELAY_ON semantics
will have the following behavior changes:

1. Station mode without bssid set:

```
$ ifup wlan0
$ wapi mode wlan0 2
$ wapi psk wlan0 12345678 3
$ wapi essid wlan0 archer 1
$ renew wlan0
```

2. Station mode with bssid set:

```
$ ifup wlan0
$ wapi mode wlan0 2
$ wapi psk wlan0 12345678 3
$ wapi essid wlan0 archer 2       <----- WAPI_ESSID_DELAY_ON will indicate the driver delay
$                                        the connection event late to bssid set (SIOCSIWAP).
$ wapi ap wlan0 ec:41:18:e0:76:7e
$ renew wlan0
```

## Impact

Wireless Station mode flow

## Testing

1. work as expected as default mode
```
$ ifup wlan0
$ wapi mode wlan0 2
$ wapi psk wlan0 12345678 3
$ wapi essid wlan0 archer 1
$ renew wlan0
```

2. work as expected as extended mode
```
$ ifup wlan0
$ wapi mode wlan0 2
$ wapi psk wlan0 12345678 3
$ wapi essid wlan0 archer 2
$ wapi ap wlan0 ec:41:18:e0:76:7e
$ renew wlan0
```