### PR TITLE
system/i2c: Add command for resetting an I2C bus

### DIFF
--- a/system/i2c/Makefile
+++ b/system/i2c/Makefile
@@ -38,6 +38,11 @@ include $(APPDIR)/Make.defs
 # I2C tool
 CSRCS   = i2c_bus.c i2c_common.c i2c_dev.c i2c_get.c i2c_set.c i2c_verf.c
 CSRCS  += i2c_devif.c i2c_dump.c i2c_hexdump.c
+
+ifeq ($(CONFIG_I2C_RESET),y)
+CSRCS += i2c_reset.c
+endif
+
 MAINSRC = i2c_main.c
 
 PROGNAME = i2c

--- a/system/i2c/i2c_devif.c
+++ b/system/i2c/i2c_devif.c
@@ -142,3 +142,17 @@ int i2cdev_transfer(int fd, FAR struct i2c_msg_s *msgv, int msgc)
 
   return ioctl(fd, I2CIOC_TRANSFER, (unsigned long)((uintptr_t)&xfer));
 }
+
+/****************************************************************************
+ * Name: i2cdev_reset
+ ****************************************************************************/
+
+#ifdef CONFIG_I2C_RESET
+int i2cdev_reset(int fd)
+{
+  /* Perform the IOCTL */
+
+  return ioctl(fd, I2CIOC_RESET, 0);
+}
+#endif
+

--- a/system/i2c/i2c_main.c
+++ b/system/i2c/i2c_main.c
@@ -68,18 +68,21 @@ static struct i2ctool_s g_i2ctool;
 
 static const struct cmdmap_s g_i2ccmds[] =
 {
-  { "?",    i2ccmd_help, "Show help     ", NULL },
-  { "bus",  i2ccmd_bus,  "List buses    ", NULL },
-  { "dev",  i2ccmd_dev,  "List devices  ", "[OPTIONS] <first> <last>" },
-  { "get",  i2ccmd_get,  "Read register ", "[OPTIONS] [<repetitions>]" },
-  { "dump", i2ccmd_dump, "Dump register ", "[OPTIONS] [<num bytes>]" },
-  { "help", i2ccmd_help, "Show help     ", NULL },
+  { "?",     i2ccmd_help,  "Show help     ", NULL },
+  { "bus",   i2ccmd_bus,   "List buses    ", NULL },
+#ifdef CONFIG_I2C_RESET
+  { "reset", i2ccmd_reset, "Reset bus     ", NULL },
+#endif
+  { "dev",   i2ccmd_dev,   "List devices  ", "[OPTIONS] <first> <last>" },
+  { "get",   i2ccmd_get,   "Read register ", "[OPTIONS] [<repetitions>]" },
+  { "dump",  i2ccmd_dump,  "Dump register ", "[OPTIONS] [<num bytes>]" },
+  { "help",  i2ccmd_help,  "Show help     ", NULL },
   {
-    "set",  i2ccmd_set,  "Write register",
+    "set",   i2ccmd_set,   "Write register",
       "[OPTIONS] <value> [<repetitions>]"
   },
   {
-    "verf", i2ccmd_verf, "Verify access ",
+    "verf",  i2ccmd_verf,  "Verify access ",
       "[OPTIONS] [<value>] [<repetitions>]"
   },
   { NULL,   NULL,        NULL,             NULL }

--- a/system/i2c/i2c_reset.c
+++ b/system/i2c/i2c_reset.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * apps/system/i2c/i2c_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/i2c/i2c_master.h>
+
+#include "i2ctool.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: i2ccmd_reset
+ ****************************************************************************/
+
+int i2ccmd_reset(FAR struct i2ctool_s *i2ctool, int argc, char **argv)
+{
+  int ret;
+  int fd;
+
+  /* Get a handle to the I2C bus */
+
+  fd = i2cdev_open(i2ctool->bus);
+  if (fd < 0)
+    {
+      i2ctool_printf(i2ctool, "Failed to get bus %d\n", i2ctool->bus);
+      return ERROR;
+    }
+
+  ret = i2cdev_reset(fd);
+  if (ret == OK)
+    {
+      i2ctool_printf(i2ctool, "Reset command sent successfully\n");
+    }
+  else
+    {
+      i2ctool_printf(i2ctool, "Failed to send the reset command\n");
+    }
+
+  return ret;
+}
+

--- a/system/i2c/i2ctool.h
+++ b/system/i2c/i2ctool.h
@@ -198,6 +198,10 @@ int i2ccmd_dump(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv);
 int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv);
 int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv);
 
+#ifdef CONFIG_I2C_RESET
+int i2ccmd_reset(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv);
+#endif
+
 /* I2C access functions */
 
 int i2ctool_get(FAR struct i2ctool_s *i2ctool, int fd, uint8_t regaddr,
@@ -215,5 +219,9 @@ FAR char *i2cdev_path(int bus);
 bool i2cdev_exists(int bus);
 int i2cdev_open(int bus);
 int i2cdev_transfer(int fd, FAR struct i2c_msg_s *msgv, int msgc);
+
+#ifdef CONFIG_I2C_RESET
+int i2cdev_reset(int fd);
+#endif
 
 #endif /* __APPS_SYSTEM_I2C_I2CTOOLS_H */


### PR DESCRIPTION
## Summary
This PR intends to add a new command to the I2C tool for enabling a quick test of the Reset function.

## Impact
No impact, new command for the I2C tool.

## Testing
Tested with `esp32c3-devkit`.

