### PR TITLE
Fix CLE initial cursor position

### DIFF
--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -1196,7 +1196,7 @@ int cle(FAR char *line, const char *prompt, uint16_t linelen,
       return -EINVAL;
     }
 
-  priv.coloffs = column - 1;
+  priv.coloffs = column;
 
   cleinfo("row=%d column=%d\n", priv.row, column);
 

--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -168,7 +168,7 @@ struct cle_s
  ****************************************************************************/
 
 #if CONFIG_SYSTEM_CLE_DEBUGLEVEL > 0
-static int      cle_debug(FAR const char *fmt, ...);
+static void     cle_debug(FAR const char *fmt, ...);
 #endif
 
 /* Low-level display and data entry functions */
@@ -248,17 +248,15 @@ static const char g_setcolor[]     = VT100_FMT_FORE_COLOR;
  ****************************************************************************/
 
 #if CONFIG_SYSTEM_CLE_DEBUGLEVEL > 0
-static int cle_debug(FAR const char *fmt, ...)
+static void cle_debug(FAR const char *fmt, ...)
 {
   va_list ap;
-  int ret;
 
   /* Let vsyslog do the real work */
 
   va_start(ap, fmt);
-  ret = vsyslog(LOG_DEBUG, fmt, ap);
+  vsyslog(LOG_DEBUG, fmt, ap);
   va_end(ap);
-  return ret;
 }
 #endif
 


### PR DESCRIPTION
## Summary
As noted by @v01d in [incubator-nuttx#2838](https://github.com/apache/incubator-nuttx/pull/2838#issuecomment-778363299), there was a missing whitespace after the NSH prompt.
It seems it was due to a bug in the CLE application, which was miscalculating the initial cursor position. At first, after printing the "nsh> " prompt the Host correctly reports the initial cursor position as `ESC ] 39 ; 6 R`, which means **row:39** and **column:6**.

But, next the CLE app calculates an offset of 5 (column - 1) for the initial cursor position. But, this offset is sent to the Host later as if the first column was 0.

```
NuttShell (NSH) NuttX-10.0.1
nsh> Returning: .[1b]
Returning: [[5b]
Returning: 3[33]
Returning: 9[39]
Returning: ;[3b]
Returning: 6[36]
Returning: R[52]
row=39 column=6
row=39 column=6
row=39 column=0 offset=5
row=39 column=0 offset=5
```
According to the [VT100 documentation](https://vt100.net/docs/vt100-ug/chapter3.html), the column for the initial cursor position is 1:

![image](https://user-images.githubusercontent.com/38959758/108504250-5616e780-7294-11eb-8487-f6e9e0925de6.png)

## Impact
Visual impact and only for targets using SYSTEM_CLE as the NSH command line editor.

## Testing
Tested on:
- `esp32c3-devkit:nsh`
- `esp32-devkitc:nsh`

