### PR TITLE
netutils/webclient: Fixed socket descriptor leak.

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -822,6 +822,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
           if (ret == -1)
             {
               ret = -errno;
+              close(conn.sockfd);
             }
         }
 


### PR DESCRIPTION
## Summary
If a connection to the HTTP server cannot be established, the socket descriptor will leak.

## Impact

## Testing
I tested my local app.
