### PR TITLE
interpreters/ficl: Fix compilation issue

### DIFF
--- a/interpreters/ficl/Makefile
+++ b/interpreters/ficl/Makefile
@@ -39,6 +39,10 @@ include $(APPDIR)/Make.defs
 
 # Tools
 
+# Include the generated Make.srcs
+
+-include Make.srcs
+
 # Include paths
 
 CFLAGS += ${shell $(INCDIR) "$(CC)" $(BUILDDIR)/$(FICL_SUBDIR) $(BUILDDIR)/src}
@@ -46,8 +50,6 @@ CFLAGS += ${shell $(INCDIR) "$(CC)" $(BUILDDIR)/$(FICL_SUBDIR) $(BUILDDIR)/src}
 # Source Files
 
 CSRCS = nuttx.c
-
--include Make.srcs
 
 ASRCS += $(FICL_ASRCS)
 CXXSRCS += $(FICL_CXXSRCS)


### PR DESCRIPTION
## Summary
A NuttX user told that ficl wasn't working as suggested in the
README.txt, then I found that the root cause was the order of the
Make.srcs inclusion inside the Makefile. I think we can do better:
we could automate the process to download and configure ficl.

## Impact
Users will get ficl support working on NuttX

## Testing
Compiled correctly
