### PR TITLE
graphics/lvgl: Add config to enable LVGL Performance Monitor

### DIFF
--- a/graphics/lvgl/Kconfig
+++ b/graphics/lvgl/Kconfig
@@ -28,6 +28,12 @@ config LV_USE_USER_DATA
 	---help---
 		Add a `user_data` to drivers and objects
 
+config LV_USE_PERF_MONITOR
+	bool "Show CPU usage and FPS count"
+	default n
+	---help---
+		Show CPU usage and FPS count in the right bottom corner
+
 menu "Graphics settings"
 
 config LV_HOR_RES

--- a/graphics/lvgl/lv_conf.h
+++ b/graphics/lvgl/lv_conf.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/graphics/littlevgl/lv_conf.h
+ * apps/graphics/lvgl/lv_conf.h
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Author: Gábor Kiss-Vámosi <kisvegabor@gmail.com>
@@ -330,7 +330,11 @@ typedef void * lv_fs_drv_user_data_t;
 
 /* 1: Show CPU usage and FPS count in the right bottom corner */
 
-#define LV_USE_PERF_MONITOR     0
+#ifdef CONFIG_LV_USE_PERF_MONITOR
+#define LV_USE_PERF_MONITOR        CONFIG_LV_USE_PERF_MONITOR
+#else
+#define LV_USE_PERF_MONITOR        0
+#endif
 
 /* 1: Use the functions and types from the older API if possible */
 


### PR DESCRIPTION
## Summary
This PR intends to add a new option for enabling LVGL's performance monitor, which adds a small widget at the bottom right corner for showing CPU usage and FPS count real-time stats.

![image](https://user-images.githubusercontent.com/38959758/113892210-2cf6db80-979c-11eb-998f-d6db217df701.png)

## Impact
New feature, no impact if not used.

## Testing
`sim:lvgl`

![image](https://user-images.githubusercontent.com/38959758/113892456-60d20100-979c-11eb-96b9-c2781c78b8ec.png)


