### PR TITLE
dhcpd/telnet: don't need to dupcalite listen socket when task_create

### DIFF
--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/dhcpd/dhcpd.c
+ * apps/netutils/dhcpd/dhcpd.c
  *
  *   Copyright (C) 2007-2009, 2011-2014, 2017, 2020 Gregory Nutt. All rights
  *     reserved.
@@ -846,7 +846,7 @@ static inline int dhcpd_socket(void)
 
   /* Create a socket to listen for requests from DHCP clients */
 
-  sockfd = socket(PF_INET, SOCK_DGRAM, 0);
+  sockfd = socket(PF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (sockfd < 0)
     {
       nerr("ERROR: socket failed: %d\n", errno);

--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/telnetd/telnetd_daemon.c
+ * apps/netutils/telnetd/telnetd_daemon.c
  *
  *   Copyright (C) 2012, 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -171,7 +171,7 @@ static int telnetd_daemon(int argc, FAR char *argv[])
 
   /* Create a new TCP socket to use to listen for connections */
 
-  listensd = socket(daemon->family, SOCK_STREAM, 0);
+  listensd = socket(daemon->family, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (listensd < 0)
     {
       nerr("ERROR: socket() failed for family %u: %d\n",


### PR DESCRIPTION
## Summary
dhcpd/telnet: don't need to dupcalite listen socket when task_create. this patch associates with https://github.com/apache/incubator-nuttx/pull/3045
## Impact
normal using telnetd/dhcpd.
## Testing
daily test
