### PR TITLE
httpd: expose http_send_headers to be used in CGI handlers

### DIFF
--- a/include/netutils/httpd.h
+++ b/include/netutils/httpd.h
@@ -192,11 +192,82 @@ EXTERN const int g_httpd_numfiles;
  * Public Function Prototypes
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: httpd_init
+ *
+ * Description:
+ *   This function initializes the web server and should be called at system
+ *   boot-up.
+ *
+ ****************************************************************************/
+
 void httpd_init(void);
+
+/****************************************************************************
+ * Name: httpd_listen
+ *
+ * Description:
+ *   This is the main processing thread for the webserver.  It never returns
+ *   unless an error occurs
+ *
+ ****************************************************************************/
+
 int httpd_listen(void);
+
+/****************************************************************************
+ * Name: httpd_cgi_register
+ *
+ * Description:
+ *   Register a CGI handler
+ *
+ ****************************************************************************/
+
 void httpd_cgi_register(struct httpd_cgi_call *cgi_call);
-uint16_t httpd_fs_count(char *name);
+
+/****************************************************************************
+ * Name: httpd_send_datachunk
+ *
+ * Description:
+ *   Sends a chunk of HTML data using either chunked or non-chunked encoding.
+ *
+ * Input Parameters:
+ *   sockfd   Socket to which to send the data.
+ *   data     Data to send
+ *   len      Length of data to send
+ *   chunked  If True, sends an HTTP Chunked-Encoding prolog before the data
+ *            block, and a HTTP Chunked-Encoding epilog ("\r\n") after the
+ *            data block. If False, just sends the data.
+ *
+ * Returned Value:
+ *   On success, returns >=0. On failure, returns a negative number
+ *   indicating the failure code.
+ *
+ ****************************************************************************/
+
 int httpd_send_datachunk(int sockfd, void *data, int len, bool chunked);
+
+/****************************************************************************
+ * Name: httpd_send_headers
+ *
+ * Description:
+ *   Sends HTTP headers
+ *
+ * Input Parameters:
+ *   pstate   The httpd state
+ *   status   Numeric HTTP status code
+ *   len      Length of data to be sent in subsequent send
+ *
+ * Returned Value:
+ *   On success, returns >=0. On failure, returns a negative number
+ *   indicating the failure code.
+ *
+ ****************************************************************************/
+
+int httpd_send_headers(struct httpd_state *pstate, int status, int len);
+
+#ifdef CONFIG_NETUTILS_HTTPDFSSTATS
+uint16_t httpd_fs_count(char *name);
+#endif
 
 #ifdef CONFIG_NETUTILS_HTTPD_DIRLIST
 bool httpd_is_file(FAR const char *filename);

--- a/netutils/webserver/httpd_cgi.c
+++ b/netutils/webserver/httpd_cgi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * httpd_cgi.c
+ * apps/netutils/webserver/httpd_cgi.c
  * Web server script interface
  * Author: Adam Dunkels <adam@sics.se>
  *
@@ -58,6 +58,10 @@ struct httpd_cgi_call *cgi_calls = NULL;
  * Public Functions
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: httpd_cgi_register
+ ****************************************************************************/
+
 void httpd_cgi_register(struct httpd_cgi_call *cgi_call)
 {
   if (cgi_calls == NULL)
@@ -70,6 +74,10 @@ void httpd_cgi_register(struct httpd_cgi_call *cgi_call)
       cgi_calls = cgi_call;
     }
 }
+
+/****************************************************************************
+ * Name: httpd_cgi
+ ****************************************************************************/
 
 httpd_cgifunction httpd_cgi(char *name)
 {


### PR DESCRIPTION
## Summary

This exposes https_send_headers (previously send_headers) to public interface so it can be used from within
a CGI handler (otherwise there's no way to build a complete HTTP response).
I also added some comments to existing functions.

## Impact

Make public internal HTTPD interface.

## Testing

esp32-devkitc:wapi
