### PR TITLE
i8sak: Fixes bug where daemon was being requested again

### DIFF
--- a/wireless/ieee802154/i8sak/i8sak_scan.c
+++ b/wireless/ieee802154/i8sak/i8sak_scan.c
@@ -281,5 +281,5 @@ static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive,
         }
     }
 
-  i8sak_requestdaemon(i8sak);
+  i8sak_releasedaemon(i8sak);
 }

--- a/wireless/ieee802154/i8sak/i8sak_tx.c
+++ b/wireless/ieee802154/i8sak/i8sak_tx.c
@@ -301,5 +301,5 @@ static void tx_eventcb(FAR struct ieee802154_primitive_s *primitive,
 
   sem_post(&i8sak->sigsem);
 
-  i8sak_requestdaemon(i8sak);
+  i8sak_releasedaemon(i8sak);
 }


### PR DESCRIPTION
## Summary
 i8sak: Fixes bug where daemon was being requested again when operation is finished, instead of being released.

## Impact
Running the i8sak tx or i8sak scan app repeatedly won't keep requesting the daemon count over and over and things should shut down as it's supposed to.

## Testing
Built and ran configuration. 

