### PR TITLE
app: delete NFILE_DESCRIPTORS limits

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1781,8 +1781,6 @@ This is at trivial test of the Union File System. See
 
 - `CONFIG_DISABLE_MOUNTPOINT`          – Mountpoint support must not be
   disabled.
-- `CONFIG_NFILE_DESCRIPTORS > 4`       – Some file descriptors must be
-  allocated.
 - `CONFIG_FS_ROMFS`                    – ROMFS support is required.
 - `CONFIG_FS_UNIONFS`                  – Union File System support is required.
 

--- a/examples/romfs/romfs_main.c
+++ b/examples/romfs/romfs_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/romfs/romfs_main.c
+ * apps/examples/romfs/romfs_main.c
  *
  *   Copyright (C) 2008-2009, 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -95,10 +95,6 @@
 
 #ifdef CONFIG_DISABLE_MOUNTPOINT
 #  error "Mountpoint support is disabled"
-#endif
-
-#if CONFIG_NFILE_DESCRIPTORS < 4
-#  error "Not enough file descriptors"
 #endif
 
 #ifndef CONFIG_FS_ROMFS

--- a/examples/unionfs/unionfs_main.c
+++ b/examples/unionfs/unionfs_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/unionfs/unionfs_main.c
+ * apps/examples/unionfs/unionfs_main.c
  *
  *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -68,10 +68,6 @@
 #  error "Mountpoint support is disabled"
 #endif
 
-#if CONFIG_NFILE_DESCRIPTORS < 4
-#  error "Not enough file descriptors"
-#endif
-
 #ifndef CONFIG_FS_ROMFS
 #  error "ROMFS support not enabled"
 #endif
@@ -131,7 +127,7 @@
 
 int main(int argc, FAR char *argv[])
 {
-   int  ret;
+  int ret;
 
   /* Create a RAM disk for file system 1 */
 

--- a/graphics/ft80x/ft80x_audio.c
+++ b/graphics/ft80x/ft80x_audio.c
@@ -183,7 +183,6 @@ int ft80x_audio_playsound(int fd, uint16_t effect, uint16_t pitch)
  *
  ****************************************************************************/
 
-#if CONFIG_NFILE_DESCRIPTORS > 3
 int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
                          FAR const char *filepath, uint8_t format,
                          uint16_t frequency, uint8_t volume)
@@ -309,7 +308,7 @@ int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
            * free up to the end of the RAM G buffer (actually already
            * handled by the above 'break')
            */
-       }
+        }
       while (freespace < MAX_DLBUFFER &&
              freespace < remaining &&
              freespace < (AUDIO_BUFSIZE - offset));
@@ -364,8 +363,9 @@ int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
 
       if (!started)
         {
-          /* Start playing at the beginning of graphics memory */
-          /* Set the audio playback start address */
+          /* Start playing at the beginning of graphics memory
+           * Set the audio playback start address
+           */
 
           ret = ft80x_putreg32(fd, FT80X_REG_PLAYBACK_START,
                                RAMG_STARTADDR);
@@ -432,7 +432,7 @@ int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
 
           started = true;
         }
-   }
+    }
 
   /* Transfer is complete.  'offset' points to the end of the file in RAM G.
    * Clear all of the RAM G at the end of the file so that audio is muted
@@ -509,7 +509,6 @@ int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
           ft80x_err("ERROR: ft80x_coproc_send failed: %d\n", ret);
           goto errout_with_fd;
         }
-
     }
 
   /* Wait until the read pointer wraps back to the beginning of the buffer */
@@ -544,8 +543,7 @@ int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
     }
   while (readptr < offset);
 
-  /* The file is done... */
-  /* Stop looping */
+  /* The file is done... Stop looping */
 
   ret = ft80x_putreg8(fd, FT80X_REG_PLAYBACK_LOOP, 1);
   if (ret < 0)
@@ -584,5 +582,3 @@ errout_with_fd:
   close(audiofd);
   return ret;
 }
-
-#endif /* CONFIG_NFILE_DESCRIPTORS > 3 */

--- a/include/graphics/ft80x.h
+++ b/include/graphics/ft80x.h
@@ -224,8 +224,8 @@ int ft80x_dl_string(int fd, FAR struct ft80x_dlbuffer_s *buffer,
  *   hardware and reset the local display list buffer offset to zero.
  *
  * Input Parameters:
- *   fd     - The file descriptor of the FT80x device.  Opened by the caller with
- *            write access.
+ *   fd     - The file descriptor of the FT80x device.  Opened by the caller
+ *            with write access.
  *   buffer - An instance of struct ft80x_dlbuffer_s allocated by the caller.
  *   wait   - True: wait until data has been consumed by the co-processor
  *            (only for co-processor destination); false:  Send to hardware
@@ -371,7 +371,8 @@ int ft80x_touch_gettransform(int fd, FAR uint32_t matrix[6]);
  *
  * Returned Value:
  *   A value of 1-255 is returned if a graphics object is touched.  Zero is
- *   returned if no graphics object is touched.  A negated errno value on failure.
+ *   returned if no graphics object is touched.  A negated errno value on
+ *   failure.
  *
  ****************************************************************************/
 
@@ -391,7 +392,8 @@ int ft80x_touch_tag(int fd);
  *
  * Returned Value:
  *   A value of 1-255 is returned if a graphics object is touched.  Zero is
- *   returned if no graphics object is touched.  A negated errno value on failure.
+ *   returned if no graphics object is touched.  A negated errno value on
+ *   failure.
  *
  ****************************************************************************/
 
@@ -415,7 +417,8 @@ int ft80x_touch_waittag(int fd, uint8_t oldtag);
  *
  * Returned Value:
  *   A value of 1-255 is returned if a graphics object is touched.  Zero is
- *   returned if no graphics object is touched.  A negated errno value on failure.
+ *   returned if no graphics object is touched.  A negated errno value on
+ *   failure.
  *
  ****************************************************************************/
 
@@ -494,11 +497,9 @@ int ft80x_audio_playsound(int fd, uint16_t effect, uint16_t pitch);
  *
  ****************************************************************************/
 
-#if CONFIG_NFILE_DESCRIPTORS > 3
 int ft80x_audio_playfile(int fd, FAR struct ft80x_dlbuffer_s *buffer,
                          FAR const char *filepath, uint8_t format,
                          uint16_t frequency, uint8_t volume);
-#endif
 
 /****************************************************************************
  * Name: ft80x_backlight_set

--- a/netutils/usrsock_rpmsg/Kconfig
+++ b/netutils/usrsock_rpmsg/Kconfig
@@ -24,4 +24,10 @@ config NETUTILS_USRSOCK_RPMSG_STACKSIZE
 	---help---
 		The stack size allocated for the usrsock task.
 
+config NETUTILS_USRSOCK_NSOCK_DESCRIPTORS
+	int "the maximum number of socket descriptors for usrsock monitoring"
+	default 64
+	---help---
+		The maximum number of socket description for usrsosck monitoring.
+
 endif # NETUTILS_USRSOCK_RPMSG

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -42,9 +42,9 @@ struct usrsock_rpmsg_s
   pid_t                 pid;
   pthread_mutex_t       mutex;
   pthread_cond_t        cond;
-  struct socket         socks[CONFIG_NFILE_DESCRIPTORS];
-  struct rpmsg_endpoint *epts[CONFIG_NFILE_DESCRIPTORS];
-  struct pollfd         pfds[CONFIG_NFILE_DESCRIPTORS];
+  struct socket         socks[CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS];
+  struct rpmsg_endpoint *epts[CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS];
+  struct pollfd         pfds[CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS];
 };
 
 /****************************************************************************
@@ -204,7 +204,7 @@ static int usrsock_rpmsg_socket_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -ENFILE;
 
-  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS; i++)
     {
       pthread_mutex_lock(&priv->mutex);
       if (priv->socks[i].s_conn == NULL)
@@ -250,7 +250,8 @@ static int usrsock_rpmsg_close_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       priv->pfds[req->usockid].ptr = NULL;
       priv->epts[req->usockid] = NULL;
@@ -280,7 +281,8 @@ static int usrsock_rpmsg_connect_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_connect(&priv->socks[req->usockid],
               (const struct sockaddr *)(req + 1), req->addrlen);
@@ -323,7 +325,8 @@ static int usrsock_rpmsg_sendto_handler(struct rpmsg_endpoint *ept,
   ssize_t ret = -EBADF;
   int retr;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_sendto(&priv->socks[req->usockid],
               (const void *)(req + 1) + req->addrlen, req->buflen,
@@ -371,7 +374,8 @@ static int usrsock_rpmsg_recvfrom_handler(struct rpmsg_endpoint *ept,
       buflen = len - sizeof(*ack) - inaddrlen;
     }
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_recvfrom(&priv->socks[req->usockid],
               (void *)(ack + 1) + inaddrlen, buflen, req->flags,
@@ -405,7 +409,8 @@ static int usrsock_rpmsg_setsockopt_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_setsockopt(&priv->socks[req->usockid],
               req->level, req->option, req + 1, req->valuelen);
@@ -426,7 +431,8 @@ static int usrsock_rpmsg_getsockopt_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_getsockopt(&priv->socks[req->usockid],
               req->level, req->option, ack + 1, &optlen);
@@ -449,7 +455,8 @@ static int usrsock_rpmsg_getsockname_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_getsockname(&priv->socks[req->usockid],
               (struct sockaddr *)(ack + 1), &outaddrlen);
@@ -472,7 +479,8 @@ static int usrsock_rpmsg_getpeername_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_getpeername(&priv->socks[req->usockid],
               (struct sockaddr *)(ack + 1), &outaddrlen);
@@ -490,7 +498,8 @@ static int usrsock_rpmsg_bind_handler(struct rpmsg_endpoint *ept,
   struct usrsock_rpmsg_s *priv = priv_;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_bind(&priv->socks[req->usockid],
               (const struct sockaddr *)(req + 1), req->addrlen);
@@ -508,7 +517,8 @@ static int usrsock_rpmsg_listen_handler(struct rpmsg_endpoint *ept,
   int retr;
   int ret = -EBADF;
 
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = psock_listen(&priv->socks[req->usockid], req->backlog);
     }
@@ -541,10 +551,11 @@ static int usrsock_rpmsg_accept_handler(struct rpmsg_endpoint *ept,
   int retr;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       ret = -ENFILE; /* Assume no free socket handler */
-      for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
+      for (i = 0; i < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS; i++)
         {
           pthread_mutex_lock(&priv->mutex);
           if (priv->socks[i].s_conn == NULL)
@@ -607,7 +618,8 @@ static int usrsock_rpmsg_ioctl_handler(struct rpmsg_endpoint *ept,
   uint32_t len;
 
   ack = rpmsg_get_tx_payload_buffer(ept, &len, true);
-  if (req->usockid >= 0 && req->usockid < CONFIG_NFILE_DESCRIPTORS)
+  if (req->usockid >= 0 &&
+      req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
       memcpy(ack + 1, req + 1, req->arglen);
       ret = psock_ioctl(&priv->socks[req->usockid],
@@ -676,7 +688,7 @@ static void usrsock_rpmsg_ns_bind(struct rpmsg_device *rdev, void *priv_,
 static void usrsock_rpmsg_ns_unbind(struct rpmsg_endpoint *ept)
 {
   struct usrsock_rpmsg_s *priv = ept->priv;
-  struct socket *socks[CONFIG_NFILE_DESCRIPTORS];
+  struct socket *socks[CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS];
   int count = 0;
   int i;
 
@@ -686,7 +698,7 @@ static void usrsock_rpmsg_ns_unbind(struct rpmsg_endpoint *ept)
 
   /* Collect all socks belong to the dead client */
 
-  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS; i++)
     {
       if (priv->epts[i] == ept)
         {
@@ -739,7 +751,7 @@ static int usrsock_rpmsg_prepare_poll(struct usrsock_rpmsg_s *priv,
 
   pthread_cond_signal(&priv->cond);
 
-  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
+  for (i = 0; i < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS; i++)
     {
       if (priv->pfds[i].ptr)
         {
@@ -811,7 +823,7 @@ static void usrsock_rpmsg_process_poll(struct usrsock_rpmsg_s *priv,
 
 int main(int argc, char *argv[])
 {
-  struct pollfd pfds[CONFIG_NFILE_DESCRIPTORS];
+  struct pollfd pfds[CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS];
   struct usrsock_rpmsg_s *priv;
   sigset_t sigmask;
   int ret;

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -184,7 +184,6 @@ configuration options as described in the final section of this README. This
 capability also depends on:
 
 - `CONFIG_DISABLE_MOUNTPOINT` not set
-- `CONFIG_NFILE_DESCRIPTORS > 4`
 - `CONFIG_FS_ROMFS`
 
 ### Default Start-Up Behavior

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -331,11 +331,6 @@
 #    undef CONFIG_NSH_ROMFSETC
 #  endif
 
-#  if CONFIG_NFILE_DESCRIPTORS < 4
-#    error "Not enough file descriptors"
-#    undef CONFIG_NSH_ROMFSETC
-#  endif
-
 #  ifndef CONFIG_FS_ROMFS
 #    error "ROMFS support not enabled"
 #    undef CONFIG_NSH_ROMFSETC


### PR DESCRIPTION
## Summary
Dynamically allocated file descriptor and delete NFILE_DESCRIPTORS limits. This patch associates with https://github.com/apache/incubator-nuttx/pull/3045.
## Impact

## Testing
daily test
