### PR TITLE
fsutils: update geometry size (c.f. apache/incubator-nuttx#2861)

### DIFF
--- a/fsutils/mkfatfs/mkfatfs.c
+++ b/fsutils/mkfatfs/mkfatfs.c
@@ -154,7 +154,7 @@ static inline int mkfatfs_getgeometry(FAR struct fat_format_s *fmt,
       if (fmt->ff_nsectors > geometry.geo_nsectors)
         {
           ferr("ERROR: User maxblocks (%" PRId32
-               ") exceeds blocks on device (%zu)\n",
+               ") exceeds blocks on device (%" PRIu32 ")\n",
                fmt->ff_nsectors, geometry.geo_nsectors);
 
           return -EINVAL;


### PR DESCRIPTION
## Summary

apache/incubator-nuttx#2861 updates `struct geometry` to use `uint32_t` instead of `size_t`. This PR alters the format string used for printing geometry details.

## Impact

Along with the other PR, this PR fixes geometry support on platforms where `size_t` is not 32 bits.

## Testing

CI tests only.