### PR TITLE
build: Fix builtin list regeneration after config update

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -90,7 +90,11 @@ ifneq ($(BUILD_MODULE),y)
   OBJS += $(MAINCOBJ) $(MAINCXXOBJ)
 endif
 
+DEPPATH += --dep-path .
+DEPPATH += --obj-path .
 DEPPATH += --obj-suffix $(SUFFIX)$(OBJEXT)
+
+VPATH += :.
 
 # Targets follow
 


### PR DESCRIPTION
## Summary
This PR intends to revert a change from PR #626 that introduced a regression to the build system.
After a configuration change that modifies the list of builtin applications, the build system will not generate the updated object files for the builtin application list, resulting in linker errors.

## Impact
Fix to the build system.

## Testing
Follow the steps to reproduce the issue:
```shell
$ ./tools/configure.sh -E sim:nsh
$ make
# First build terminates successfully
$ make menuconfig
# Disable "Hello, World!" example
$ make
```
It will result in the following error:
```shell
/usr/bin/ld: nuttx.rel:(.data.rel.ro+0x7b0): undefined reference to `hello_main'                         
collect2: error: ld returned 1 exit status                                                                                                                                                                         
make[1]: *** [Makefile:322: nuttx] Error 1
```