### PR TITLE
examples/hdc1008_demo: fix wrong printf parameter

### DIFF
--- a/examples/hdc1008_demo/hdc1008_main.c
+++ b/examples/hdc1008_demo/hdc1008_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/hdc1008_demo/hdc1008_main.c
+ * apps/examples/hdc1008_demo/hdc1008_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/examples/hdc1008_demo/hdc1008_main.c
+++ b/examples/hdc1008_demo/hdc1008_main.c
@@ -78,7 +78,7 @@ int main(int argc, FAR char *argv[])
 
   printf("Temperature and humidity\n"
          "========================\n");
-  printf("data=%s%d\n\n", buf);
+  printf("data=%s\n\n", buf);
 
   /* Measure using ioctl */
 


### PR DESCRIPTION
## Summary
An extra "%d" that shouldn't be there.

## Impact
Only the hdc1008_demo app. Warning removed.

## Testing
Tested on custom board and it works the same way, but the warning is gone.

Thanks!
