### PR TITLE
lvgldemo: Add support for lcddev

### DIFF
--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -52,7 +52,7 @@ MODULE = $(CONFIG_EXAMPLES_LVGLDEMO)
 
 # LittleVGL demo Example
 
-CSRCS += fbdev.c tp.c tp_cal.c
+CSRCS += fbdev.c lcddev.c tp.c tp_cal.c
 
 # static common assets used in mutiple example
 

--- a/examples/lvgldemo/fbdev.h
+++ b/examples/lvgldemo/fbdev.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/lvgldemo/demo.h
+ * apps/examples/lvgldemo/fbdev.h
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Author: Gábor Kiss-Vámosi <kisvegabor@gmail.com>
@@ -52,13 +52,7 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-int fbdev_init(void);
-void fbdev_flush(struct _disp_drv_t *disp_drv, const lv_area_t *area,
-                 lv_color_t *color_p);
-void fbdev_fill(int32_t x1, int32_t y1, int32_t x2, int32_t y2,
-                lv_color_t color);
-void fbdev_map(int32_t x1, int32_t y1, int32_t x2, int32_t y2,
-               FAR const lv_color_t *color_p);
+int fbdev_init(lv_disp_drv_t *lv_drvr);
 
 #ifdef __cplusplus
 }

--- a/examples/lvgldemo/lcddev.c
+++ b/examples/lvgldemo/lcddev.c
@@ -1,0 +1,197 @@
+/****************************************************************************
+ * apps/examples/lvgldemo/lcddev.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "lcddev.h"
+
+#include <nuttx/config.h>
+#include <nuttx/lcd/lcd_dev.h>
+
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef LCDDEV_PATH
+#  define LCDDEV_PATH  "/dev/lcd0"
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct lcd_state_s
+{
+  int fd;
+  struct fb_videoinfo_s vinfo;
+  struct lcd_planeinfo_s pinfo;
+  bool rotated;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct lcd_state_s state;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lcddev_flush
+ *
+ * Description:
+ *   Flush a buffer to the marked area.
+ *
+ * Input Parameters:
+ *   disp_drv  - LVGL driver interface
+ *   lv_area_t - Area of the screen to be flushed
+ *   color_p   - A n array of colors
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void lcddev_flush(struct _disp_drv_t *disp_drv, const lv_area_t *area,
+                         lv_color_t *color_p)
+{
+  int ret;
+  struct lcddev_area_s lcd_area;
+
+  lcd_area.row_start = area->y1;
+  lcd_area.row_end = area->y2;
+  lcd_area.col_start = area->x1;
+  lcd_area.col_end = area->x2;
+
+  lcd_area.data = (uint8_t *)color_p;
+
+  ret = ioctl(state.fd, LCDDEVIO_PUTAREA,
+              (unsigned long)((uintptr_t)&lcd_area));
+
+  if (ret < 0)
+    {
+      int errcode = errno;
+
+      gerr("ERROR: ioctl(LCDDEVIO_PUTAREA) failed: %d\n",
+           errcode);
+      close(state.fd);
+      return;
+    }
+
+  /* Tell the flushing is ready */
+
+  lv_disp_flush_ready(disp_drv);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lcddev_init
+ *
+ * Description:
+ *   Initialize LCD device.
+ *
+ * Input Parameters:
+ *   lv_drvr -- LVGL driver interface
+ *
+ * Returned Value:
+ *   EXIT_SUCCESS on success; EXIT_FAILURE on failure.
+ *
+ ****************************************************************************/
+
+int lcddev_init(lv_disp_drv_t *lv_drvr)
+{
+  FAR const char *lcddev = LCDDEV_PATH;
+  int ret;
+
+  /* Open the framebuffer driver */
+
+  state.fd = open(lcddev, 0);
+  if (state.fd < 0)
+    {
+      int errcode = errno;
+      gerr("ERROR: Failed to open %s: %d\n", state.fd, errcode);
+      return EXIT_FAILURE;
+    }
+
+  /* Get the characteristics of the framebuffer */
+
+  ret = ioctl(state.fd, LCDDEVIO_GETVIDEOINFO,
+              (unsigned long)((uintptr_t)&state.vinfo));
+  if (ret < 0)
+    {
+      int errcode = errno;
+
+      gerr("ERROR: ioctl(LCDDEVIO_GETVIDEOINFO) failed: %d\n", errcode);
+      close(state.fd);
+      state.fd = -1;
+      return EXIT_FAILURE;
+    }
+
+  ginfo("VideoInfo:\n\tfmt: %u\n\txres: %u\n\tyres: %u\n\tnplanes: %u\n",
+        state.vinfo.fmt, state.vinfo.xres, state.vinfo.yres,
+        state.vinfo.nplanes);
+
+  ret = ioctl(state.fd, LCDDEVIO_GETPLANEINFO,
+              (unsigned long)((uintptr_t)&state.pinfo));
+  if (ret < 0)
+    {
+      int errcode = errno;
+      gerr("ERROR: ioctl(LCDDEVIO_GETPLANEINFO) failed: %d\n", errcode);
+      close(state.fd);
+      state.fd = -1;
+      return EXIT_FAILURE;
+    }
+
+  ginfo("PlaneInfo (plane 0):\n\tbpp: %u\n", state.pinfo.bpp);
+
+  if (state.pinfo.bpp != CONFIG_LV_COLOR_DEPTH)
+    {
+      /* For the LCD driver we do not have a great way to translate this
+       * so fail to initialize.
+       */
+
+      gerr(
+        "ERROR: Display bpp (%u) did not match CONFIG_LV_COLOR_DEPTH (%u)\n",
+        state.pinfo.bpp,
+        CONFIG_LV_COLOR_DEPTH);
+    }
+
+  lv_drvr->hor_res = state.vinfo.xres;
+  lv_drvr->ver_res = state.vinfo.yres;
+  lv_drvr->flush_cb = lcddev_flush;
+
+  return EXIT_SUCCESS;
+}

--- a/examples/lvgldemo/lcddev.h
+++ b/examples/lvgldemo/lcddev.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * apps/examples/lvgldemo/lcddev.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_EXAMPLES_LVGLDEMO_LCDDEV_H
+#define __APPS_EXAMPLES_LVGLDEMO_LCDDEV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <lvgl/lvgl.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int lcddev_init(lv_disp_drv_t *lv_drvr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPS_EXAMPLES_LVGLDEMO_LCDDEV_H */

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/lvgdemo/lvgldemo.c
+ * apps/examples/lvgldemo/lvgldemo.c
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -43,12 +43,13 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <pthread.h>
 #include <time.h>
+#include <debug.h>
 
 #include <lvgl/lvgl.h>
 
 #include "fbdev.h"
+#include "lcddev.h"
 #include "tp.h"
 #include "tp_cal.h"
 
@@ -90,6 +91,25 @@ void lv_demo_widgets(void);
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: monitor_cb
+ *
+ * Description:
+ *   Monitoring callback from lvgl every time the screen is flushed.
+ *
+ ****************************************************************************/
+
+static void monitor_cb(lv_disp_drv_t * disp_drv, uint32_t time, uint32_t px)
+{
+  ginfo("%" PRIu32 " px refreshed in %" PRIu32 " ms\n", px, time);
+}
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static lv_color_t buf[DISPLAY_BUFFER_SIZE];
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -109,9 +129,7 @@ void lv_demo_widgets(void);
 int main(int argc, FAR char *argv[])
 {
   lv_disp_drv_t disp_drv;
-
   lv_disp_buf_t disp_buf;
-  static lv_color_t buf[DISPLAY_BUFFER_SIZE];
 
 #ifndef CONFIG_EXAMPLES_LVGLDEMO_CALIBRATE
   lv_point_t p[4];
@@ -149,20 +167,31 @@ int main(int argc, FAR char *argv[])
 #endif
 #endif
 
-  /* LittlevGL initialization */
+  /* LVGL initialization */
 
   lv_init();
 
-  /* Display interface initialization */
-
-  fbdev_init();
-
-  /* Basic LittlevGL display driver initialization */
+  /* Basic LVGL display driver initialization */
 
   lv_disp_buf_init(&disp_buf, buf, NULL, DISPLAY_BUFFER_SIZE);
   lv_disp_drv_init(&disp_drv);
-  disp_drv.flush_cb = fbdev_flush;
   disp_drv.buffer = &disp_buf;
+  disp_drv.monitor_cb = monitor_cb;
+
+  /* Display interface initialization */
+
+  if (fbdev_init(&disp_drv) != EXIT_SUCCESS)
+    {
+      /* Failed to use framebuffer falling back to lcd driver */
+
+      if (lcddev_init(&disp_drv) != EXIT_SUCCESS)
+        {
+          /* No possible drivers left, fail */
+
+          return EXIT_FAILURE;
+        }
+    }
+
   lv_disp_drv_register(&disp_drv);
 
   /* Touchpad Initialization */


### PR DESCRIPTION
## Summary
This provides an adaptor for using lvgl with the lcddev in addition to the fbdev. As part of this it also fixes a compilation error when fbdev was used with CONFIG_FB_UPDATE.  There is also a monitoring callback enabled for monitoring the performance of the demo.

## Impact
lvgldemo can now be used without requiring a framebuffer to be created.

## Testing
You can see the demo running on my keyboard feather using the lcddev here (ignore the terrible refresh rate, that is due to the 8MHz SPI bus and DMA limitations I am addressing):
```
NuttShell (NSH) NuttX-10.0.1
nsh> lvgldemo
VideoInfo:
      fmt: 11
     xres: 240
     yres: 320
  nplanes: 1
PlaneInfo (plane 0):
      bpp: 16
tp_init: Opening /dev/input0
76800 px refreshed in 2250 ms
```
![image](https://user-images.githubusercontent.com/173245/108024988-803d8080-6fda-11eb-93d8-d64a6ea72a53.png)


