### PR TITLE
Extend Testing of Sporadic Scheduler in OS test

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/testing/ostest/Makefile
 #
-#   Copyright (C) 2007-2012, 2014, 2017 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
@@ -105,7 +90,7 @@ CSRCS += roundrobin.c
 endif
 
 ifeq ($(CONFIG_SCHED_SPORADIC),y)
-CSRCS += sporadic.c
+CSRCS += sporadic.c sporadic2.c
 endif
 endif # CONFIG_DISABLE_PTHREAD
 

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -1,36 +1,20 @@
 /****************************************************************************
  * apps/testing/ostest/ostest.h
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2018 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -220,6 +204,10 @@ void rr_test(void);
 /* sporadic.c ***************************************************************/
 
 void sporadic_test(void);
+
+/* sporadic2.c **************************************************************/
+
+void sporadic2_test(void);
 
 /* tls.c ********************************************************************/
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -510,6 +510,10 @@ static int user_main(int argc, char *argv[])
       printf("\nuser_main: sporadic scheduler test\n");
       sporadic_test();
       check_test_memory_usage();
+
+      printf("\nuser_main: Dual sporadic thread test\n");
+      sporadic2_test();
+      check_test_memory_usage();
 #endif
 
 #ifndef CONFIG_DISABLE_PTHREAD

--- a/testing/ostest/sporadic2.c
+++ b/testing/ostest/sporadic2.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/testing/ostest/sporadic.c
+ * apps/testing/ostest/sporadic2.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,13 +25,13 @@
 #include <nuttx/config.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+
 #include <pthread.h>
 #include <semaphore.h>
 #include <sched.h>
 #include <time.h>
-
-#include "ostest.h"
 
 #ifdef CONFIG_SCHED_SPORADIC
 
@@ -39,17 +39,19 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* It is actually a better test without schedule locking because that
- * forces the scheduler into an uninteresting fallback mode.
- */
-
-#undef sched_lock
-#undef sched_unlock
-#define sched_lock()
-#define sched_unlock()
+#define PRIO_LOW1     20
+#define PRIO_LOW2     30
+#define PRIO_HIGH1    180
+#define PRIO_HIGH2    170
+#define REPL_INTERVAL 100000000L
+#define MAX_BUDGET    (REPL_INTERVAL / 2)
 
 #ifndef MIN
 # define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+# define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #endif
 
 /****************************************************************************
@@ -58,6 +60,9 @@
 
 static sem_t g_sporadic_sem;
 static time_t g_start_time;
+
+static int32_t sporadic_1_ms_cnt = 0;
+static int32_t sporadic_2_ms_cnt = 0;
 
 /****************************************************************************
  * Private Functions
@@ -76,73 +81,18 @@ static void my_mdelay(unsigned int milliseconds)
     }
 }
 
-static void *nuisance_func(void *parameter)
-{
-  /* Synchronized start */
-
-  while (sem_wait(&g_sporadic_sem) < 0);
-
-  /* Sleep until we are cancelled */
-
-  for (; ; )
-    {
-      /* Sleep gracefully for awhile */
-
-      usleep(500 * 1000);
-
-      /* Then hog some CPU time */
-
-      my_mdelay(100);
-    }
-
-  return NULL;
-}
-
-static void *fifo_func(void *parameter)
-{
-  struct sched_param param;
-  time_t last;
-  time_t now;
-  int ret;
-
-  while (sem_wait(&g_sporadic_sem) < 0);
-
-  last  = g_start_time;
-
-  for (; ; )
-    {
-      do
-        {
-          sched_lock(); /* Just to exercise more logic */
-          ret = sched_getparam(0, &param);
-          if (ret < 0)
-            {
-              printf("ERROR: sched_getparam failed\n");
-              return NULL;
-            }
-
-          now = time(NULL);
-          sched_unlock();
-        }
-      while (now == last);
-
-      sched_lock(); /* Just to exercise more logic */
-      printf("%4lu FIFO:     %d\n",
-             (unsigned long)(now - g_start_time), param.sched_priority);
-      last = now;
-      sched_unlock();
-    }
-}
-
 static FAR void *sporadic_func(FAR void *parameter)
 {
+  FAR int32_t *counter = (FAR void *)parameter;
   struct sched_param param;
   time_t last;
   time_t now;
   int prio = 0;
   int ret;
 
-  while (sem_wait(&g_sporadic_sem) < 0);
+  while (sem_wait(&g_sporadic_sem) < 0)
+    {
+    }
 
   last  = g_start_time;
 
@@ -150,7 +100,8 @@ static FAR void *sporadic_func(FAR void *parameter)
     {
       do
         {
-          sched_lock(); /* Just to exercise more logic */
+          my_mdelay(1);
+          (*counter)++;
           ret = sched_getparam(0, &param);
           if (ret < 0)
             {
@@ -159,40 +110,24 @@ static FAR void *sporadic_func(FAR void *parameter)
             }
 
           now = time(NULL);
-          sched_unlock();
         }
       while (now == last && prio == param.sched_priority);
 
-      sched_lock(); /* Just to exercise more logic */
-      printf("%4lu SPORADIC: %d->%d\n",
-             (unsigned long)(now - g_start_time), prio,
-             param.sched_priority);
       prio = param.sched_priority;
       last = now;
-      sched_unlock();
     }
 }
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-void sporadic_test(void)
+static void sporadic_test_case(int32_t budget_1_ns, int32_t budget_2_ns)
 {
-  pthread_t nuisance_thread = (pthread_t)0;
-  pthread_t sporadic_thread = (pthread_t)0;
-  pthread_t fifo_thread = (pthread_t)0;
+  pthread_t sporadic_thread1 = (pthread_t)0;
+  pthread_t sporadic_thread2 = (pthread_t)0;
 #ifdef SDCC
   pthread_addr_t result;
 #endif
   FAR void *result;
   struct sched_param myparam;
   struct sched_param sparam;
-  int prio_min;
-  int prio_max;
-  int prio_low;
-  int prio_mid;
-  int prio_high;
   pthread_attr_t attr;
   int ret;
 
@@ -202,17 +137,12 @@ void sporadic_test(void)
   printf("  -- There will some errors in the replenishment interval\n");
 #endif
 
-  printf("sporadic_test: Initializing semaphore to 0\n");
   sem_init(&g_sporadic_sem, 0, 0);
 
-  prio_min  = sched_get_priority_min(SCHED_FIFO);
-  prio_max  = sched_get_priority_max(SCHED_FIFO);
+  /* initilize global worker-thread millisecons-counters */
 
-  prio_low  = prio_min + ((prio_max - prio_min) >> 2);
-  prio_mid  = (prio_min + prio_max) >> 1;
-  prio_high = prio_max - ((prio_max - prio_min) >> 2);
-
-  /* Temporarily set our priority to prio_high + 2 */
+  sporadic_1_ms_cnt = 0;
+  sporadic_2_ms_cnt = 0;
 
   ret = sched_getparam(0, &myparam);
   if (ret != OK)
@@ -220,7 +150,9 @@ void sporadic_test(void)
       printf("sporadic_test: ERROR: sched_getparam failed, ret=%d\n", ret);
     }
 
-  sparam.sched_priority = prio_high + 2;
+  /* Temporarily set our priority to PRIO_HIGH + 2 */
+
+  sparam.sched_priority = MAX(PRIO_HIGH1, PRIO_HIGH2) + 2;
   ret = sched_setparam(0, &sparam);
   if (ret != OK)
     {
@@ -236,60 +168,9 @@ void sporadic_test(void)
 
   /* This semaphore will prevent anything from running until we are ready */
 
-  sched_lock();
   sem_init(&g_sporadic_sem, 0, 0);
 
-  /* Start a FIFO thread at the highest priority (prio_max + 1) */
-
-  printf("sporadic_test: Starting FIFO thread at priority %d\n", prio_mid);
-
-  ret = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
-  if (ret != OK)
-    {
-      printf("sporadic_test: ERROR: pthread_attr_setschedpolicy failed, "
-             "ret=%d\n",
-             ret);
-    }
-
-  sparam.sched_priority = prio_high + 1;
-  ret = pthread_attr_setschedparam(&attr, &sparam);
-  if (ret != OK)
-    {
-      printf("sporadic_test: ERROR: pthread_attr_setschedparam failed, "
-             "ret=%d\n",
-             ret);
-    }
-
-  ret = pthread_create(&nuisance_thread, &attr, nuisance_func, NULL);
-  if (ret != 0)
-    {
-      printf("sporadic_test: ERROR: FIFO thread creation failed: %d\n",
-             ret);
-    }
-
-  /* Start a FIFO thread at the middle priority */
-
-  sparam.sched_priority = prio_mid;
-  ret = pthread_attr_setschedparam(&attr, &sparam);
-  if (ret != OK)
-    {
-      printf("sporadic_test: ERROR: pthread_attr_setschedparam failed, "
-             "ret=%d\n",
-             ret);
-    }
-
-  ret = pthread_create(&fifo_thread, &attr, fifo_func, NULL);
-  if (ret != 0)
-    {
-      printf("sporadic_test: ERROR: FIFO thread creation failed: %d\n",
-             ret);
-    }
-
   /* Start a sporadic thread, with the following parameters: */
-
-  printf("sporadic_test: Starting sporadic thread at priority "
-         "%d (hi) %d (lo)\n",
-         prio_high, prio_low);
 
   ret = pthread_attr_setschedpolicy(&attr, SCHED_SPORADIC);
   if (ret != OK)
@@ -299,12 +180,12 @@ void sporadic_test(void)
              ret);
     }
 
-  sparam.sched_priority               = prio_high;
-  sparam.sched_ss_low_priority        = prio_low;
-  sparam.sched_ss_repl_period.tv_sec  = 5;
-  sparam.sched_ss_repl_period.tv_nsec = 0;
-  sparam.sched_ss_init_budget.tv_sec  = 2;
-  sparam.sched_ss_init_budget.tv_nsec = 0;
+  sparam.sched_priority               = PRIO_HIGH1;
+  sparam.sched_ss_low_priority        = PRIO_LOW1;
+  sparam.sched_ss_repl_period.tv_sec  = 0;
+  sparam.sched_ss_repl_period.tv_nsec = REPL_INTERVAL;
+  sparam.sched_ss_init_budget.tv_sec  = 0;
+  sparam.sched_ss_init_budget.tv_nsec = budget_1_ns;
   sparam.sched_ss_max_repl            = CONFIG_SCHED_SPORADIC_MAXREPL;
 
   ret = pthread_attr_setschedparam(&attr, &sparam);
@@ -315,11 +196,47 @@ void sporadic_test(void)
              ret);
     }
 
-  ret = pthread_create(&sporadic_thread, &attr, sporadic_func,
-                       (pthread_addr_t)1);
+  ret = pthread_create(&sporadic_thread1, &attr, sporadic_func,
+                       &sporadic_1_ms_cnt);
   if (ret != 0)
     {
       printf("sporadic_test: ERROR: sporadic thread creation failed: %d\n",
+             ret);
+    }
+
+  ret = pthread_attr_setschedpolicy(&attr, SCHED_SPORADIC);
+  if (ret != OK)
+    {
+      printf("sporadic_test: ERROR: pthread_attr_setschedpolicy failed, "
+             "ret=%d\n",
+             ret);
+    }
+
+  sparam.sched_priority               = PRIO_HIGH2;
+  sparam.sched_ss_low_priority        = PRIO_LOW2;
+  sparam.sched_ss_init_budget.tv_nsec = budget_2_ns;
+
+  ret = pthread_attr_setschedparam(&attr, &sparam);
+  if (ret != OK)
+    {
+      printf("sporadic_test: ERROR: pthread_attr_setsched param failed, "
+             "ret=%d\n",
+             ret);
+    }
+
+  ret = pthread_create(&sporadic_thread2, &attr, sporadic_func,
+                       (pthread_addr_t)&sporadic_2_ms_cnt);
+  if (ret != 0)
+    {
+      printf("sporadic_test: ERROR: sporadic thread creation failed: %d\n",
+             ret);
+    }
+
+  ret = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+  if (ret != OK)
+    {
+      printf("sporadic_test: ERROR: pthread_attr_setschedpolicy failed, "
+             "ret=%d\n",
              ret);
     }
 
@@ -327,35 +244,51 @@ void sporadic_test(void)
 
   sem_post(&g_sporadic_sem);
   sem_post(&g_sporadic_sem);
-  sem_post(&g_sporadic_sem);
 
-  /* Wait a while then kill the FIFO thread */
+  sleep(100);
 
-  sleep(15);
-  ret = pthread_cancel(fifo_thread);
-  pthread_join(fifo_thread, &result);
+  ret = pthread_cancel(sporadic_thread1);
+  pthread_join(sporadic_thread1, &result);
 
-  /* Wait a bit longer then kill the nuisance thread */
+  ret = pthread_cancel(sporadic_thread2);
+  pthread_join(sporadic_thread1, &result);
 
-  sleep(10);
-  ret = pthread_cancel(nuisance_thread);
-  pthread_join(nuisance_thread, &result);
-
-  /* Wait a bit longer then kill the sporadic thread */
-
-  sleep(10);
-  ret = pthread_cancel(sporadic_thread);
-  pthread_join(sporadic_thread, &result);
-  sched_unlock();
-
-  printf("sporadic_test: Done\n");
   sem_destroy(&g_sporadic_sem);
-
   ret = sched_setparam(0, &myparam);
   if (ret != OK)
     {
       printf("sporadic_test: ERROR: sched_setparam failed, ret=%d\n", ret);
     }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int sporadic2_test(void)
+{
+  int32_t budget_1_ns;
+  int32_t budget_2_ns = 30 * 1000000;
+  int i;
+
+  printf("Sporadic 1: prio high %d, low %d, repl %" PRIi32 " ns\n",
+         PRIO_HIGH1, PRIO_LOW1, REPL_INTERVAL);
+  printf("Sporadic 2: prio high %d, low %d, repl %" PRIi32 " ns\n",
+         PRIO_HIGH2, PRIO_LOW2, REPL_INTERVAL);
+
+  for (budget_1_ns = 0, i = 1;
+       budget_1_ns <= MAX_BUDGET;
+       budget_1_ns += 10 * 1000000, i++)
+    {
+      sporadic_test_case(budget_1_ns, budget_2_ns);
+
+      printf("%3d Sporadic 1 budget %09" PRIi32 " ns %6" PRIi32 " ms\n",
+             i, budget_1_ns, sporadic_1_ms_cnt);
+      printf("    Sporadic 2 budget %09" PRIi32 " ns %6" PRIi32 " ms\n",
+             budget_2_ns, sporadic_2_ms_cnt);
+    }
+
+  return 0;
 }
 
 #endif /* CONFIG_SCHED_SPORADIC */


### PR DESCRIPTION
## Summary

This commit adds the test developed by Jan Staschulat with Issue #apache/incubator-nuttx/2935

## Impact

It is expected to cause the OS test to fail for the time being since that issue reports a bug (that has been corrected; no bug is reported by OS test).

The test is rather long (about 10 minutes), however, that is only if the sporadic scheduler is enabled.  I don't think it ever is.

## Testing

Tested using the (new) stm32f4discovery:sporadic configuration.

