### PR TITLE
webclient: 304 and 305 are not really redirects

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/webclient/webclient.c
+ * apps/netutils/webclient/webclient.c
  * Implementation of the HTTP client.
  *
  *   Copyright (C) 2007, 2009, 2011-2012, 2014, 2020 Gregory Nutt.

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -423,9 +423,15 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
 
               /* Check for 3xx (Redirection)
                * Location: header line will contain the new location.
+               *
+               * Note: the following 3xx are not redirects.
+               *   304 not modified
+               *   305 use proxy
                */
 
-              else if ((http_status / 100) == 3)
+              else if ((http_status / 100) == 3 &&
+                       (http_status != 304) &&
+                       (http_status != 305))
                 {
                   ws->httpstatus = HTTPSTATUS_MOVED;
                 }


### PR DESCRIPTION
## Summary
webclient: 304 and 305 are not really redirects

Eg. The docker API sometimes returns 304 even for requests without etags.
https://docs.docker.com/engine/api/v1.40/#operation/ContainerStop

## Impact

## Testing
tested against the docker api
(not on nuttx, with my fork of webclient.c)
