### PR TITLE
wireless/wapi: Fix issue of getting the operating frequency

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -125,8 +125,8 @@ enum wapi_route_target_e
 
 enum wapi_essid_flag_e
 {
-  WAPI_ESSID_OFF,
-  WAPI_ESSID_ON,
+  WAPI_ESSID_OFF = IW_ESSID_OFF,
+  WAPI_ESSID_ON  = IW_ESSID_ON,
 
 /* Extended flag "WAPI_ESSID_DELAY_ON" instructs the driver
  * to delay the connection behavior of essid, so that which can accept
@@ -155,7 +155,7 @@ enum wapi_essid_flag_e
  * $ renew wlan0
  */
 
-  WAPI_ESSID_DELAY_ON
+  WAPI_ESSID_DELAY_ON = IW_ESSID_DELAY_ON
 };
 
 /* Supported operation modes. */

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -137,6 +137,10 @@ static const struct wapi_command_s g_wapi_commands[] =
 
 #define NCOMMANDS (sizeof(g_wapi_commands) / sizeof(struct wapi_command_s))
 
+/* Maximum length of the PASSPHRASE, refer to IEEE802.11i specification */
+
+#define PASSPHRASE_MAX_LEN  (64)
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -842,7 +846,7 @@ static int wapi_save_config_cmd(int sock, int argc, FAR char **argv)
   uint8_t if_flags;
   uint32_t value;
   size_t psk_len;
-  char psk[32];
+  char psk[PASSPHRASE_MAX_LEN];
   int ret;
 
   ret = netlib_getifstatus(argv[0], &if_flags);

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -475,11 +475,11 @@ int wapi_get_freq(int sock, FAR const char *ifname, FAR double *freq,
     {
       /* Set flag. */
 
-      if (IW_FREQ_AUTO == (wrq.u.freq.flags & IW_FREQ_AUTO))
+      if (IW_FREQ_AUTO == wrq.u.freq.flags)
         {
           *flag = WAPI_FREQ_AUTO;
         }
-      else if (IW_FREQ_FIXED == (wrq.u.freq.flags & IW_FREQ_FIXED))
+      else if (IW_FREQ_FIXED == wrq.u.freq.flags)
         {
           *flag = WAPI_FREQ_FIXED;
         }


### PR DESCRIPTION
## Summary

Fix issue of getting the incorrect operating frequency flags.

## Impact

- None

## Testing

`wapi show <ifname>`
