### PR TITLE
apps/examples/watcher: Fixed an assert failure

### DIFF
--- a/examples/watched/watched.c
+++ b/examples/watched/watched.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/watched/watched.c
+ * apps/examples/watched/watched.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -156,7 +156,7 @@ int watched_unsubscribe(struct watched_info_s *info)
   return ret;
 }
 
-int feed_dog(struct watched_info_s *info)
+int watched_feed_dog(struct watched_info_s *info)
 {
   int ret;
 
@@ -168,7 +168,7 @@ int feed_dog(struct watched_info_s *info)
   if (ret == ERROR)
     {
       int errcode = errno;
-      fprintf(stderr, "feed_dog: error %d\n", errcode);
+      fprintf(stderr, "watched_feed_dog: error %d\n", errcode);
       ret = errcode;
     }
 

--- a/examples/watched/watched.h
+++ b/examples/watched/watched.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/watched/watched.h
+ * apps/examples/watched/watched.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -71,9 +71,9 @@ struct watched_info_s
  ****************************************************************************/
 
 bool watched_is_watcher_on(void);
-int watched_read_watcher_info(struct watched_info_s *info);
-int watched_subscribe(struct watched_info_s *info);
-int watched_unsubscribe(struct watched_info_s *info);
-int feed_dog(struct watched_info_s *info);
+int  watched_read_watcher_info(struct watched_info_s *info);
+int  watched_subscribe(struct watched_info_s *info);
+int  watched_unsubscribe(struct watched_info_s *info);
+int  watched_feed_dog(struct watched_info_s *info);
 
 #endif                                 /* __EXAMPLES_WATCHER_WATCHED_H */

--- a/examples/watched/watched_main.c
+++ b/examples/watched/watched_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/watched/watched_main.c
+ * apps/examples/watched/watched_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -60,7 +60,7 @@ static int task1(int argc, FAR char *argv[])
 
   for (; ; )
     {
-      feed_dog(&watched_info);
+      watched_feed_dog(&watched_info);
       sleep(3);
     }
 
@@ -111,8 +111,8 @@ int main(int argc, char *argv[])
 
   if (!watched_is_watcher_on())
     {
-      printf("Please, enable the watcher service \
-              before subscribing tasks!\n");
+      printf("Please, enable the watcher service "
+             "before subscribing tasks!\n");
       ret = ENOENT;
       goto errout;
     }

--- a/examples/watcher/Kconfig
+++ b/examples/watcher/Kconfig
@@ -44,8 +44,13 @@ config EXAMPLES_WATCHER_TIMEOUT
 
 config EXAMPLES_WATCHER_SIGNAL
 	int "Signal Number for communication"
-	default 17
+	default 18
 	---help---
 		This is the Signal Number used for communication between the watcher task and the watched tasks.
 
+config EXAMPLES_WATCHER_SIGNAL_LOG
+	int "Signal Number for logging"
+	default 19
+	---help---
+		This is the Signal Number used by the wdt handler to notify the signal handler to log the tasks.
 endif

--- a/examples/watcher/task_mn.c
+++ b/examples/watcher/task_mn.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/watcher/task_mn.c
+ * apps/examples/watcher/task_mn.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -72,7 +72,7 @@ void task_mn_print_tasks_status(void)
       notefd = open("/dev/note", O_RDONLY);
       if (notefd < 0)
         {
-          fprintf(stderr, "trace: cannot open /dev/note\n");
+          printf("Error: cannot open /dev/note\n");
           return;
         }
 
@@ -82,14 +82,13 @@ void task_mn_print_tasks_status(void)
         {
           task.pid = node->task_id;
           ioctl(notefd, NOTERAM_GETTASKNAME, (unsigned long)&task);
-          printf("%s ", task.taskname);
           if (node->reset)
             {
-              printf("fed the dog.\n");
+              printf("%s fed the dog.\n", task.taskname);
             }
           else
             {
-              printf("starved the dog.\n");
+              printf("%s starved the dog.\n", task.taskname);
             }
         }
 
@@ -99,7 +98,7 @@ void task_mn_print_tasks_status(void)
     }
   else
     {
-      fprintf(stderr, "watcher: List is empty to print\n");
+      printf("Error: Task list is empty to print\n");
     }
 }
 


### PR DESCRIPTION
## Summary

This PR:
1.  Fixes an assert failure that was being caused because the print logs were being done from the ISR context.
Now, the ISR only signals a signal handler, which then print tasks that starved the dog. 
2. Improve some minor things like comments.

## Impact

All watcher/watched examples.

## Testing

![image](https://user-images.githubusercontent.com/33546913/111307698-9457ba80-8638-11eb-8425-4c7e200fac69.png)
