### PR TITLE
apps/netutils/dhcpc/Kconfig:  Auto-select CONFIG_NET_UDP_BINDTODEVICE

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -7,6 +7,7 @@ config NETUTILS_DHCPC
 	bool "DHCP client"
 	default n
 	depends on NET_UDP && NET_BROADCAST && NET_IPv4
+	select NET_UDP_BINDTODEVICE
 	---help---
 		Enable support for the DHCP client.
 


### PR DESCRIPTION
## Summary

DHCPC depends on CONFIG_NET_UDP_BINDTODEVICE in many cases.  Safest thing is to just auto-select it whenever DHCPC is selected.

## Impact

There may be circumstances where CONFIG_NET_UDP_BINDTODEVICE is not needed.  There are existing DHCPC configurations that do not set CONFIG_NET_UDP_BINDTODEVICE

    $ find boards/ -name defconfig | xargs grep -l CONFIG_NETUTILS_DHCPC | xargs grep -l CONFIG_NET_UDP=y | wc -
         26      26    1496 -

    $ find boards/ -name defconfig | xargs grep -l CONFIG_NETUTILS_DHCPC | xargs grep -l CONFIG_NET_UDP=y | xargs grep -l BINDTODEVICE | wc -
          6       6     323 -

In the past, CONFIG_NET_UDP_BINDTODEVICE was not needed if there was only a single network device.  But things have changed.

## Testing

Only successful configuration and build was verified.

