### PR TITLE
fsutils/mksmartfs: Fix regression caused by BCH separation

### DIFF
--- a/fsutils/mksmartfs/Kconfig
+++ b/fsutils/mksmartfs/Kconfig
@@ -7,5 +7,6 @@ config FSUTILS_MKSMARTFS
 	bool "mksmartfs utility"
 	default y
 	depends on FS_SMARTFS && !DISABLE_PSEUDOFS_OPERATIONS
+	select BCH
 	---help---
 		Enables support for the mksmartfs utility


### PR DESCRIPTION
## Summary
This PR intends to fix a regression caused by PR [3061](https://github.com/apache/incubator-nuttx/pull/3061), which separated the BCH logic from CONFIG_DISABLE_MOUNTPOINT.
Since the Block-to-character driver is not built by default, `mksmartfs` fails to open the file descriptor of the MTD block device.

## Impact
Fix `mksmartfs` NSH command on targets that support SMARTFS file system.

## Testing
`esp32-devkic:spiflash` and also on custom configuration for `sim`
`fstest` also executed to completion.

Previous behavior:
```shell
NuttShell (NSH) NuttX-10.0.1
nsh> mksmartfs /dev/smart0
nsh: mksmartfs: mksmartfs failed: 2
nsh> 
```
With proposed change:
```shell
NuttShell (NSH) NuttX-10.0.1
nsh> mksmartfs /dev/smart0
nsh> 
```

