### PR TITLE
nsh/telnetd: bringup the network before telnetd init 

### DIFF
--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -47,6 +47,7 @@
 
 #include <arpa/inet.h>
 
+#include "netutils/netinit.h"
 #include "netutils/telnetd.h"
 
 #ifdef CONFIG_TELNET_CHARACTER_MODE
@@ -264,6 +265,12 @@ int nsh_telnetstart(sa_family_t family)
 
 #if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
       nsh_initscript(vtbl);
+#endif
+
+#if defined(CONFIG_NSH_NETINIT) && !defined(CONFIG_NSH_CONSOLE)
+      /* Bring up the network */
+
+      netinit_bringup();
 #endif
 
       /* Perform architecture-specific final-initialization(if configured) */


### PR DESCRIPTION


## Summary

nsh/telnetd: bringup the network before telnetd init 

bringup the network before telnetd init if without NSH_CONSOLE

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Fix: 
https://github.com/apache/incubator-nuttx/issues/3663

## Testing

./tools/configure.sh -l photon:wlan