### PR TITLE
net/socket: recover POLLSOCK and support polling directly by socket

### DIFF
--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -744,7 +744,7 @@ static int usrsock_rpmsg_prepare_poll(struct usrsock_rpmsg_s *priv,
       if (priv->pfds[i].ptr)
         {
           pfds[count] = priv->pfds[i];
-          pfds[count++].events |= POLLERR | POLLHUP | POLLFILE;
+          pfds[count++].events |= POLLERR | POLLHUP | POLLSOCK;
         }
     }
 


### PR DESCRIPTION

## Summary
Recover POLLSOCK and support  polling directly by socket, this patch associated with #2899

## Impact

## Testing

