### PR TITLE
apps/examples: Adds termios example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1651,6 +1651,15 @@ character per TCP transfer):
 - `CONFIG_STDIO_BUFFER_SIZE` – Some value `>= 64`
 - `CONFIG_STDIO_LINEBUFFER=y`
 
+## `termios` Simple Termios interface test
+
+This directory contains a simple application that uses the termios interface
+to change serial parameters. Just import a `nsh` config and enable the
+following symbols:
+
+- `CONFIG_SERIAL_TERMIOS`   – Enable the termios support.
+- `CONFIG_EXAMPLES_TERMIOS` – Enable the example itself.
+
 ## `thttpd` THTTPD server
 
 An example that builds `netutils/thttpd` with some simple NXFLAT CGI programs.

--- a/examples/termios/Kconfig
+++ b/examples/termios/Kconfig
@@ -1,0 +1,24 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_TERMIOS
+	tristate "Termios example"
+	default n
+	---help---
+		Enable the Termios example. This example
+		shows how to change serial parameters like baud rate,
+		stop bits, data lenght and parity using the termios interface.
+
+if EXAMPLES_TERMIOS
+
+config EXAMPLES_TERMIOS_PRIORITY
+	int "Termios task priority"
+	default 100
+
+config EXAMPLES_TERMIOS_STACKSIZE
+	int "Termios stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/termios/Kconfig
+++ b/examples/termios/Kconfig
@@ -9,7 +9,7 @@ config EXAMPLES_TERMIOS
 	---help---
 		Enable the Termios example. This example
 		shows how to change serial parameters like baud rate,
-		stop bits, data lenght and parity using the termios interface.
+		stop bits, data length and parity using the termios interface.
 
 if EXAMPLES_TERMIOS
 

--- a/examples/termios/Make.defs
+++ b/examples/termios/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/termios/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_TERMIOS),)
+CONFIGURED_APPS += $(APPDIR)/examples/termios
+endif

--- a/examples/termios/Makefile
+++ b/examples/termios/Makefile
@@ -20,7 +20,7 @@
 
 include $(APPDIR)/Make.defs
 
-# Termios Example! built-in application info
+# Termios example built-in application info
 
 PROGNAME  = termios
 PRIORITY  = $(CONFIG_EXAMPLES_TERMIOS_PRIORITY)

--- a/examples/termios/Makefile
+++ b/examples/termios/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# examples/termios/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Termios Example! built-in application info
+
+PROGNAME  = termios
+PRIORITY  = $(CONFIG_EXAMPLES_TERMIOS_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_TERMIOS_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_TERMIOS)
+
+# Termios Example
+
+MAINSRC = termios_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/termios/termios_main.c
+++ b/examples/termios/termios_main.c
@@ -1,0 +1,127 @@
+/****************************************************************************
+ * apps/examples/termios/termios_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * main
+ ****************************************************************************/
+
+void main(int argc, FAR char *argv[])
+{
+  int fd;
+  int ret;
+  int error = OK;
+  struct termios tio;
+
+  printf("Termios example\n");
+
+  fd = open("/dev/ttyS0", O_RDONLY);
+  if (fd < 0)
+    {
+      error = errno;
+      printf("Error opening serial: %d\n", error);
+    }
+
+  /* Fill the termios struct with the current values. */
+
+  ret = tcgetattr(fd, &tio);
+  if (ret < 0)
+    {
+      error = errno;
+      printf("Error getting attributes: %d\n", error);
+    }
+
+  /* Configure a baud rate.
+   * NuttX doesn't support different baud rates for RX and TX.
+   * So, both cfisetospeed() and cfisetispeed() are overwritten
+   * by cfsetspeed.
+   */
+
+  ret = cfsetspeed(&tio, B57600);
+  if (ret < 0)
+    {
+      error = errno;
+      printf("Error setting baud rate: %d\n", error);
+    }
+
+  /* Configure 2 stop bits. */
+
+  tio.c_cflag |= CSTOPB;
+
+  /* Enable parity and configure odd parity. */
+
+  tio.c_cflag |= PARENB | PARODD;
+
+  /* Change the data size to 7 bits */
+
+  tio.c_cflag &= ~CSIZE; /* Clean the bits */
+  tio.c_cflag |= CS7;    /* 7 bits */
+
+  printf("Please, reopen the terminal with the new attributes,"
+         " otherwise you will have garbage.\n"
+         "You may try: picocom /dev/ttyUSB0 --baud 57600"
+         " --parity o --databits 5 --stopbits 2\n\n");
+  fflush(stdout); /* Clean stdout buffer */
+
+  /* Wait to empty the hardware buffer, otherwise the above message
+   * will not be seen because the following command will take effect
+   * before the hardware buffer gets empty. A small delay is enough.
+   */
+
+  usleep(100);
+
+  /* Change the attributes now. */
+
+  ret = tcsetattr(fd, TCSANOW, &tio);
+  if (ret < 0)
+    {
+      error = errno;
+      /* Print the error code in the loop because at this
+       * moment the serial attributes already changed
+       */
+    }
+
+  (void)close(fd);
+
+  /* Now, we should reopen the terminal with the new
+   * attributes to see if they took effect;
+   */
+
+  while (1)
+    {
+      printf("If you can read this message, the changes took effect.\n"
+            "Expected error code: 0. Current code: %d\n", error);
+      sleep(1);
+    }
+}
+

--- a/examples/termios/termios_main.c
+++ b/examples/termios/termios_main.c
@@ -123,6 +123,7 @@ int main(int argc, FAR char *argv[])
             "Expected error code: 0. Current code: %d\n", error);
       sleep(1);
     }
+
   return 0;
 }
 

--- a/examples/termios/termios_main.c
+++ b/examples/termios/termios_main.c
@@ -36,7 +36,7 @@
  * main
  ****************************************************************************/
 
-void main(int argc, FAR char *argv[])
+int main(int argc, FAR char *argv[])
 {
   int fd;
   int ret;
@@ -123,5 +123,6 @@ void main(int argc, FAR char *argv[])
             "Expected error code: 0. Current code: %d\n", error);
       sleep(1);
     }
+  return 0;
 }
 


### PR DESCRIPTION
## Summary

This example uses the termios interface to reconfigure serial parameters.

## Impact
N/A

## Testing
Tested in ESP32-C3 devkitc.

![image](https://user-images.githubusercontent.com/33546913/111311101-915ec900-863c-11eb-96d4-bb0fbd4d2178.png)
