### PR TITLE
webclient.c: Remove a space after a negative sign

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -432,7 +432,7 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
             }
           else
             {
-              return - ECONNABORTED;
+              return -ECONNABORTED;
             }
 
           /* We're done parsing the status line, so start parsing


### PR DESCRIPTION
## Summary

from:

    return - ECONNABORTED;

to:

    return -ECONNABORTED;

The latter style is more commonly used within NuttX code base.

Note: nxstyle doesn't complain on either of them.

## Impact

## Testing

nxstyle passed locally
