### PR TITLE
candump.c:  Must not extern optind, et al

### DIFF
--- a/canutils/candump/candump.c
+++ b/canutils/candump/candump.c
@@ -111,8 +111,6 @@ const int canfd_on = 1;
 const char anichar[MAXANI] = {'|', '/', '-', '\\'};
 const char extra_m_info[4][4] = {"- -", "B -", "- E", "B E"};
 
-extern int optind, opterr, optopt;
-
 static volatile int running = 1;
 
 static void print_usage(char *prg)


### PR DESCRIPTION
## Summary

optind, et al, are not longer simple globals variables (after incubator-nuttx PR 3170).  Redundantly externing them in application code now results in compilation errors.

## Impact

Need for compile with incubator_nuttx PR 3170.  No other impact expected.

## Testing

CI only


