### PR TITLE
ltp: Resolve compile warnings

### DIFF
--- a/testing/ltp/0001-Fix-static-struct-warning.patch
+++ b/testing/ltp/0001-Fix-static-struct-warning.patch
@@ -1,0 +1,39 @@
+From bfb99256e5e73e8d41f8d40bdeea70b2abb5de06 Mon Sep 17 00:00:00 2001
+From: Brennan Ashton <bashton@brennanashton.com>
+Date: Sat, 10 Apr 2021 15:15:29 -0700
+Subject: [PATCH 1/2] Fix static struct warning
+
+---
+ .../open_posix_testsuite/conformance/interfaces/mmap/5-1.c      | 2 +-
+ testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/mmap/5-1.c b/testcases/open_posix_testsuite/conformance/interfaces/mmap/5-1.c
+index bcb330da6..ad7b6bb2d 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/mmap/5-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/mmap/5-1.c
+@@ -34,7 +34,7 @@
+ #include "posixtest.h"
+ #include "tempfile.h"
+ 
+-static struct testcase {
++struct testcase {
+ 	int prot;
+ 	int flags;
+ };
+diff --git a/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c b/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
+index 14ad4ea2c..2133b721a 100644
+--- a/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
++++ b/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
+@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
+  * The function returns 0 when r1 is the best for all cases (latency is constant) and !0 otherwise.
+  */
+ 
+-static struct row {
++struct row {
+ 	long X;			/* the X values -- copied from function argument */
+ 	long Y_o;		/* the Y values -- copied from function argument */
+ 	long Y_c;		/* the Y values -- copied from function argument */
+-- 
+2.30.2
+

--- a/testing/ltp/0002-Use-ifdef-instead-of-if-for-__linux__.patch
+++ b/testing/ltp/0002-Use-ifdef-instead-of-if-for-__linux__.patch
@@ -1,0 +1,25 @@
+From 1482d59fc2f5ed935e8201704305684cf129fbae Mon Sep 17 00:00:00 2001
+From: Brennan Ashton <bashton@brennanashton.com>
+Date: Sun, 11 Apr 2021 00:12:06 -0700
+Subject: [PATCH 2/2] Use #ifdef instead of #if for __linux__
+
+---
+ .../conformance/interfaces/sem_timedwait/3-1.c                  | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
+index fb6f2e6cb..739fe86a5 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
+@@ -15,7 +15,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <fcntl.h>
+-#if __linux__
++#ifdef __linux__
+ #include <features.h>
+ #endif
+ #include <semaphore.h>
+-- 
+2.30.2
+

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -26,15 +26,31 @@ BLACKWORDS  += "aio.h"
 BLACKWORDS  += "SIGPOLL"
 endif
 BLACKWORDS  += "affinity.h"
+BLACKWORDS  += "endpwent"
 BLACKWORDS  += "langinfo.h"
 BLACKWORDS  += "ucontext.h"
 BLACKWORDS  += "noatime.h"
+BLACKWORDS  += "clock_getcpuclockid"
 BLACKWORDS  += "CLOCK_PROCESS_CPUTIME_ID"
 BLACKWORDS  += "CLOCK_THREAD_CPUTIME_ID"
 BLACKWORDS  += "fork()"
+BLACKWORDS  += "getpwent"
+BLACKWORDS  += "killpg"
+BLACKWORDS  += "pthread_atfork"
 BLACKWORDS  += "pthread_attr_setscope"
+BLACKWORDS  += "pthread_condattr_setpshared"
+BLACKWORDS  += "pthread_condattr_getpshared"
+BLACKWORDS  += "pthread_getattr_np"
+BLACKWORDS  += "pthread_getcpuclockid"
+BLACKWORDS  += "pthread_mutex_getprioceiling"
+BLACKWORDS  += "pthread_mutexattr_getprioceiling"
+BLACKWORDS  += "pthread_mutexattr_setprioceiling"
+BLACKWORDS  += "pthread_rwlockattr_destroy"
+BLACKWORDS  += "pthread_rwlockattr_getpshared"
+BLACKWORDS  += "pthread_rwlockattr_init"
 BLACKWORDS  += "RLIMIT_MEMLOCK"
 BLACKWORDS  += "PTHREAD_SCOPE_PROCESS"
+BLACKWORDS  += "setpwent"
 BLACKWORDS  += "SIGABRT"
 BLACKWORDS  += "SIGBUS"
 BLACKWORDS  += "SIGFPE"
@@ -103,9 +119,18 @@ CFLAGS       += -I$(LTP_UNPACK)
 CFLAGS       += -I$(TESTDIR)/include
 endif
 
+# Relax warning checks to avoid expected compile errors:
+CFLAGS += -Wno-strict-prototypes -Wno-return-type -Wno-format -Wno-uninitialized
+CFLAGS += -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-value
+
+# Should be removed if possible in the future
+CFLAGS += -Wno-incompatible-pointer-types -Wno-overflow -Wno-int-to-pointer-cast
+
 $(LTP_UNPACK):
 	$(Q) echo "git clone $(LTP_URL)"
 	$(Q) git clone $(LTP_URL)
+	$(Q) git -C $(LTP_UNPACK) am < 0001-Fix-static-struct-warning.patch
+	$(Q) git -C $(LTP_UNPACK) am < 0002-Use-ifdef-instead-of-if-for-__linux__.patch
 
 context:: $(LTP_UNPACK)
 


### PR DESCRIPTION
## Summary
This adjusts the build for LTP so that it can pass the CI system and build correctly.

## Impact
Should be able to enable LTP configuration.

## Testing
With this PR https://github.com/apache/incubator-nuttx/pull/3510 I am able to build the sim:ltp configuration with our standard build flags `make EXTRAFLAGS="-Werror -Wno-cpp" -j8`
