### PR TITLE
examples/lvgldemo: Add support for asynchronous flush

### DIFF
--- a/examples/lvgldemo/Kconfig
+++ b/examples/lvgldemo/Kconfig
@@ -22,6 +22,13 @@ config EXAMPLES_LVGLDEMO_BUFF_SIZE
 	int "Display buffer size (in line)"
 	default 20
 
+config EXAMPLES_LVGLDEMO_ASYNC_FLUSH
+	bool "Flush the display buffer asynchronously"
+	default n
+	---help---
+		Enable this option to perform an asynchronous write of the buffer
+		contents to the display device.
+
 choice
 	prompt "Select a demo application"
 	default EXAMPLES_LVGLDEMO_WIDGETS


### PR DESCRIPTION
## Summary
This PR intends to add support for asynchronous flush operation on the `lvgldemo` example application, for both the Framebuffer and LCD character devices.
This enables the parallelization of the rendering of the next frame by LVGL and the drawing of the current frame to the display device.

## Impact
Expected some performance improvement when `CONFIG_EXAMPLES_LVGLDEMO_DOUBLE_BUFFERING` is also enabled.
No impact if `CONFIG_EXAMPLES_LVGLDEMO_ASYNC_FLUSH` is not enabled.

## Testing
Tested `sim:lvgl` with **Benchmark** and **Stress**  examples from `lvgldemo`.
