### PR TITLE
Improve modbus example and let it to control USERLEDs

### DIFF
--- a/examples/modbus/Kconfig
+++ b/examples/modbus/Kconfig
@@ -50,4 +50,15 @@ config EXAMPLES_MODBUS_REG_HOLDING_NREGS
 	int "Number of holding registers"
 	default 130
 
+config EXAMPLES_MODBUS_REG_COILS_START
+	int "Coils registers start address"
+	default 3000
+
+config EXAMPLES_MODBUS_REG_COILS_NREGS
+	int "Number of coils registers"
+	default 32
+
+config EXAMPLES_MODBUS_REG_COILS_USERLEDS
+	bool "Enable Reg Coils to control USERLEDs"
+	depends on USERLED
 endif

--- a/examples/modbus/modbus_main.c
+++ b/examples/modbus/modbus_main.c
@@ -458,8 +458,8 @@ eMBErrorCode eMBRegInputCB(uint8_t *buffer, uint16_t address, uint16_t nregs)
       index = (int)(address - CONFIG_EXAMPLES_MODBUS_REG_INPUT_START);
       while (nregs > 0)
         {
-          *buffer++ = (uint8_t)(g_modbus.reginput[index] >> 8);
           *buffer++ = (uint8_t)(g_modbus.reginput[index] & 0xff);
+          *buffer++ = (uint8_t)(g_modbus.reginput[index] >> 8);
           index++;
           nregs--;
         }
@@ -498,8 +498,8 @@ eMBErrorCode eMBRegHoldingCB(uint8_t *buffer, uint16_t address, uint16_t nregs,
           case MB_REG_READ:
             while (nregs > 0)
               {
-                *buffer++ = (uint8_t)(g_modbus.regholding[index] >> 8);
                 *buffer++ = (uint8_t)(g_modbus.regholding[index] & 0xff);
+                *buffer++ = (uint8_t)(g_modbus.regholding[index] >> 8);
                 index++;
                 nregs--;
               }
@@ -512,8 +512,8 @@ eMBErrorCode eMBRegHoldingCB(uint8_t *buffer, uint16_t address, uint16_t nregs,
           case MB_REG_WRITE:
             while (nregs > 0)
               {
-                g_modbus.regholding[index] = *buffer++ << 8;
-                g_modbus.regholding[index] |= *buffer++;
+                g_modbus.regholding[index] = *buffer++;
+                g_modbus.regholding[index] |= *buffer++ << 8;
                 index++;
                 nregs--;
               }


### PR DESCRIPTION
## Summary
Improve Modbus slave example and let it to control USERLEDs
## Impact
User will be able to control USERLEDs over Modbus
## Testing
STM32F4Discovery

NOTE: CI will fail because Modbus used Mixed case, please ignore it.