### PR TITLE
example/lvgldemo: Fix "unused-but-set-variable" build warning

### DIFF
--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -54,7 +54,7 @@ MODULE = $(CONFIG_EXAMPLES_LVGLDEMO)
 
 CSRCS += fbdev.c lcddev.c
 
-ifneq ($(CONFIG_INPUT),)
+ifneq ($(CONFIG_INPUT_TOUCHSCREEN)$(CONFIG_INPUT_MOUSE),)
 CSRCS += tp.c tp_cal.c
 endif
 

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -51,7 +51,7 @@
 #include "fbdev.h"
 #include "lcddev.h"
 
-#ifdef CONFIG_INPUT
+#if defined(CONFIG_INPUT_TOUCHSCREEN) || defined(CONFIG_INPUT_MOUSE)
 #include "tp.h"
 #include "tp_cal.h"
 #endif
@@ -203,7 +203,7 @@ int main(int argc, FAR char *argv[])
 
   lv_disp_drv_register(&disp_drv);
 
-#ifdef CONFIG_INPUT
+#if defined(CONFIG_INPUT_TOUCHSCREEN) || defined(CONFIG_INPUT_MOUSE)
   /* Touchpad Initialization */
 
   tp_init();
@@ -229,7 +229,7 @@ int main(int argc, FAR char *argv[])
   lv_demo_widgets();
 #endif
 
-#ifdef CONFIG_INPUT
+#if defined(CONFIG_INPUT_TOUCHSCREEN) || defined(CONFIG_INPUT_MOUSE)
   /* Start TP calibration */
 
 #ifdef CONFIG_EXAMPLES_LVGLDEMO_CALIBRATE

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -140,6 +140,7 @@ int main(int argc, FAR char *argv[])
   lv_disp_drv_t disp_drv;
   lv_disp_buf_t disp_buf;
 
+#if defined(CONFIG_INPUT_TOUCHSCREEN) || defined(CONFIG_INPUT_MOUSE)
 #ifndef CONFIG_EXAMPLES_LVGLDEMO_CALIBRATE
   lv_point_t p[4];
 
@@ -162,6 +163,7 @@ int main(int argc, FAR char *argv[])
 
   p[3].x = LV_HOR_RES;
   p[3].y = LV_VER_RES;
+#endif
 #endif
 
 #ifdef NEED_BOARDINIT

--- a/examples/lvgldemo/tp.h
+++ b/examples/lvgldemo/tp.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/touchscreen/tc.h
+ * apps/examples/lvgldemo/tp.h
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Author: Gábor Kiss-Vámosi <kisvegabor@gmail.com>
@@ -59,8 +59,8 @@
  *   configured to work with a mouse driver by setting this option.
  */
 
-#ifndef CONFIG_INPUT
-#  error "Input device support is not enabled (CONFIG_INPUT)"
+#if !defined(CONFIG_INPUT_TOUCHSCREEN) && !defined(CONFIG_INPUT_MOUSE)
+#  error "Input device support is not enabled (CONFIG_INPUT_TOUCHSCREEN || CONFIG_INPUT_MOUSE)"
 #endif
 
 #ifndef CONFIG_EXAMPLES_LGVLDEMO_MINOR


### PR DESCRIPTION
## Summary
This PR intends to fix a build warning introduced in recent PRs related to LVGL demo application.

It also changes some `ifdef`s that were checking for `CONFIG_INPUT` in favor of more specific input subclasses configs (`CONFIG_INPUT_TOUCHSCREEN` or `CONFIG_INPUT_MOUSE`)

## Impact
No impact, only fix build warning.

## Testing
`sim:lvgl` with an without input configurations
