### PR TITLE
canutils: changed print_usage function to static

### DIFF
--- a/canutils/candump/candump.c
+++ b/canutils/candump/candump.c
@@ -115,7 +115,7 @@ extern int optind, opterr, optopt;
 
 static volatile int running = 1;
 
-void print_usage(char *prg)
+static void print_usage(char *prg)
 {
 	fprintf(stderr, "%s - dump CAN bus traffic.\n", prg);
 	fprintf(stderr, "\nUsage: %s [options] <CAN interface>+\n", prg);

--- a/canutils/cansend/cansend.c
+++ b/canutils/cansend/cansend.c
@@ -56,7 +56,7 @@
 
 #include "lib.h"
 
-void print_usage_send(char *prg)
+static void print_usage_send(char *prg)
 {
 	fprintf(stderr, "%s - send CAN-frames via CAN_RAW sockets.\n", prg);
 	fprintf(stderr, "\nUsage: %s <device> <can_frame>.\n", prg);


### PR DESCRIPTION
## Summary
Global print_usage function in canutils/candump/ was causing double definition error while compiling NuttX with some extern apps, like pysimCoder for example. Therefore the following change to static function. To be on safe side, the same change was also done in cansend.

## Testing

Tested on Teensy 4.1 with pysimCoder.
