### PR TITLE
Pin Nimble release to working commit until stable tag is ready

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -9,7 +9,7 @@ config NIMBLE
 if NIMBLE
   config NIMBLE_REF
   string "Version"
-  default "master"
+  default "7b5b5e5b512133e50ef8a517b13e7269f9c821fd"
   ---help---
     Git ref name to use when downloading from nimBLE repo
 endif


### PR DESCRIPTION
## Summary
Pin Nimble release to working commit until stable tag is ready
See issue noted here: https://github.com/apache/incubator-nuttx-apps/issues/592

## Impact
CI should function again

## Testing
CI passes this was a previously tested sha.
