### PR TITLE
thttpd: add THTTPD_NFILE_DESCRIPTORS

### DIFF
--- a/netutils/thttpd/Kconfig
+++ b/netutils/thttpd/Kconfig
@@ -12,6 +12,12 @@ config NETUTILS_THTTPD
 
 if NETUTILS_THTTPD
 
+config THTTPD_NFILE_DESCRIPTORS
+	int "the maximum number of file descriptors for thttpd webserver"
+	default 16
+	---help---
+	        The maximum number of file descriptors for thttpd webserver
+
 config THTTPD_PORT
 	int "THTTPD port number"
 	default 80

--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/thttpd/thttpd.c
+ * apps/netutils/thttpd/thttpd.c
  * Tiny HTTP Server
  *
  *   Copyright (C) 2009, 2011 Gregory Nutt. All rights reserved.
@@ -85,7 +85,7 @@
 #define CNST_LINGERING 3
 
 #define SPARE_FDS      2
-#define AVAILABLE_FDS  (CONFIG_NFILE_DESCRIPTORS - SPARE_FDS)
+#define AVAILABLE_FDS  (CONFIG_THTTPD_NFILE_DESCRIPTORS - SPARE_FDS)
 
 /****************************************************************************
  * Private Types
@@ -696,7 +696,7 @@ int thttpd_main(int argc, char **argv)
    * socket descriptors
    */
 
-  fw = fdwatch_initialize(CONFIG_NFILE_DESCRIPTORS);
+  fw = fdwatch_initialize(CONFIG_THTTPD_NFILE_DESCRIPTORS);
   if (!fw)
     {
       nerr("ERROR: fdwatch initialization failure\n");

--- a/netutils/thttpd/thttpd_cgi.c
+++ b/netutils/thttpd/thttpd_cgi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/thttpd/thttpd_cgi.c
+ * apps/netutils/thttpd/thttpd_cgi.c
  * CGI support
  *
  *   Copyright (C) 2009, 2011, 2016 Gregory Nutt. All rights reserved.
@@ -771,7 +771,7 @@ static int cgi_child(int argc, char **argv)
    */
 
   ninfo("Closing descriptors\n");
-  for (fd = 3; fd < CONFIG_NFILE_DESCRIPTORS; fd++)
+  for (fd = 3; fd < CONFIG_THTTPD_NFILE_DESCRIPTORS; fd++)
     {
       /* Keep hc->conn_fd open for obvious reasons */
 


### PR DESCRIPTION
## Summary
 using THTTPD_NFILE_DESCRIPTORS instead of NFILE_DESCRIPTORS. This patch associates with https://github.com/apache/incubator-nuttx/pull/3045.
## Impact

## Testing
daily test
