### PR TITLE
ntpclient: Add api and command to query status

### DIFF
--- a/include/netutils/ntpclient.h
+++ b/include/netutils/ntpclient.h
@@ -42,6 +42,8 @@
 
 #include <nuttx/config.h>
 
+#include <sys/socket.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -143,6 +145,34 @@ int ntpc_start(void);
  ****************************************************************************/
 
 int ntpc_stop(void);
+
+/****************************************************************************
+ * Name: ntpc_status
+ *
+ * Description:
+ *   Get a status of the NTP daemon
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+struct ntpc_status_s
+{
+  /* the latest samples */
+
+  unsigned int nsamples;
+  struct
+  {
+    int64_t offset;
+    int64_t delay;
+    FAR const struct sockaddr *srv_addr;
+    struct sockaddr_storage _srv_addr_store;
+  }
+  samples[CONFIG_NETUTILS_NTPCLIENT_NUM_SAMPLES];
+};
+
+int ntpc_status(struct ntpc_status_s *statusp);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -160,6 +160,7 @@ union ntp_addr_u
 #ifdef CONFIG_NET_IPv6
   struct sockaddr_in6 in6;
 #endif
+  struct sockaddr_storage ss;
 };
 
 /* NTP offset. */
@@ -210,6 +211,10 @@ static struct ntpc_daemon_s g_ntpc_daemon =
   { NULL, NULL },
   AF_UNSPEC,         /* Default is both IPv4 and IPv6 */
 };
+
+static struct ntp_sample_s g_last_samples
+    [CONFIG_NETUTILS_NTPCLIENT_NUM_SAMPLES];
+unsigned int g_last_nsamples = 0;
 
 /****************************************************************************
  * Private Functions
@@ -1369,6 +1374,13 @@ static int ntpc_daemon(int argc, FAR char **argv)
 
           ntpc_settime(offset, &start_realtime, &start_monotonic);
 
+          /* Save samples for ntpc_status() */
+
+          sem_wait(&g_ntpc_daemon.lock);
+          g_last_nsamples = nsamples;
+          memcpy(&g_last_samples, samples, nsamples * sizeof(*samples));
+          sem_post(&g_ntpc_daemon.lock);
+
 #ifndef CONFIG_NETUTILS_NTPCLIENT_STAY_ON
           /* Configured to exit at success. */
 
@@ -1566,6 +1578,25 @@ int ntpc_stop(void)
           sem_wait(&g_ntpc_daemon.sync);
         }
       while (g_ntpc_daemon.state == NTP_STOP_REQUESTED);
+    }
+
+  sem_post(&g_ntpc_daemon.lock);
+  return OK;
+}
+
+int ntpc_status(struct ntpc_status_s *statusp)
+{
+  unsigned int i;
+
+  sem_wait(&g_ntpc_daemon.lock);
+  statusp->nsamples = g_last_nsamples;
+  for (i = 0; i < g_last_nsamples; i++)
+    {
+      statusp->samples[i].offset = g_last_samples[i].offset;
+      statusp->samples[i].delay = g_last_samples[i].delay;
+      statusp->samples[i]._srv_addr_store = g_last_samples[i].srv_addr.ss;
+      statusp->samples[i].srv_addr = (FAR const struct sockaddr *)
+                                     &statusp->samples[i]._srv_addr_store;
     }
 
   sem_post(&g_ntpc_daemon.lock);

--- a/system/ntpc/Makefile
+++ b/system/ntpc/Makefile
@@ -37,13 +37,13 @@ include $(APPDIR)/Make.defs
 
 # NTPC address renewal built-in application info
 
-PROGNAME = ntpcstart ntpcstop
+PROGNAME = ntpcstart ntpcstop ntpcstatus
 PRIORITY = $(CONFIG_SYSTEM_NTPC_PRIORITY)
 STACKSIZE = $(CONFIG_SYSTEM_NTPC_STACKSIZE)
 MODULE = $(CONFIG_SYSTEM_NTPC)
 
 # NTPC address renewal
 
-MAINSRC = ntpcstart_main.c ntpcstop_main.c
+MAINSRC = ntpcstart_main.c ntpcstop_main.c ntpcstatus_main.c
 
 include $(APPDIR)/Application.mk

--- a/system/ntpc/ntpcstatus_main.c
+++ b/system/ntpc/ntpcstatus_main.c
@@ -1,0 +1,125 @@
+/****************************************************************************
+ * system/ntpc/ntpc_status.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <inttypes.h>
+#ifdef CONFIG_LIBC_NETDB
+#include <netdb.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "netutils/ntpclient.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/* "-", uint64_t, ".", 9 digits fraction part, NUL */
+
+#define	NTP_TIME_STR_MAX_LEN (1 + 21 + 1 + 9 + 1)
+
+static void
+format_ntptimestamp(int64_t ts, FAR char *buf)
+{
+  FAR const char *sign;
+  uint64_t absts;
+
+  if (ts < 0)
+    {
+      sign = "-";
+      absts = -ts;
+    }
+  else
+    {
+      sign = "";
+      absts = ts;
+    }
+
+  sprintf(buf, "%s%" PRIu64 ".%09" PRIu64,
+          sign, absts >> 32,
+          ((absts & 0xffffffff) * NSEC_PER_SEC) >> 32);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * ntpcstatus_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct ntpc_status_s status;
+  unsigned int i;
+  int ret;
+
+  ret = ntpc_status(&status);
+  if (ret < 0)
+    {
+      fprintf(stderr, "ERROR: ntpc_status() failed\n");
+      return EXIT_FAILURE;
+    }
+
+  printf("The number of last samples: %u\n", status.nsamples);
+  for (i = 0; i < status.nsamples; i++)
+    {
+      FAR const struct sockaddr *sa;
+      socklen_t salen;
+      FAR const char *name = "<noname>";
+      char offset_buf[NTP_TIME_STR_MAX_LEN];
+      char delay_buf[NTP_TIME_STR_MAX_LEN];
+
+      sa = status.samples[i].srv_addr;
+      salen = (sa->sa_family == AF_INET) ? sizeof(struct sockaddr_in)
+                                         : sizeof(struct sockaddr_in6);
+#ifdef CONFIG_LIBC_NETDB
+      char hbuf[NI_MAXHOST];
+
+      ret = getnameinfo(sa, salen,
+                        hbuf, sizeof(hbuf), NULL, 0, NI_NUMERICHOST);
+      if (ret == 0)
+        {
+          name = hbuf;
+        }
+      else
+        {
+          fprintf(stderr, "WARNING: getnameinfo failed: %s\n",
+                  gai_strerror(ret));
+        }
+#endif
+
+      format_ntptimestamp(status.samples[i].offset, offset_buf);
+      format_ntptimestamp(status.samples[i].delay, delay_buf);
+      printf("[%u] srv %s offset %s delay %s\n",
+             i, name, offset_buf, delay_buf);
+    }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add ntpcstatus command, which shows the client status.

```
nsh> ntpcstatus
The number of last samples: 5
[0] srv 178.16.23.50 offset -0.014006560 delay 0.349967444
[1] srv 5.9.57.158 offset 0.001792161 delay 0.269991633
[2] srv 206.75.147.25 offset 0.009916600 delay 0.129989672
[3] srv 162.159.200.1 offset 0.011508908 delay 0.019917401
[4] srv 185.19.184.35 offset 0.021468135 delay 0.239915030
nsh> 
```

this depends on https://github.com/apache/incubator-nuttx/pull/2869

## Impact

## Testing
tested locally with `lm3s6965-ek:qemu-protected` config.
