### PR TITLE
wireless/wapi/src/wapi.c: When executing a command return it's error code on failure.

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -1025,6 +1025,7 @@ int main(int argc, FAR char *argv[])
   FAR const struct wapi_command_s *wapicmd;
   int sock;
   int i;
+  int ret;
 
   /* Get the command */
 
@@ -1084,7 +1085,8 @@ int main(int argc, FAR char *argv[])
       return EXIT_FAILURE;
     }
 
-  if (wapicmd->handler(sock, argc - 2, argc == 2 ? NULL : &argv[2]) < 0)
+  ret = wapicmd->handler(sock, argc - 2, argc == 2 ? NULL : &argv[2]);
+  if (ret < 0)
     {
       WAPI_ERROR("ERROR: Process command (%s) failed.\n", cmdname);
     }
@@ -1092,5 +1094,5 @@ int main(int argc, FAR char *argv[])
   /* Close communication socket */
 
   close(sock);
-  return EXIT_SUCCESS;
+  return ret;
 }


### PR DESCRIPTION
## Summary
When a command was executed `EXIT_SUCCESS` was always returned even if the command failed.  This made the `echo $?` return not reliable.
## Impact
Fix return of WAPI commands
## Testing
Tested with ESP32.

Before:
```
nsh> wapi essid wlan0 wrongssid 1
ioctl(SIOCSIWESSID): 1
ERROR: Process command (essid) failed.
nsh> echo $?
0
```
After

```
nsh> wapi essid wlan0 wrongssid 1
ioctl(SIOCSIWESSID): 1
ERROR: Process command (essid) failed.
nsh> echo $?
1
```

