### PR TITLE
netutils/thttpd: fix compile break

### DIFF
--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -696,7 +696,7 @@ int thttpd_main(int argc, char **argv)
    * socket descriptors
    */
 
-  fw = fdwatch_initialize(CONFIG_NSOCKET_DESCRIPTORS);
+  fw = fdwatch_initialize(CONFIG_NFILE_DESCRIPTORS);
   if (!fw)
     {
       nerr("ERROR: fdwatch initialization failure\n");


### PR DESCRIPTION

## Summary
netutils/thttpd: fix compile break
change NSOCKET_DESCRIPTORS to NFILE_DESCRIPTORS

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

