### PR TITLE
netutils/dhcpc: configurable Bootstrap flags

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -29,4 +29,12 @@ config NETUTILS_DHCPC_RETRIES
 		This setting determines how many times resolver retries request
 		until failing.
 
+config NETUTILS_DHCPC_BOOTP_FLAGS
+	hex "Flags of Bootstrap"
+	default 0x8000
+	---help---
+		This setting to set the BOOTP broadcast flags.
+		Reference RFC1542: Clarifications and Extensions for the
+		Bootstrap Protocol.
+
 endif

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -71,8 +71,6 @@
 #define STATE_HAVE_OFFER        1
 #define STATE_HAVE_LEASE        2
 
-#define BOOTP_BROADCAST         0x8000
-
 #define DHCP_REQUEST            1
 #define DHCP_REPLY              2
 #define DHCP_HTYPE_ETHERNET     1
@@ -261,7 +259,9 @@ static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
          * unicast traffic before being fully configured.
          */
 
-        pdhcpc->packet.flags = HTONS(BOOTP_BROADCAST); /*  Broadcast bit. */
+        /* Broadcast bit. */
+
+        pdhcpc->packet.flags = HTONS(CONFIG_NETUTILS_DHCPC_BOOTP_FLAGS);
 
         pend     = dhcpc_addhostname(hostname, pend);
         pend     = dhcpc_addreqoptions(pend);
@@ -274,7 +274,9 @@ static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
          * unicast traffic before being fully configured.
          */
 
-        pdhcpc->packet.flags = HTONS(BOOTP_BROADCAST); /*  Broadcast bit. */
+        /* Broadcast bit. */
+
+        pdhcpc->packet.flags = HTONS(CONFIG_NETUTILS_DHCPC_BOOTP_FLAGS);
 
         pend     = dhcpc_addhostname(hostname, pend);
         pend     = dhcpc_addserverid(&pdhcpc->serverid, pend);


### PR DESCRIPTION
## Summary

netutils/dhcpc: configurable Bootstrap flags

Change-Id: I9a364fda2ac536422ef3294a7217474f48eaad21
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

depends on: https://github.com/apache/incubator-nuttx/pull/2774

## Testing

