### PR TITLE
examples/lvgldemo: Add config to enable Slideshow mode for Widgets demo

### DIFF
--- a/examples/lvgldemo/Kconfig
+++ b/examples/lvgldemo/Kconfig
@@ -49,6 +49,17 @@ config EXAMPLES_LVGLDEMO_WIDGETS
 
 endchoice
 
+if EXAMPLES_LVGLDEMO_WIDGETS
+
+config EXAMPLES_LVGLDEMO_WIDGETS_SLIDESHOW
+	bool "Enable Slideshow mode for Widgets example"
+	default n
+	---help---
+		Slideshow mode consists of a non-interactive demonstration of the
+		Widgets example.
+
+endif # EXAMPLES_LVGLDEMO_WIDGETS
+
 config EXAMPLES_LVGLDEMO_PRIORITY
 	int "lvgl task priority"
 	default 100

--- a/examples/lvgldemo/lv_ex_conf.h
+++ b/examples/lvgldemo/lv_ex_conf.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/lvgldemo/lv_ex_conf.h
+ * apps/examples/lvgldemo/lv_ex_conf.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -45,7 +45,11 @@
 
 #define LV_USE_DEMO_WIDGETS        1
 #if LV_USE_DEMO_WIDGETS
-#define LV_DEMO_WIDGETS_SLIDESHOW  0
+#ifdef CONFIG_EXAMPLES_LVGLDEMO_WIDGETS_SLIDESHOW
+#define LV_DEMO_WIDGETS_SLIDESHOW        CONFIG_EXAMPLES_LVGLDEMO_WIDGETS_SLIDESHOW
+#else
+#define LV_DEMO_WIDGETS_SLIDESHOW        0
+#endif
 #endif
 
 /* Printer demo, optimized for 800x480 */


### PR DESCRIPTION
## Summary
This PR intends to add a new config for enabling Slideshow mode for the LVGL Widgets example demo.

![image](https://user-images.githubusercontent.com/38959758/113892829-ccb46980-979c-11eb-9082-59c4392d1086.png)

## Impact
New feature, no impact if not selected.

## Testing
`sim:lvgl`

