### PR TITLE
system/spi: Print sent data in the same way as received.

### DIFF
--- a/system/spi/spi_exch.c
+++ b/system/spi/spi_exch.c
@@ -71,10 +71,12 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
   {
     0
   };
+
   uint8_t rxdata[MAX_XDATA] =
   {
     0
   };
+
   uint8_t *txdatap = txdata;
   struct spi_trans_s trans;
   struct spi_sequence_s seq;
@@ -111,7 +113,6 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
       return ERROR;
     }
 
-
   while (argndx < argc)
     {
       FAR uint8_t *a = (uint8_t *)argv[argndx];
@@ -119,7 +120,7 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
         {
           if ((*(a + 1) == 0) || !ISHEX(*a) || !ISHEX(*(a + 1)))
             {
-              /* Uneven number of characters or illegal char .... that's an error */
+              /* Uneven number of characters or illegal character error */
 
               spitool_printf(spitool, g_spiincompleteparam, argv[0]);
               return ERROR;

--- a/system/spi/spi_exch.c
+++ b/system/spi/spi_exch.c
@@ -132,6 +132,21 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
       argndx += 1;
     }
 
+  spitool_printf(spitool, "Sending:\t");
+  for (d = 0; d < spitool->count; d++)
+    {
+      if (spitool->width <= 8)
+        {
+          spitool_printf(spitool, "%02X ", txdata[d]);
+        }
+      else
+        {
+          spitool_printf(spitool, "%04X ", ((uint16_t *)txdata)[d]);
+        }
+    }
+
+  spitool_printf(spitool, "\n");
+
   /* Get a handle to the SPI bus */
 
   fd = spidev_open(spitool->bus);
@@ -168,7 +183,7 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
       return ret;
     }
 
-  spitool_printf(spitool, "Received: ");
+  spitool_printf(spitool, "Received:\t");
   for (d = 0; d < spitool->count; d++)
     {
       if (spitool->width <= 8)


### PR DESCRIPTION
## Summary
This PR intends to improve the output of the `exchange` command of SPI tool. This eases the comparison for testing SPI with looped back MOSI and MISO signals.

## Impact
Visual impact to the output of `exchange` command of SPI tool.

## Testing
Tested with `esp32c3-devkit` platform by looping back MOSI and MISO pins, width configured as 16-bit:
```shell
nsh> spi exch -x 15 DEADA55ABEEFA55ADEADA55ABEEFA55ADEADA55ABEEFA55ADEADA55ABEEF

Sending: ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 
Received: ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 5AA5 ADDE 5AA5 EFBE 
```
