### PR TITLE
netutils/ntpclient/Kconfig: Add NETUTILS_NTPCLIENT_STAY_ON

### DIFF
--- a/netutils/ntpclient/Kconfig
+++ b/netutils/ntpclient/Kconfig
@@ -45,9 +45,14 @@ config NETUTILS_NTPCLIENT_SERVERPRIO
 	int "NTP client daemon priority"
 	default 100
 
+config NETUTILS_NTPCLIENT_STAY_ON
+	bool "Make NTP client keep polling"
+	default y
+
 config NETUTILS_NTPCLIENT_POLLDELAYSEC
 	int "NTP client poll interval (seconds)"
 	default 60
+	depends on NETUTILS_NTPCLIENT_STAY_ON
 
 config NETUTILS_NTPCLIENT_RETRIES
 	int "NTP client retry seconds to wait for network up"


### PR DESCRIPTION
## Summary
netutils/ntpclient/Kconfig: Add NETUTILS_NTPCLIENT_STAY_ON

It's used in the code but missing in Kconfig.
I guess the PR [1] forgot to add this.

Make it "y" by default because it seems like the original behavior
before the PR [1].  I have no strong opinions on the default
either ways.

[1] https://github.com/apache/incubator-nuttx-apps/pull/570

## Impact

## Testing
tested on qemu with lm3s6965-ek:qemu-protected (with https://github.com/apache/incubator-nuttx/pull/2851)