### PR TITLE
netlib_parseurl.c: Fix string overruns

### DIFF
--- a/netutils/netlib/netlib_parseurl.c
+++ b/netutils/netlib/netlib_parseurl.c
@@ -113,21 +113,21 @@ int netlib_parseurl(FAR const char *str, FAR struct url_s *url)
 
   if (*src != ':')
     {
-      ret = -EINVAL;
+      return -EINVAL;
     }
 
   src++;
 
   if (*src != '/')
     {
-      ret = -EINVAL;
+      return -EINVAL;
     }
 
   src++;
 
   if (*src != '/')
     {
-      ret = -EINVAL;
+      return -EINVAL;
     }
 
   src++;

--- a/netutils/netlib/netlib_parseurl.c
+++ b/netutils/netlib/netlib_parseurl.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * netutils/netlib/netlib_parseurl.c
+ * apps/netutils/netlib/netlib_parseurl.c
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Author: Sebastien Lorquet <sebastien@lorquet.fr>


### PR DESCRIPTION
## Summary

    For EINVAL, it doesn't make sense to keep parsing.
    (For E2BIG, it might make some sense.)
    
    Found by LLVM ASan.

## Impact

## Testing

    Tested with my local app.
