### PR TITLE
system/spi: Adopt CPHA as the abbreviation for clock phase

### DIFF
--- a/system/spi/Kconfig
+++ b/system/spi/Kconfig
@@ -61,10 +61,10 @@ config SPITOOL_DEFMODE
 	default 0
 	---help---
 		Default SPI mode, where;
-		0 = CPOL=0, CHPHA=0
-		1 = CPOL=0, CHPHA=1
-		2 = CPOL=1, CHPHA=0
-		3 = CPOL=1, CHPHA=1
+		0 = CPOL=0, CPHA=0
+		1 = CPOL=0, CPHA=1
+		2 = CPOL=1, CPHA=0
+		3 = CPOL=1, CPHA=1
 
 config SPITOOL_DEFWIDTH
 	int "SPI Bit width"

--- a/system/spi/README.md
+++ b/system/spi/README.md
@@ -39,10 +39,10 @@ The SPI tool is designed to be implemented as a NuttShell (NSH) add-on. Read the
 - `CONFIG_SPITOOL_DEFFREQ`  – Default frequency (default: `40000000`).
 - `CONFIG_SPITOOL_DEFMODE`  – Default mode, where
   ```
-  0 = CPOL=0, CHPHA=0
-  1 = CPOL=0, CHPHA=1
-  2 = CPOL=1, CHPHA=0
-  3 = CPOL=1, CHPHA=1
+  0 = CPOL=0, CPHA=0
+  1 = CPOL=0, CPHA=1
+  2 = CPOL=1, CPHA=0
+  3 = CPOL=1, CPHA=1
   ```
 - `CONFIG_SPITOOL_DEFWIDTH` – Default bit width (default `8`).
 - `CONFIG_SPITOOL_DEFWORDS` – Default number of words to exchange (default `1`).
@@ -159,10 +159,10 @@ NSH scripts to execute a longer, more complex series of SPI commands.
   Which of the available SPI modes is to be used. Options are;
 
   ```
-  0 = CPOL=0, CHPHA=0
-  1 = CPOL=0, CHPHA=1
-  2 = CPOL=1, CHPHA=0
-  3 = CPOL=1, CHPHA=1
+  0 = CPOL=0, CPHA=0
+  1 = CPOL=0, CPHA=1
+  2 = CPOL=1, CPHA=0
+  3 = CPOL=1, CPHA=1
   ```
 
 - `[-u udelay]` Delay after transfer in uS. Default: `0`

--- a/system/spi/spitool.h
+++ b/system/spi/spitool.h
@@ -65,10 +65,10 @@
  *                           (default 3)
  * CONFIG_SPITOOL_DEFFREQ  - Default frequency (default: 40000000)
  * CONFIG_SPITOOL_DEFMODE  - Default mode, where;
- *                             0 = CPOL=0, CHPHA=0
- *                             1 = CPOL=0, CHPHA=1
- *                             2 = CPOL=1, CHPHA=0
- *                             3 = CPOL=1, CHPHA=1
+ *                             0 = CPOL=0, CPHA=0
+ *                             1 = CPOL=0, CPHA=1
+ *                             2 = CPOL=1, CPHA=0
+ *                             3 = CPOL=1, CPHA=1
  * CONFIG_SPITOOL_DEFWIDTH - Default bit width (default 8)
  * CONFIG_SPITOOL_DEFWORDS - Default number of words to exchange
  *                           (default 1)
@@ -87,7 +87,7 @@
 #endif
 
 #ifndef CONFIG_SPITOOL_DEFMODE
-#define  CONFIG_SPITOOL_DEFMODE  0 /* CPOL=0, CHPHA=0 */
+#define  CONFIG_SPITOOL_DEFMODE  0 /* CPOL=0, CPHA=0 */
 #endif
 
 #ifndef CONFIG_SPITOOL_DEFWIDTH


### PR DESCRIPTION
## Summary
This PR intends to address some documentation issues I found while studying the SPI Slave architecture.

Related to: https://github.com/apache/incubator-nuttx/pull/3662

## Impact
No impact, just changes to documentation.

## Testing
Not applicable.
