### PR TITLE
system/i2c: Fix typo in "repetitions" word

### DIFF
--- a/system/i2c/README.md
+++ b/system/i2c/README.md
@@ -69,10 +69,10 @@ Where <cmd> is one of:
   Show help     : ?
   List buses    : bus
   List devices  : dev [OPTIONS] <first> <last>
-  Read register : get [OPTIONS] [<repititions>]
+  Read register : get [OPTIONS] [<repetitions>]
   Show help     : help
-  Write register: set [OPTIONS] <value> [<repititions>]
-  Verify access : verf [OPTIONS] <value> [<repititions>]
+  Write register: set [OPTIONS] <value> [<repetitions>]
+  Verify access : verf [OPTIONS] <value> [<repetitions>]
 
   Where common _sticky_ OPTIONS include:
     [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -80,7 +80,7 @@ Where <cmd> is one of:
     [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
     [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
     [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-    [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+    [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
     [-f freq] I2C frequency.  Default: 100000 Current: 100000
 ```
 
@@ -192,7 +192,7 @@ NSH scripts to execute a longer, more complex series of I2C commands.
   This determines whether or not there should be a new I2C START between sending
   of the register address and sending/receiving of the register data.
 
-- `[-i|j]`, Auto increment|don't increment `regaddr` on repititions. Default:
+- `[-i|j]`, Auto increment|don't increment `regaddr` on repetitions. Default:
   `NO` Current: `NO`
 
   On commands that take a optional number of repetitions, the option can be used
@@ -269,10 +269,10 @@ This command with write the 8-bit address value then read an 8- or 16-bit data
 value from the device. Optionally, it may re-start the transfer before obtaining
 the data.
 
-An optional `<repititions>` argument can be supplied to repeat the read
+An optional `<repetitions>` argument can be supplied to repeat the read
 operation an arbitrary number of times (up to 2 billion). If auto-increment is
 select (`-i`), then the register address will be temporarily incremented on each
-repitions. The increment is temporary in the since that it will not alter the
+repetitions. The increment is temporary in the since that it will not alter the
 _sticky_ value of the register address.
 
 On success, the output will look like the following (the data value read will be
@@ -297,10 +297,10 @@ This command will write the 8-bit address value then write the 8- or 16-bit data
 value to the device. Optionally, it may re-start the transfer before writing the
 data.
 
-An optional `<repititions>` argument can be supplied to repeat the write
+An optional `<repetitions>` argument can be supplied to repeat the write
 operation an arbitrary number of times (up to 2 billion). If auto-increment is
 select (`-i`), then the register address will be temporarily incremented on each
-repitions. The increment is temporary in the since that it will not alter the
+repetitions. The increment is temporary in the since that it will not alter the
 _sticky_ value of the register address.
 
 On success, the output will look like the following (the data value written will
@@ -313,7 +313,7 @@ WROTE Bus: 1 Addr: 49 Subaddr: 04 Value: 96
 
 All values (except the bus numbers) are hexadecimal.
 
-### Verify access: `verf [OPTIONS] <value> [<repititions>]`
+### Verify access: `verf [OPTIONS] <value> [<repetitions>]`
 
 
 This command combines writing and reading from an I2C device register. It will
@@ -326,10 +326,10 @@ and emit an error message if they do not match.
 If no value is provided, then this command will use the register address itself
 as the data, providing for a address-in-address test.
 
-An optional `<repititions>` argument can be supplied to repeat the verify
+An optional `<repetitions>` argument can be supplied to repeat the verify
 operation an arbitrary number of times (up to 2 billion). If auto-increment is
 select (`-i`), then the register address will be temporarily incremented on each
-repitions. The increment is temporary in the since that it will not alter the
+repetitions. The increment is temporary in the since that it will not alter the
 `sticky` value of the register address.
 
 On success, the output will look like the following (the data value written will

--- a/system/i2c/i2c_get.c
+++ b/system/i2c/i2c_get.c
@@ -116,8 +116,8 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   fd = i2cdev_open(i2ctool->bus);
   if (fd < 0)
     {
-       i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
-       return ERROR;
+      i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
+      return ERROR;
     }
 
   /* Loop for the requested number of repetitions */
@@ -135,7 +135,8 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
       if (ret == OK)
         {
-          i2ctool_printf(i2ctool, "READ Bus: %d Addr: %02x Subaddr: %02x Value: ",
+          i2ctool_printf(i2ctool,
+                         "READ Bus: %d Addr: %02x Subaddr: %02x Value: ",
                          i2ctool->bus, i2ctool->addr, regaddr);
 
           if (i2ctool->width == 8)
@@ -173,12 +174,12 @@ int i2ctool_get(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
                 FAR uint16_t *result)
 {
   struct i2c_msg_s msg[2];
+  int ret;
   union
   {
     uint16_t data16;
     uint8_t  data8;
   } u;
-  int ret;
 
   /* Set up data structures */
 
@@ -201,14 +202,14 @@ int i2ctool_get(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
         }
       else
         {
-          msg[1].buffer = (uint8_t*)&u.data16;
+          msg[1].buffer = (uint8_t *)&u.data16;
           msg[1].length = 2;
         }
 
       if (i2ctool->start)
         {
           ret = i2cdev_transfer(fd, &msg[0], 1);
-          if (ret== OK)
+          if (ret == OK)
             {
               ret = i2cdev_transfer(fd, &msg[1], 1);
             }
@@ -235,7 +236,7 @@ int i2ctool_get(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
         }
       else
         {
-          msg[0].buffer = (uint8_t*)&u.data16;
+          msg[0].buffer = (uint8_t *)&u.data16;
           msg[0].length = 2;
         }
 

--- a/system/i2c/i2c_get.c
+++ b/system/i2c/i2c_get.c
@@ -58,7 +58,7 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   FAR char *ptr;
   uint16_t result;
   uint8_t regaddr;
-  long repititions;
+  long repetitions;
   int nargs;
   int argndx;
   int ret;
@@ -92,11 +92,11 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
    * count.
    */
 
-  repititions = 1;
+  repetitions = 1;
   if (argndx < argc)
     {
-      repititions = strtol(argv[argndx], NULL, 16);
-      if (repititions < 1)
+      repetitions = strtol(argv[argndx], NULL, 16);
+      if (repetitions < 1)
         {
           i2ctool_printf(i2ctool, g_i2cargrange, argv[0]);
           return ERROR;
@@ -120,12 +120,12 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
        return ERROR;
     }
 
-  /* Loop for the requested number of repititions */
+  /* Loop for the requested number of repetitions */
 
   regaddr = i2ctool->regaddr;
   ret = OK;
 
-  for (i = 0; i < repititions; i++)
+  for (i = 0; i < repetitions; i++)
     {
       /* Read from the I2C bus */
 

--- a/system/i2c/i2c_main.c
+++ b/system/i2c/i2c_main.c
@@ -71,11 +71,11 @@ static const struct cmdmap_s g_i2ccmds[] =
   { "?",    i2ccmd_help, "Show help     ",  NULL },
   { "bus",  i2ccmd_bus,  "List buses    ",  NULL },
   { "dev",  i2ccmd_dev,  "List devices  ", "[OPTIONS] <first> <last>" },
-  { "get",  i2ccmd_get,  "Read register ", "[OPTIONS] [<repititions>]" },
+  { "get",  i2ccmd_get,  "Read register ", "[OPTIONS] [<repetitions>]" },
   { "dump", i2ccmd_dump, "Dump register ", "[OPTIONS] [<num bytes>]" },
   { "help", i2ccmd_help, "Show help     ", NULL },
-  { "set",  i2ccmd_set,  "Write register", "[OPTIONS] <value> [<repititions>]" },
-  { "verf", i2ccmd_verf, "Verify access ", "[OPTIONS] [<value>] [<repititions>]" },
+  { "set",  i2ccmd_set,  "Write register", "[OPTIONS] <value> [<repetitions>]" },
+  { "verf", i2ccmd_verf, "Verify access ", "[OPTIONS] [<value>] [<repetitions>]" },
   { NULL,   NULL,        NULL,             NULL }
 };
 
@@ -133,7 +133,7 @@ static int i2ccmd_help(FAR struct i2ctool_s *i2ctool, int argc, char **argv)
   i2ctool_printf(i2ctool, "  [-s|n], send/don't send start between command and data.  "
                           "Default: -n Current: %s\n",
                  i2ctool->start ? "-s" : "-n");
-  i2ctool_printf(i2ctool, "  [-i|j], Auto increment|don't increment regaddr on repititions.  "
+  i2ctool_printf(i2ctool, "  [-i|j], Auto increment|don't increment regaddr on repetitions.  "
                           "Default: NO Current: %s\n",
                  i2ctool->autoincr ? "YES" : "NO");
   i2ctool_printf(i2ctool, "  [-f freq] I2C frequency.  "

--- a/system/i2c/i2c_main.c
+++ b/system/i2c/i2c_main.c
@@ -68,14 +68,20 @@ static struct i2ctool_s g_i2ctool;
 
 static const struct cmdmap_s g_i2ccmds[] =
 {
-  { "?",    i2ccmd_help, "Show help     ",  NULL },
-  { "bus",  i2ccmd_bus,  "List buses    ",  NULL },
+  { "?",    i2ccmd_help, "Show help     ", NULL },
+  { "bus",  i2ccmd_bus,  "List buses    ", NULL },
   { "dev",  i2ccmd_dev,  "List devices  ", "[OPTIONS] <first> <last>" },
   { "get",  i2ccmd_get,  "Read register ", "[OPTIONS] [<repetitions>]" },
   { "dump", i2ccmd_dump, "Dump register ", "[OPTIONS] [<num bytes>]" },
   { "help", i2ccmd_help, "Show help     ", NULL },
-  { "set",  i2ccmd_set,  "Write register", "[OPTIONS] <value> [<repetitions>]" },
-  { "verf", i2ccmd_verf, "Verify access ", "[OPTIONS] [<value>] [<repetitions>]" },
+  {
+    "set",  i2ccmd_set,  "Write register",
+      "[OPTIONS] <value> [<repetitions>]"
+  },
+  {
+    "verf", i2ccmd_verf, "Verify access ",
+      "[OPTIONS] [<value>] [<repetitions>]"
+  },
   { NULL,   NULL,        NULL,             NULL }
 };
 
@@ -85,7 +91,8 @@ static const struct cmdmap_s g_i2ccmds[] =
 
 /* Common, message formats */
 
-const char g_i2cargrequired[] = "i2ctool: %s: missing required argument(s)\n";
+const char g_i2cargrequired[] =
+                    "i2ctool: %s: missing required argument(s)\n";
 const char g_i2carginvalid[]  = "i2ctool: %s: argument invalid\n";
 const char g_i2cargrange[]    = "i2ctool: %s: value out of range\n";
 const char g_i2ccmdnotfound[] = "i2ctool: %s: command not found\n";
@@ -120,38 +127,54 @@ static int i2ccmd_help(FAR struct i2ctool_s *i2ctool, int argc, char **argv)
         }
     }
 
-  i2ctool_printf(i2ctool, "\nWhere common \"sticky\" OPTIONS include:\n");
-  i2ctool_printf(i2ctool, "  [-a addr] is the I2C device address (hex).  "
-                          "Default: %02x Current: %02x\n",
+  i2ctool_printf(i2ctool,
+                 "\nWhere common \"sticky\" OPTIONS include:\n");
+  i2ctool_printf(i2ctool,
+                 "  [-a addr] is the I2C device address (hex)."
+                 "  Default: %02x Current: %02x\n",
                  CONFIG_I2CTOOL_MINADDR, i2ctool->addr);
-  i2ctool_printf(i2ctool, "  [-b bus] is the I2C bus number (decimal).  "
-                          "Default: %d Current: %d\n",
+  i2ctool_printf(i2ctool,
+                 "  [-b bus] is the I2C bus number (decimal)."
+                 "  Default: %d Current: %d\n",
                  CONFIG_I2CTOOL_MINBUS, i2ctool->bus);
-  i2ctool_printf(i2ctool, "  [-w width] is the data width (8 or 16 decimal).  "
-                          "Default: 8 Current: %d\n",
+  i2ctool_printf(i2ctool,
+                 "  [-w width] is the data width (8 or 16 decimal)."
+                 "  Default: 8 Current: %d\n",
                  i2ctool->width);
-  i2ctool_printf(i2ctool, "  [-s|n], send/don't send start between command and data.  "
-                          "Default: -n Current: %s\n",
+  i2ctool_printf(i2ctool,
+                 "  [-s|n], send/don't send start between command and data."
+                 "  Default: -n Current: %s\n",
                  i2ctool->start ? "-s" : "-n");
-  i2ctool_printf(i2ctool, "  [-i|j], Auto increment|don't increment regaddr on repetitions.  "
-                          "Default: NO Current: %s\n",
+  i2ctool_printf(i2ctool,
+                 "  [-i|j], Auto increment|don't increment regaddr on "
+                 "repetitions."
+                 "  Default: NO Current: %s\n",
                  i2ctool->autoincr ? "YES" : "NO");
-  i2ctool_printf(i2ctool, "  [-f freq] I2C frequency.  "
-                          "Default: %d Current: %d\n",
+  i2ctool_printf(i2ctool,
+                 "  [-f freq] I2C frequency."
+                 "  Default: %d Current: %d\n",
                  CONFIG_I2CTOOL_DEFFREQ, i2ctool->freq);
 
   i2ctool_printf(i2ctool, "\nSpecial non-sticky options:\n");
-  i2ctool_printf(i2ctool, "  [-r regaddr] is the I2C device register index (hex).  "
-                          "Default: not used/sent\n");
+  i2ctool_printf(i2ctool,
+                 "  [-r regaddr] is the I2C device register index (hex)."
+                 "  Default: not used/sent\n");
 
   i2ctool_printf(i2ctool, "\nNOTES:\n");
 #ifndef CONFIG_DISABLE_ENVIRON
-  i2ctool_printf(i2ctool, "o An environment variable like $PATH may be used for any argument.\n");
+  i2ctool_printf(i2ctool, "o An environment variable like $PATH may be used "
+                          "for any argument.\n");
 #endif
-  i2ctool_printf(i2ctool, "o Arguments are \"sticky\".  For example, once the I2C address is\n");
-  i2ctool_printf(i2ctool, "  specified, that address will be re-used until it is changed.\n");
+  i2ctool_printf(i2ctool,
+                 "o Arguments are \"sticky\". For example, once "
+                 "the I2C address is\n");
+  i2ctool_printf(i2ctool,
+                 "  specified, that address will be re-used until "
+                 "it is changed.\n");
   i2ctool_printf(i2ctool, "\nWARNING:\n");
-  i2ctool_printf(i2ctool, "o The I2C dev command may have bad side effects on your I2C devices.\n");
+  i2ctool_printf(i2ctool,
+                 "o The I2C dev command may have bad side effects "
+                 "on your I2C devices.\n");
   i2ctool_printf(i2ctool, "  Use only at your own risk.\n");
   return OK;
 }

--- a/system/i2c/i2c_set.c
+++ b/system/i2c/i2c_set.c
@@ -58,7 +58,7 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   FAR char *ptr;
   uint8_t regaddr;
   long value;
-  long repititions;
+  long repetitions;
   int nargs;
   int argndx;
   int ret;
@@ -120,11 +120,11 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
    * count.
    */
 
-  repititions = 1;
+  repetitions = 1;
   if (argndx < argc)
     {
-      repititions = strtol(argv[argndx], NULL, 16);
-      if (repititions < 1)
+      repetitions = strtol(argv[argndx], NULL, 16);
+      if (repetitions < 1)
         {
           i2ctool_printf(i2ctool, g_i2cargrange, argv[0]);
           return ERROR;
@@ -148,12 +148,12 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
        return ERROR;
     }
 
-  /* Loop for the requested number of repititions */
+  /* Loop for the requested number of repetitions */
 
   regaddr = i2ctool->regaddr;
   ret = OK;
 
-  for (i = 0; i < repititions; i++)
+  for (i = 0; i < repetitions; i++)
     {
       /* Write to the I2C bus */
 

--- a/system/i2c/i2c_set.c
+++ b/system/i2c/i2c_set.c
@@ -84,6 +84,7 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
         {
           return ERROR;
         }
+
       argndx += nargs;
     }
 
@@ -144,8 +145,8 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   fd = i2cdev_open(i2ctool->bus);
   if (fd < 0)
     {
-       i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
-       return ERROR;
+      i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
+      return ERROR;
     }
 
   /* Loop for the requested number of repetitions */
@@ -163,7 +164,8 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
       if (ret == OK)
         {
-          i2ctool_printf(i2ctool, "WROTE Bus: %d Addr: %02x Subaddr: %02x Value: ",
+          i2ctool_printf(i2ctool,
+                         "WROTE Bus: %d Addr: %02x Subaddr: %02x Value: ",
                          i2ctool->bus, i2ctool->addr, i2ctool->regaddr);
           if (i2ctool->width == 8)
             {
@@ -200,13 +202,12 @@ int i2ctool_set(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
                 uint16_t value)
 {
   struct i2c_msg_s msg[2];
+  int ret;
   union
   {
     uint16_t data16;
     uint8_t  data8;
   } u;
-  int ret;
-
 
   if (i2ctool->hasregindx)
     {
@@ -231,7 +232,7 @@ int i2ctool_set(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
       else
         {
           u.data16      = value;
-          msg[1].buffer = (uint8_t*)&u.data16;
+          msg[1].buffer = (uint8_t *)&u.data16;
           msg[1].length = 2;
         }
 
@@ -268,7 +269,7 @@ int i2ctool_set(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
       else
         {
           u.data16      = value;
-          msg[0].buffer = (uint8_t*)&u.data16;
+          msg[0].buffer = (uint8_t *)&u.data16;
           msg[0].length = 2;
         }
 

--- a/system/i2c/i2c_verf.c
+++ b/system/i2c/i2c_verf.c
@@ -60,7 +60,7 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   uint8_t regaddr;
   bool addrinaddr;
   long wrvalue;
-  long repititions;
+  long repetitions;
   int nargs;
   int argndx;
   int ret;
@@ -122,11 +122,11 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
    * count.
    */
 
-  repititions = 1;
+  repetitions = 1;
   if (argndx < argc)
     {
-      repititions = strtol(argv[argndx], NULL, 16);
-      if (repititions < 1)
+      repetitions = strtol(argv[argndx], NULL, 16);
+      if (repetitions < 1)
         {
           i2ctool_printf(i2ctool, g_i2cargrange, argv[0]);
           return ERROR;
@@ -150,12 +150,12 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
        return ERROR;
     }
 
-  /* Loop for the requested number of repititions */
+  /* Loop for the requested number of repetitions */
 
   regaddr = i2ctool->regaddr;
   ret = OK;
 
-  for (i = 0; i < repititions; i++)
+  for (i = 0; i < repetitions; i++)
     {
       /* If we are performing an address-in-address test, then use the register
        * address as the value to write.

--- a/system/i2c/i2c_verf.c
+++ b/system/i2c/i2c_verf.c
@@ -86,12 +86,13 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
         {
           return ERROR;
         }
+
       argndx += nargs;
     }
 
-  /* The options may be followed by the optional wrvalue to be written.  If omitted, then
-   * the register address will be used as the wrvalue, providing an address-in-address
-   * test.
+  /* The options may be followed by the optional wrvalue to be written.
+   * If omitted, then the register address will be used as the wrvalue,
+   * providing an address-in-address test.
    */
 
   addrinaddr = true;
@@ -146,8 +147,8 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
   fd = i2cdev_open(i2ctool->bus);
   if (fd < 0)
     {
-       i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
-       return ERROR;
+      i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
+      return ERROR;
     }
 
   /* Loop for the requested number of repetitions */
@@ -157,8 +158,8 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
   for (i = 0; i < repetitions; i++)
     {
-      /* If we are performing an address-in-address test, then use the register
-       * address as the value to write.
+      /* If we are performing an address-in-address test, then use the
+       * register address as the value to write.
        */
 
       if (addrinaddr)
@@ -180,16 +181,21 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
       if (ret == OK)
         {
-          i2ctool_printf(i2ctool, "VERIFY Bus: %d Addr: %02x Subaddr: %02x Wrote: ",
+          i2ctool_printf(i2ctool,
+                         "VERIFY Bus: %d Addr: %02x Subaddr: %02x Wrote: ",
                          i2ctool->bus, i2ctool->addr, i2ctool->regaddr);
 
           if (i2ctool->width == 8)
             {
-              i2ctool_printf(i2ctool, "%02x Read: %02x", (int)wrvalue, (int)rdvalue);
+              i2ctool_printf(i2ctool,
+                             "%02x Read: %02x",
+                             (int)wrvalue, (int)rdvalue);
             }
           else
             {
-              i2ctool_printf(i2ctool, "%04x Read: %04x", (int)wrvalue, (int)rdvalue);
+              i2ctool_printf(i2ctool,
+                             "%04x Read: %04x",
+                             (int)wrvalue, (int)rdvalue);
             }
 
           if (wrvalue != rdvalue)

--- a/system/i2c/i2ctool.h
+++ b/system/i2c/i2ctool.h
@@ -142,7 +142,7 @@ struct i2ctool_s
   uint8_t  regaddr;    /* [-r regaddr] is the I2C device register address */
   uint8_t  width;      /* [-w width] is the data width (8 or 16) */
   bool     start;      /* [-s|n], send|don't send start between command and data */
-  bool     autoincr;   /* [-i|j], Auto increment|don't increment regaddr on repititions */
+  bool     autoincr;   /* [-i|j], Auto increment|don't increment regaddr on repetitions */
   bool     hasregindx; /* true with the use of -r */
   uint32_t freq;       /* [-f freq] I2C frequency */
 


### PR DESCRIPTION
## Summary
Fix several typos in the "repetitions" word.

## Impact
No impact.

## Testing
Not applicable.

