### PR TITLE
examples/oneshot: fixed wrong constant and refactored

### DIFF
--- a/examples/oneshot/oneshot_main.c
+++ b/examples/oneshot/oneshot_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/oneshot/oneshot_main.c
+ * apps/examples/oneshot/oneshot_main.c
  *
  *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -178,9 +178,10 @@ int main(int argc, FAR char *argv[])
       return EXIT_FAILURE;
     }
 
-  maxus = (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000;
+  maxus = (uint64_t)ts.tv_sec * USEC_PER_SEC +
+          (uint64_t)ts.tv_nsec / NSEC_PER_USEC;
 
-  printf("Maximum delay is %llu\n", maxus);
+  printf("Maximum delay is %" PRIu64 "\n", maxus);
 
   /* Ignore the default signal action */
 
@@ -202,13 +203,12 @@ int main(int argc, FAR char *argv[])
           printf("Starting oneshot timer with delay %lu microseconds\n",
                  usecs);
 
-          start.pid        = 0;
-
-          secs             = usecs / 1000000;
-          usecs           -= 1000000 * secs;
+          start.pid  = 0;
+          secs       = usecs / USEC_PER_SEC;
+          usecs     -= USEC_PER_SEC * secs;
 
           start.ts.tv_sec  = secs;
-          start.ts.tv_nsec = usecs * 1000;
+          start.ts.tv_nsec = usecs * NSEC_PER_USEC;
 
           start.event.sigev_notify = SIGEV_SIGNAL;
           start.event.sigev_signo  = CONFIG_EXAMPLES_ONESHOT_SIGNO;
@@ -228,16 +228,16 @@ int main(int argc, FAR char *argv[])
           start.ts.tv_sec  = ts.tv_sec;
           start.ts.tv_nsec = ts.tv_nsec;
 
-          usecs           -= maxus;
+          usecs -= maxus;
 
 #if FUDGE_FACTOR > 0
           if (usecs > FUDGE_FACTOR)
             {
-              usecs      -= FUDGE_FACTOR;
+              usecs -= FUDGE_FACTOR;
             }
           else
             {
-              usecs       = 0;
+              usecs = 0;
             }
 #endif
         }


### PR DESCRIPTION
## Summary
This little PR is intended only to:
* Fix a wrong constant that was being used to convert time unities and 
* Refactor the code using constant definitions instead of raw numbers. 

## Impact
N/A

## Testing
After the changes the maximum delay became correct.

