### PR TITLE
examples/watcher: Add missing dependencies on Kconfig

### DIFF
--- a/examples/watcher/Kconfig
+++ b/examples/watcher/Kconfig
@@ -6,6 +6,8 @@
 config EXAMPLES_WATCHER
 	tristate "Watcher example"
 	default n
+	depends on DRIVER_NOTERAM
+	depends on FSUTILS_MKFATFS
 	---help---
 		Enable the watcher example. The watcher is a task that will monitor
 		other tasks that have previously subscribed to be watched. If the 


### PR DESCRIPTION
## Summary
Watcher application makes use of the Note RAM Driver and also calls `mkfatfs` function which is only available if `FSUTILS_MKFATFS` is provided.
This PR makes the dependencies explicit on Kconfig.

## Impact
No impact, only `esp32-devkitc:watcher` included Watcher application, and it already included both dependencies.

## Testing
Watcher example application no longer shows when dependencies are missing.

