### PR TITLE
net/socket: change config CONFIG_NSOCKET_DESCRIPTORS to CONFIG_NFILE_DESCRIPTORS

### DIFF
--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -7,8 +7,8 @@
  *
  * Derived from the file of the same name in the original THTTPD package:
  *
- *   Copyright (C) 1995,1998,1999,2000,2001 by Jef Poskanzer <jef@mail.acme.com>.
- *   All rights reserved.
+ *   Copyright (C) 1995,1998,1999,2000,2001 by
+ *   Jef Poskanzer <jef@mail.acme.com>. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,7 +85,7 @@
 #define CNST_LINGERING 3
 
 #define SPARE_FDS      2
-#define AVAILABLE_FDS  (CONFIG_NSOCKET_DESCRIPTORS - SPARE_FDS)
+#define AVAILABLE_FDS  (CONFIG_NFILE_DESCRIPTORS - SPARE_FDS)
 
 /****************************************************************************
  * Private Types

--- a/netutils/thttpd/thttpd_cgi.c
+++ b/netutils/thttpd/thttpd_cgi.c
@@ -7,8 +7,8 @@
  *
  * Derived from the file libhttpd.c in the original THTTPD package:
  *
- *   Copyright © 1995,1998,1999,2000,2001 by Jef Poskanzer <jef@mail.acme.com>.
- *   All rights reserved.
+ *   Copyright © 1995,1998,1999,2000,2001 by
+ *   Jef Poskanzer <jef@mail.acme.com>. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* CONFIG_THTTPD_CGIDUMP will dump the contents of each transfer to and from the CGI task. */
+/* CONFIG_THTTPD_CGIDUMP will dump the contents of each transfer to and
+ * from the CGI task.
+ */
 
 #ifdef CONFIG_THTTPD_CGIDUMP
 #  define cgi_dumpbuffer(m,a,n) lib_dumpbuffer(m,(FAR const uint8_t*)a,n)
@@ -102,8 +104,8 @@ struct cgi_outbuffer_s
 
 struct cgi_inbuffer_s
 {
-  int    contentlength;			/* Size of content to send to CGI task */
-  int    nbytes;				/* Number of bytes sent */
+  int    contentlength;                         /* Size of content to send to CGI task */
+  int    nbytes;                                /* Number of bytes sent */
   char   buffer[CONFIG_THTTPD_CGIINBUFFERSIZE]; /* Fixed size input buffer */
 };
 
@@ -221,7 +223,8 @@ static void create_environment(httpd_conn *hc)
         }
     }
 
-  snprintf(buf, sizeof(buf), "/%s",strcmp(hc->origfilename, ".") == 0 ? "" : hc->origfilename);
+  snprintf(buf, sizeof(buf), "/%s", strcmp(hc->origfilename, ".") == 0 ?
+           "" : hc->origfilename);
   setenv("SCRIPT_NAME", buf, TRUE);
 
   if (hc->query[0] != '\0')
@@ -325,6 +328,7 @@ static FAR char **make_argp(httpd_conn *hc)
     {
       argp[0] = hc->expnfilename;
     }
+
   argn = 1;
 
   /* According to the CGI spec at http://hoohoo.ncsa.uiuc.edu/cgi/cl.html,
@@ -357,8 +361,9 @@ static FAR char **make_argp(httpd_conn *hc)
   return argp;
 }
 
-/* Data is available from the client socket. This routine is used only for POST
- * requests.  It reads the data from the client and sends it to the child thread.
+/* Data is available from the client socket. This routine is
+ * used only for POST requests. It reads the data from the
+ * client and sends it to the child thread.
  */
 
 static inline int cgi_interpose_input(struct cgi_conn_s *cc)
@@ -366,13 +371,15 @@ static inline int cgi_interpose_input(struct cgi_conn_s *cc)
   ssize_t nbytes_read;
   ssize_t nbytes_written;
 
-  ninfo("nbytes: %d contentlength: %d\n", cc->inbuf.nbytes, cc->inbuf.contentlength);
+  ninfo("nbytes: %d contentlength: %d\n", cc->inbuf.nbytes,
+        cc->inbuf.contentlength);
   if (cc->inbuf.nbytes < cc->inbuf.contentlength)
     {
       do
         {
           nbytes_read = read(cc->connfd, cc->inbuf.buffer,
-            MIN(CONFIG_THTTPD_CGIINBUFFERSIZE, cc->inbuf.contentlength - cc->inbuf.nbytes));
+                             MIN(CONFIG_THTTPD_CGIINBUFFERSIZE,
+                             cc->inbuf.contentlength - cc->inbuf.nbytes));
           ninfo("nbytes_read: %d\n", nbytes_read);
           if (nbytes_read < 0)
             {
@@ -387,13 +394,15 @@ static inline int cgi_interpose_input(struct cgi_conn_s *cc)
 
       if (nbytes_read > 0)
         {
-          nbytes_written = httpd_write(cc->wrfd, cc->inbuf.buffer, nbytes_read);
+          nbytes_written = httpd_write(cc->wrfd, cc->inbuf.buffer,
+                                       nbytes_read);
           ninfo("nbytes_written: %d\n", nbytes_written);
           if (nbytes_written != nbytes_read)
             {
               nerr("ERROR: httpd_write failed\n");
               return 1;
             }
+
           cgi_dumpbuffer("Sent to CGI:", cc->inbuf.buffer, nbytes_written);
         }
 
@@ -420,6 +429,7 @@ static inline int cgi_interpose_input(struct cgi_conn_s *cc)
       read(cc->connfd, cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE);
       return 1;
     }
+
   return 0;
 }
 
@@ -456,11 +466,13 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
 
           do
             {
-              /* Read until we successfully read data or until an error occurs.
-               * EAGAIN is not an error, but it is still cause to return.
+              /* Read until we successfully read data or until an error
+               * occurs. EAGAIN is not an error, but it is still cause to
+               * return.
                */
 
-              nbytes_read = read(cc->rdfd, cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE);
+              nbytes_read = read(cc->rdfd, cc->inbuf.buffer,
+                                 CONFIG_THTTPD_CGIINBUFFERSIZE);
               ninfo("Read %d bytes from fd %d\n", nbytes_read, cc->rdfd);
 
               if (nbytes_read < 0)
@@ -471,12 +483,14 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
                         {
                           nerr("ERROR: read: %d\n", errno);
                         }
+
                       return 1;
                     }
                 }
               else
                 {
-                  cgi_dumpbuffer("Received from CGI:", cc->inbuf.buffer, nbytes_read);
+                  cgi_dumpbuffer("Received from CGI:", cc->inbuf.buffer,
+                                 nbytes_read);
                 }
             }
           while (nbytes_read < 0);
@@ -493,8 +507,10 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
             {
               /* Accumulate more header data */
 
-              httpd_realloc_str(&cc->outbuf.buffer, &cc->outbuf.size, cc->outbuf.len + nbytes_read);
-              memcpy(&(cc->outbuf.buffer[cc->outbuf.len]), cc->inbuf.buffer, nbytes_read);
+              httpd_realloc_str(&cc->outbuf.buffer, &cc->outbuf.size,
+                                cc->outbuf.len + nbytes_read);
+              memcpy(&(cc->outbuf.buffer[cc->outbuf.len]), cc->inbuf.buffer,
+                       nbytes_read);
               cc->outbuf.len                   += nbytes_read;
               cc->outbuf.buffer[cc->outbuf.len] = '\0';
               ninfo("Header bytes accumulated: %d\n", cc->outbuf.len);
@@ -509,9 +525,9 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
                 }
               else
                 {
-                  /* All of the headers have not yet been read ... Return.  We
-                   * will be called again when more data is available in the pipe
-                   * connected to the CGI task.
+                  /* All of the headers have not yet been read ... Return.
+                   * We will be called again when more data is available
+                   * in the pipe connected to the CGI task.
                    */
 
                   return 0;
@@ -531,8 +547,9 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
               return 1;
             }
 
-          /* Figure out the status.  Look for a Status: or Location: header; else if
-           * there's an HTTP header line, get it from there; else default to 200.
+          /* Figure out the status.  Look for a Status: or Location: header;
+           * else if there's an HTTP header line, get it from there; else
+           * default to 200.
            */
 
           status = 200;
@@ -616,17 +633,19 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
               break;
             }
 
-          snprintf(cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE, "HTTP/1.0 %d %s\r\n", status, title);
-          httpd_write(cc->connfd, cc->inbuf.buffer, strlen(cc->inbuf.buffer));
+          snprintf(cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE,
+                   "HTTP/1.0 %d %s\r\n", status, title);
+          httpd_write(cc->connfd, cc->inbuf.buffer,
+                      strlen(cc->inbuf.buffer));
 
           /* Write the saved cc->outbuf.buffer to the client. */
 
           httpd_write(cc->connfd, cc->outbuf.buffer, cc->outbuf.len);
         }
 
-        /* Then set up to read the data following the header from the CGI program and
-         * pass it back to the client. We return now; we will be called again when
-         * data is available on the pipe.
+        /* Then set up to read the data following the header from the CGI
+         * program and pass it back to the client. We return now; we will
+         * be called again when data is available on the pipe.
          */
 
         cc->outbuf.state = CGI_OUTBUFFER_READDATA;
@@ -638,11 +657,13 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
 
           do
             {
-              /* Read until we successfully read data or until an error occurs.
-               * EAGAIN is not an error, but it is still cause to return.
+              /* Read until we successfully read data or until an error
+               * occurs. EAGAIN is not an error, but it is still cause
+               * to return.
                */
 
-              nbytes_read = read(cc->rdfd, cc->inbuf.buffer, CONFIG_THTTPD_CGIINBUFFERSIZE);
+              nbytes_read = read(cc->rdfd, cc->inbuf.buffer,
+                                 CONFIG_THTTPD_CGIINBUFFERSIZE);
               ninfo("Read %d bytes from fd %d\n", nbytes_read, cc->rdfd);
 
               if (nbytes_read < 0)
@@ -653,12 +674,14 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
                         {
                           nerr("ERROR: read: %d\n", errno);
                         }
+
                       return 1;
                     }
                 }
               else
                 {
-                  cgi_dumpbuffer("Received from CGI:", cc->inbuf.buffer, nbytes_read);
+                  cgi_dumpbuffer("Received from CGI:", cc->inbuf.buffer,
+                                 nbytes_read);
                 }
             }
           while (nbytes_read < 0);
@@ -684,6 +707,7 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
       default:
         return 1;
     }
+
   return 0;
 }
 
@@ -691,7 +715,7 @@ static inline int cgi_interpose_output(struct cgi_conn_s *cc)
 
 static int cgi_child(int argc, char **argv)
 {
-  FAR httpd_conn *hc = (FAR httpd_conn*)strtoul(argv[1], NULL, 16);
+  FAR httpd_conn *hc = (FAR httpd_conn *)strtoul(argv[1], NULL, 16);
 #if CONFIG_THTTPD_CGI_TIMELIMIT > 0
   ClientData client_data;
 #endif
@@ -709,15 +733,15 @@ static int cgi_child(int argc, char **argv)
   int        ret;
   int        errcode = 1;
 
-  /* Use low-level debug out (because the low-level output may survive closing
-   * all file descriptors
+  /* Use low-level debug out (because the low-level output may survive
+   * closing all file descriptors
    */
 
   ninfo("Started: %s\n", argv[1]);
 
   /* Allocate memory and initialize memory for interposing */
 
-  cc = (FAR struct cgi_conn_s*)httpd_malloc(sizeof(struct cgi_conn_s));
+  cc = (FAR struct cgi_conn_s *)httpd_malloc(sizeof(struct cgi_conn_s));
   if (!cc)
     {
       nerr("ERROR: cgi_conn allocation failed\n");
@@ -747,14 +771,14 @@ static int cgi_child(int argc, char **argv)
    */
 
   ninfo("Closing descriptors\n");
-  for (fd = 3; fd < (CONFIG_NFILE_DESCRIPTORS + CONFIG_NSOCKET_DESCRIPTORS); fd++)
+  for (fd = 3; fd < CONFIG_NFILE_DESCRIPTORS; fd++)
     {
-       /* Keep hc->conn_fd open for obvious reasons */
+      /* Keep hc->conn_fd open for obvious reasons */
 
-       if (fd != hc->conn_fd)
-         {
-           close(fd);
-         }
+      if (fd != hc->conn_fd)
+        {
+          close(fd);
+        }
     }
 
   /* Create pipes that will be interposed between the CGI task's stdin or
@@ -773,8 +797,8 @@ static int cgi_child(int argc, char **argv)
     }
   else
     {
-      /* Then map the receiving end the pipe to stdin, save the sending end, and
-       * closing the original receiving end
+      /* Then map the receiving end the pipe to stdin, save the sending end,
+       * and closing the original receiving end
        */
 
       ret = dup2(pipefd[0], 0);
@@ -789,8 +813,8 @@ static int cgi_child(int argc, char **argv)
         }
     }
 
-  /* Set up the STDOUT pipe - a pipe to transfer data received from the CGI program
-   * to the client.
+  /* Set up the STDOUT pipe - a pipe to transfer data received from the CGI
+   * program to the client.
    */
 
   if (ret == 0)
@@ -804,8 +828,8 @@ static int cgi_child(int argc, char **argv)
         }
       else
         {
-          /* Then map the sending end the pipe to stdout, save the receiving end, and
-           * closing the original sending end
+          /* Then map the sending end the pipe to stdout, save the
+           * receiving end, and closing the original sending end
            */
 
           ret = dup2(pipefd[1], 1);
@@ -839,7 +863,8 @@ static int cgi_child(int argc, char **argv)
 
   /* Allocate memory for output buffering */
 
-  httpd_realloc_str(&cc->outbuf.buffer, &cc->outbuf.size, CONFIG_THTTPD_CGIOUTBUFFERSIZE);
+  httpd_realloc_str(&cc->outbuf.buffer, &cc->outbuf.size,
+                    CONFIG_THTTPD_CGIOUTBUFFERSIZE);
   if (!cc->outbuf.buffer)
     {
       nerr("ERROR: hdr allocation failed\n");
@@ -860,7 +885,8 @@ static int cgi_child(int argc, char **argv)
   ninfo("Starting CGI: %s\n", hc->expnfilename);
 
 #ifdef CONFIG_THTTPD_NXFLAT
-  child = exec(hc->expnfilename, (FAR char * const *)argp, g_thttpdsymtab, g_thttpdnsymbols);
+  child = exec(hc->expnfilename, (FAR char * const *)argp,
+               g_thttpdsymtab, g_thttpdnsymbols);
 #else
   child = exec(hc->expnfilename, (FAR char * const *)argp, NULL, 0);
 #endif
@@ -870,13 +896,14 @@ static int cgi_child(int argc, char **argv)
 
       nerr("ERROR: execve %s: %d\n", hc->expnfilename, errno);
       goto errout_with_watch;
-   }
+    }
 
   /* Schedule a kill for the child task in case it runs too long. */
 
 #if CONFIG_THTTPD_CGI_TIMELIMIT > 0
   client_data.i = child;
-  if (tmr_create(NULL, cgi_kill, client_data, CONFIG_THTTPD_CGI_TIMELIMIT * 1000L, 0) == NULL)
+  if (tmr_create(NULL, cgi_kill, client_data,
+                 CONFIG_THTTPD_CGI_TIMELIMIT * 1000L, 0) == NULL)
     {
       nerr("ERROR: tmr_create(cgi_kill child) failed\n");
       goto errout_with_watch;
@@ -894,7 +921,8 @@ static int cgi_child(int argc, char **argv)
   ninfo("nbytes: %d contentlength: %d\n", nbytes, hc->contentlength);
   if (nbytes > 0)
     {
-      if (httpd_write(cc->wrfd, &(hc->read_buf[hc->checked_idx]), nbytes) != nbytes)
+      if (httpd_write(cc->wrfd, &(hc->read_buf[hc->checked_idx]), nbytes)
+          != nbytes)
         {
           nerr("ERROR: httpd_write failed\n");
           return 1;
@@ -952,7 +980,7 @@ static int cgi_child(int argc, char **argv)
           ninfo("CGI no longer running: %d\n", errno);
           outdone = true;
         }
-  }
+    }
   while (!outdone);
   errcode = 0;
 
@@ -1017,12 +1045,13 @@ int cgi(httpd_conn *hc)
           goto errout_with_sem;
         }
 #endif
+
       ++hc->hs->cgi_count;
       httpd_clear_ndelay(hc->conn_fd);
 
       /* Start the child task.  We use a trampoline task here so that we can
-       * safely muck with the file descriptors before actually started the CGI
-       * task.
+       * safely muck with the file descriptors before actually started the
+       * CGI task.
        */
 
       snprintf(arg, 16, "%p", hc); /* task_create doesn't handle binary arguments. */

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -42,9 +42,9 @@ struct usrsock_rpmsg_s
   pid_t                 pid;
   pthread_mutex_t       mutex;
   pthread_cond_t        cond;
-  struct socket         socks[CONFIG_NSOCKET_DESCRIPTORS];
-  struct rpmsg_endpoint *epts[CONFIG_NSOCKET_DESCRIPTORS];
-  struct pollfd         pfds[CONFIG_NSOCKET_DESCRIPTORS];
+  struct socket         socks[CONFIG_NFILE_DESCRIPTORS];
+  struct rpmsg_endpoint *epts[CONFIG_NFILE_DESCRIPTORS];
+  struct pollfd         pfds[CONFIG_NFILE_DESCRIPTORS];
 };
 
 /****************************************************************************
@@ -204,7 +204,7 @@ static int usrsock_rpmsg_socket_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -ENFILE;
 
-  for (i = 0; i < CONFIG_NSOCKET_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
     {
       pthread_mutex_lock(&priv->mutex);
       if (priv->socks[i].s_crefs == 0)
@@ -256,7 +256,7 @@ static int usrsock_rpmsg_close_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       priv->pfds[req->usockid].ptr = NULL;
       priv->epts[req->usockid] = NULL;
@@ -286,7 +286,7 @@ static int usrsock_rpmsg_connect_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_connect(&priv->socks[req->usockid],
               (const struct sockaddr *)(req + 1), req->addrlen);
@@ -329,7 +329,7 @@ static int usrsock_rpmsg_sendto_handler(struct rpmsg_endpoint *ept,
   ssize_t ret = -EBADF;
   int retr;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_sendto(&priv->socks[req->usockid],
               (const void *)(req + 1) + req->addrlen, req->buflen,
@@ -377,7 +377,7 @@ static int usrsock_rpmsg_recvfrom_handler(struct rpmsg_endpoint *ept,
       buflen = len - sizeof(*ack) - inaddrlen;
     }
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_recvfrom(&priv->socks[req->usockid],
               (void *)(ack + 1) + inaddrlen, buflen, req->flags,
@@ -411,7 +411,7 @@ static int usrsock_rpmsg_setsockopt_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_setsockopt(&priv->socks[req->usockid],
               req->level, req->option, req + 1, req->valuelen);
@@ -432,7 +432,7 @@ static int usrsock_rpmsg_getsockopt_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_getsockopt(&priv->socks[req->usockid],
               req->level, req->option, ack + 1, &optlen);
@@ -455,7 +455,7 @@ static int usrsock_rpmsg_getsockname_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_getsockname(&priv->socks[req->usockid],
               (struct sockaddr *)(ack + 1), &outaddrlen);
@@ -478,7 +478,7 @@ static int usrsock_rpmsg_getpeername_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_getpeername(&priv->socks[req->usockid],
               (struct sockaddr *)(ack + 1), &outaddrlen);
@@ -496,7 +496,7 @@ static int usrsock_rpmsg_bind_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_bind(&priv->socks[req->usockid],
               (const struct sockaddr *)(req + 1), req->addrlen);
@@ -514,7 +514,7 @@ static int usrsock_rpmsg_listen_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = psock_listen(&priv->socks[req->usockid], req->backlog);
     }
@@ -547,10 +547,10 @@ static int usrsock_rpmsg_accept_handler(struct rpmsg_endpoint *ept,
   int retr;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       ret = -ENFILE; /* Assume no free socket handler */
-      for (i = 0; i < CONFIG_NSOCKET_DESCRIPTORS; i++)
+      for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
         {
           pthread_mutex_lock(&priv->mutex);
           if (priv->socks[i].s_crefs == 0)
@@ -619,7 +619,7 @@ static int usrsock_rpmsg_ioctl_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NSOCKET_DESCRIPTORS)
+  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
     {
       memcpy(ack + 1, req + 1, req->arglen);
       ret = psock_ioctl(&priv->socks[req->usockid],
@@ -688,7 +688,7 @@ static void usrsock_rpmsg_ns_bind(struct rpmsg_device *rdev, void *priv_,
 static void usrsock_rpmsg_ns_unbind(struct rpmsg_endpoint *ept)
 {
   struct usrsock_rpmsg_s *priv = ept->priv;
-  struct socket *socks[CONFIG_NSOCKET_DESCRIPTORS];
+  struct socket *socks[CONFIG_NFILE_DESCRIPTORS];
   int count = 0;
   int i;
 
@@ -698,7 +698,7 @@ static void usrsock_rpmsg_ns_unbind(struct rpmsg_endpoint *ept)
 
   /* Collect all socks belong to the dead client */
 
-  for (i = 0; i < CONFIG_NSOCKET_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
     {
       if (priv->epts[i] == ept)
         {
@@ -751,12 +751,12 @@ static int usrsock_rpmsg_prepare_poll(struct usrsock_rpmsg_s *priv,
 
   pthread_cond_signal(&priv->cond);
 
-  for (i = 0; i < CONFIG_NSOCKET_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
     {
       if (priv->pfds[i].ptr)
         {
           pfds[count] = priv->pfds[i];
-          pfds[count++].events |= POLLERR | POLLHUP | POLLSOCK;
+          pfds[count++].events |= POLLERR | POLLHUP | POLLFILE;
         }
     }
 
@@ -823,7 +823,7 @@ static void usrsock_rpmsg_process_poll(struct usrsock_rpmsg_s *priv,
 
 int main(int argc, char *argv[])
 {
-  struct pollfd pfds[CONFIG_NSOCKET_DESCRIPTORS];
+  struct pollfd pfds[CONFIG_NFILE_DESCRIPTORS];
   struct usrsock_rpmsg_s *priv;
   sigset_t sigmask;
   int ret;


### PR DESCRIPTION
## Summary
Merges the socket array info file descriptor array. this patch associated with patch:
https://github.com/apache/incubator-nuttx/pull/2899
## Impact

## Testing
daily test.
