### PR TITLE
nshlib: Fix dependency on FSUTILS_MKFATFS

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -381,7 +381,7 @@ config NSH_DISABLE_MKFATFS
 	bool "Disable mkfatfs"
 	default y if DEFAULT_SMALL
 	default n if !DEFAULT_SMALL
-	depends on FUTILS_MKFATFS
+	depends on FSUTILS_MKFATFS
 
 config NSH_DISABLE_MKFIFO
 	bool "Disable mkfifo"


### PR DESCRIPTION
## Summary
Currently it is not possible to disable the `mkfatfs` NSH command due to a typo in the `FSUTILS_MKFATFS` configuration in the dependency list.

## Impact
No impact, since no board configuration currently selects `NSH_DISABLE_MKFATFS`

## Testing
`NSH_DISABLE_MKFATFS` option properly appear on `make menuconfig` after dependencies are satisfied.
