### PR TITLE
wget: print a message on an error

### DIFF
--- a/examples/wget/wget_main.c
+++ b/examples/wget/wget_main.c
@@ -176,7 +176,11 @@ int main(int argc, FAR char *argv[])
       ctx.url = CONFIG_EXAMPLES_WGET_URL;
     }
 
-  webclient_perform(&ctx);
+  int ret = webclient_perform(&ctx);
+  if (ret != 0)
+    {
+      printf("webclient_perform failed with %d\n", ret);
+    }
 
   return 0;
 }


### PR DESCRIPTION
## Summary
wget: print a message on an error
To give the user some clue on what's going.
## Impact

## Testing
a slight variant was tested locally