### PR TITLE
CI: Migrate ci tooling from testing repository to main os repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         id: gittargets
         shell: bash
         run: |
-          TESTING_REF="master"  # Always use master for testing
           OS_REF=""
           APPS_REF=""
 
@@ -76,7 +75,6 @@ jobs:
 
           echo ::set-output name=os_ref::$OS_REF
           echo ::set-output name=apps_ref::$APPS_REF
-          echo ::set-output name=testing_ref::$TESTING_REF
 
       - name: Checkout nuttx repo
         uses: actions/checkout@v2
@@ -94,14 +92,6 @@ jobs:
           repository: apache/incubator-nuttx-apps
           ref: ${{ steps.gittargets.outputs.apps_ref }}
           path: sources/apps
-          fetch-depth: 1
-
-      - name: Checkout testing repo
-        uses: actions/checkout@v2
-        with:
-          repository: apache/incubator-nuttx-testing
-          ref: ${{ steps.gittargets.outputs.testing_ref }}
-          path: sources/testing
           fetch-depth: 1
 
       - name: Tar sources
@@ -138,11 +128,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Pull
-        run: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
+        run: docker pull docker.pkg.github.com/apache/incubator-nuttx/apache-nuttx-ci-linux
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run builds
-        uses: ./sources/testing/.github/actions/ci-container
+        uses: ./sources/nuttx/.github/actions/ci-container
         env:
           BLOBDIR: /tools/blobs
         with:
@@ -150,8 +140,8 @@ jobs:
             echo "::add-matcher::sources/nuttx/.github/gcc.json"
             export CCACHE_DIR=`pwd`/ccache
             mkdir $CCACHE_DIR
-            cd sources/testing
-            export ARTIFACTDIR=`pwd`/../../buildartifacts
+            export ARTIFACTDIR=`pwd`/buildartifacts
+            cd sources/nuttx/tools/ci
             ./cibuild.sh -A -c testlist/${{matrix.boards}}.dat
             ccache -s
       - uses: actions/upload-artifact@v2
@@ -181,7 +171,7 @@ jobs:
           cache-name: ${{ runner.os }}-cache-tools
         with:
           path: prebuilt
-          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/testing/cibuild.sh') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/cibuild.sh') }}
 
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
@@ -190,8 +180,8 @@ jobs:
           echo "::add-matcher::sources/nuttx/.github/gcc.json"
           export CCACHE_DIR=`pwd`/ccache
           mkdir $CCACHE_DIR
-          cd sources/testing
-          export ARTIFACTDIR=`pwd`/../../buildartifacts
+          export ARTIFACTDIR=`pwd`/buildartifacts
+          cd sources/nuttx/tools/ci
           ./cibuild.sh -i -A -c testlist/${{matrix.boards}}.dat
           ccache -s
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary
This is the app half off https://github.com/apache/incubator-nuttx/pull/3318
CI tooling and docker container is now in the os repo.

## Testing
CI should build.
