### PR TITLE
examples/mqttc: Makes fd invalid when connect() fails.

### DIFF
--- a/examples/mqttc/mqttc_pub.c
+++ b/examples/mqttc/mqttc_pub.c
@@ -174,6 +174,7 @@ static int initserver(const FAR struct mqttc_cfg_s *cfg)
         }
 
       close(fd);
+      fd = -1;
     }
   while ((itr = itr->ai_next) != NULL);
 


### PR DESCRIPTION
## Summary
This little MR intends to prevent a dump when the broker ip address is not valid.
To achieve this purpose, we set fd to -1, so even if the socket function returns
a valid fd, in case the connect function fails, fd will be invalidated preventing the 
rest of the code to execute. Instead, it will print `ERROR! Couldn't create socket`
and leave the program.

## Impact

Target: MQTT users.
Consequence: People will not have a dump when type a wrong broker ip address. 

## Testing

I passed a wrong IP broker address. It showed the expected error message.
I passed a valid IP broker address. It connected and published as expected.

PS: The coding style will fail due to a Mixed case identifier.
