### PR TITLE
netutils: iperf: Add pthread_join() to wait for completion

### DIFF
--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -653,6 +653,7 @@ static uint32_t iperf_get_buffer_len(void)
 int iperf_start(struct iperf_cfg_t *cfg)
 {
   int ret;
+  void *retval;
   struct sched_param param;
   pthread_t thread;
   pthread_attr_t attr;
@@ -696,6 +697,7 @@ int iperf_start(struct iperf_cfg_t *cfg)
       return -1;
     }
 
+  pthread_join(thread, &retval);
   return 0;
 }
 


### PR DESCRIPTION
## Summary

- I noticed that lc823450-xgevk:rndis does not work with iperf
- Finally, I found that it does not call pthread_join()
- This commit fixes this issue

## Impact

- No impact

## Testing

- Tested with lc823450-xgevk:rndis
- NOTE: need to add iperf in the defconfig

