### PR TITLE
mqttc example: provide sane hostname default to avoid crash

### DIFF
--- a/examples/mqttc/README.md
+++ b/examples/mqttc/README.md
@@ -12,7 +12,7 @@ mosquitto is used:
 mosquitto&
 mosquitto_sub -t test
 ```
-Make sure that mosquitto is configured in local mode only.
+Make sure that mosquitto is not configured in local mode only.
 
 From the nsh:
 

--- a/examples/mqttc/mqttc_pub.c
+++ b/examples/mqttc/mqttc_pub.c
@@ -150,10 +150,12 @@ static int initserver(const FAR struct mqttc_cfg_s *cfg)
   hints.ai_family  = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
 
+  printf("Connecting to %s:%s...\n", cfg->host, cfg->port);
+
   ret = getaddrinfo(cfg->host, cfg->port, &hints, &servinfo);
   if (ret < 0)
     {
-      printf("ERROR! getaddrinfo() failed:%s\n", gai_strerror(ret));
+      printf("ERROR! getaddrinfo() failed: %s\n", gai_strerror(ret));
     }
 
   itr = servinfo;
@@ -186,14 +188,14 @@ static int initserver(const FAR struct mqttc_cfg_s *cfg)
   ret = fcntl(fd, F_GETFL, 0);
   if (ret < 0)
     {
-      printf("ERROR! fcntl() F_GETFL failed, errno:%d\n", errno);
+      printf("ERROR! fcntl() F_GETFL failed, errno: %d\n", errno);
       return -1;
     }
 
   ret = fcntl(fd, F_SETFL, ret | O_NONBLOCK);
   if (ret < 0)
     {
-      printf("ERROR! fcntl() F_SETFL failed, errno:%d\n", errno);
+      printf("ERROR! fcntl() F_SETFL failed, errno: %d\n", errno);
       return -1;
     }
 
@@ -212,6 +214,7 @@ int main(int argc, char *argv[])
   int n = 1;
   struct mqttc_cfg_s mqtt_cfg =
     {
+      .host = "broker.hivemq.com",
       .port = "1883",
       .topic = "test",
       .msg = "test",


### PR DESCRIPTION
## Summary

Provide a sane hostname default (I used a public test broker for convenience). Otherwise it results in a crash since the
hostname variable was uninitialized. I also made slight improvements to output.

## Impact

Fix potential crash in example app.

## Testing

esp32-devkitc:wapi
