### PR TITLE
netutils: dhcpc: Fix Kconfig for the usrsock

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -7,7 +7,7 @@ config NETUTILS_DHCPC
 	bool "DHCP client"
 	default n
 	depends on NET_UDP && NET_BROADCAST && NET_IPv4
-	select NET_UDP_BINDTODEVICE
+	select NET_UDP_BINDTODEVICE if !NET_UDP_NO_STACK
 	---help---
 		Enable support for the DHCP client.
 


### PR DESCRIPTION
## Summary

- This commit fixes the renew command with the usrsock
- https://github.com/apache/incubator-nuttx-apps/pull/696#issuecomment-828930765

## Impact

- None

## Testing

- Tested with spresense:wifi and esp32-devkitc:wapi
