### PR TITLE
examples: Update missing DJOYSTICK macro to new INPUT template

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -266,7 +266,7 @@ driver in `nuttx/include/nuttx/input/djoystick.h`.
 
 Configuration Pre-requisites:
 
-- `CONFIG_DJOYSTICK` – The discrete joystick driver.
+- `CONFIG_INPUT_DJOYSTICK` – The discrete joystick driver.
 
 Example Configuration:
 

--- a/examples/djoystick/djoy_main.c
+++ b/examples/djoystick/djoy_main.c
@@ -54,8 +54,8 @@
 
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_DJOYSTICK
-#  error "CONFIG_DJOYSTICK is not defined in the configuration"
+#ifndef CONFIG_INPUT_DJOYSTICK
+#  error "CONFIG_INPUT_DJOYSTICK is not defined in the configuration"
 #endif
 
 #ifndef CONFIG_EXAMPLES_DJOYSTICK_DEVNAME


### PR DESCRIPTION
## Summary
This PR intends to fixup #675, which missed one DJOYSTICK macro.

## Impact
Fix CI build from https://github.com/apache/incubator-nuttx/pull/3482

## Testing
Successfully built `open1788:pdcurses` configuration
