### PR TITLE
nshlib: Fix the build break in nsh_telnetd.c when CONFIG_NSH_CONSOLE=n

### DIFF
--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -463,8 +463,8 @@ FAR struct console_stdio_s *nsh_newconsole(void)
 
 #ifndef CONFIG_NSH_DISABLEBG
       pstate->cn_vtbl.clone       = nsh_consoleclone;
-      pstate->cn_vtbl.release     = nsh_consolerelease;
 #endif
+      pstate->cn_vtbl.release     = nsh_consolerelease;
       pstate->cn_vtbl.write       = nsh_consolewrite;
       pstate->cn_vtbl.output      = nsh_consoleoutput;
       pstate->cn_vtbl.error       = nsh_erroroutput;

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -123,8 +123,8 @@ struct nsh_vtbl_s
 #ifndef CONFIG_NSH_DISABLEBG
   FAR struct nsh_vtbl_s *(*clone)(FAR struct nsh_vtbl_s *vtbl);
   void (*addref)(FAR struct nsh_vtbl_s *vtbl);
-  void (*release)(FAR struct nsh_vtbl_s *vtbl);
 #endif
+  void (*release)(FAR struct nsh_vtbl_s *vtbl);
   ssize_t (*write)(FAR struct nsh_vtbl_s *vtbl, FAR const void *buffer,
                    size_t nbytes);
   int (*error)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...);

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -240,6 +240,9 @@ int nsh_telnetstart(sa_family_t family)
 
   if (state == TELNETD_NOTRUNNING)
     {
+#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
+      FAR struct console_stdio_s *pstate;
+#endif
       struct telnetd_config_s config;
 
       /* There is a tiny race condition here if two tasks were to try to
@@ -263,7 +266,9 @@ int nsh_telnetstart(sa_family_t family)
        */
 
 #if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
-      nsh_initscript(vtbl);
+      pstate = nsh_newconsole();
+      nsh_initscript(&pstate->cn_vtbl);
+      nsh_release(&pstate->cn_vtbl);
 #endif
 
       /* Perform architecture-specific final-initialization(if configured) */


### PR DESCRIPTION
## Summary

nshlib: Fix the build break in nsh_telnetd.c when CONFIG_NSH_CONSOLE=n

set the config:
CONFIG_NSH_ROMFSETC=y
CONFIG_NSH_CONSOLE=n

nsh_telnetd.c: In function 'nsh_telnetstart':
nsh_telnetd.c:267:22: error: 'vtbl' undeclared (first use in this function)
  267 |       nsh_initscript(vtbl);
      |                      ^~~~

## Impact

CONFIG_NSH_ROMFSETC=y
CONFIG_NSH_CONSOLE=n

## Testing

./tools/configure.sh -l photon:wlan