### PR TITLE
system: adb: fix shell service

### DIFF
--- a/system/adb/shell_pipe.c
+++ b/system/adb/shell_pipe.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * system/adb/shell_pipe.c
+ * apps/system/adb/shell_pipe.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -187,7 +187,7 @@ int shell_pipe_exec(char * const argv[], shell_pipe_t *apipe,
   /* Setup stdout (read: adb, write: child) */
 
   ret = dup2(out_fds[1], 1);
-  assert(ret == 0);
+  assert(ret == 1);
 
   ret = close(out_fds[1]);
   assert(ret == 0);
@@ -229,8 +229,9 @@ int shell_pipe_exec(char * const argv[], shell_pipe_t *apipe,
   /* Create shell process */
 
   ret = task_create("ADB shell", CONFIG_SYSTEM_NSH_PRIORITY,
-                    CONFIG_SYSTEM_NSH_STACKSIZE, nsh_consolemain,
-                    &argv[1]);
+                    CONFIG_SYSTEM_NSH_STACKSIZE,
+                    argv ? nsh_system : nsh_consolemain,
+                    argv);
 
   /* Close stdin and stdout */
 


### PR DESCRIPTION
## Summary

Fix wrong dup2 return value check after:
[fs: file_dup2 shouldn't hold the file list lock](https://github.com/apache/incubator-nuttx/commit/1e5bfa623aa93b918566e8dc0e2f9c1a1037f45e)

Fix issue in adb shell introduced in:
[nsh: Pass the correct command lines to nsh_consolemain](https://github.com/apache/incubator-nuttx-apps/commit/6aca60133c663cae0de8fa31a64b472f8675fcbb)

## Impact

## Testing

Tested on board "raspberrypi-pico" with enc28j60:

```
$ adb connect xxx.xxx.xxx.xxx:5555
$ adb shell

NuttShell (NSH) NuttX-10.1.0-RC1
nsh> help
help usage:  help [-v] [<cmd>]

  .         cat       delroute  false     kill      nslookup  route     truncate  
  [         cd        df        free      ls        printf    set       uname     
  ?         cp        dmesg     help      mkdir     ps        sleep     umount    
  addroute  cmp       echo      hexdump   mkfifo    pwd       source    unset     
  arp       dirname   env       ifconfig  mkrd      reboot    test      usleep    
  basename  date      exec      ifdown    mount     rm        time      xd        
  break     dd        exit      ifup      mv        rmdir     true      

Builtin Apps:
  adbd        netdb       ntpcstatus  ping        spi         
  getprime    nsh         ntpcstop    renew       taskset     
  hello       ntpcstart   ostest      sh          telnet      
nsh> exit
$ adb shell cat /proc/meminfo
                     total       used       free    largest
        Umem:       249968      25216     224752     224704
```
Configuration used:
```
#
# This file is autogenerated: PLEASE DO NOT EDIT IT.
#
# You can use "make menuconfig" to make any modifications to the installed .config file.
# You can then do "make savedefconfig" to generate a new defconfig file that includes your
# modifications.
#
# CONFIG_FS_PROCFS_EXCLUDE_ENVIRON is not set
# CONFIG_LIBC_LONG_LONG is not set
# CONFIG_NSH_ARGCAT is not set
# CONFIG_NSH_CMDOPT_HEXDUMP is not set
# CONFIG_NSH_DISABLE_DATE is not set
# CONFIG_NSH_DISABLE_LOSMART is not set
# CONFIG_NSH_DISABLE_PRINTF is not set
# CONFIG_NSH_DISABLE_TRUNCATE is not set
# CONFIG_STANDARD_SERIAL is not set
CONFIG_ADBD_BOARD_INIT=y
CONFIG_ADBD_FILE_SERVICE=y
CONFIG_ADBD_LOGCAT_SERVICE=y
CONFIG_ADBD_NET_INIT=y
CONFIG_ADBD_SHELL_SERVICE=y
CONFIG_ADBD_TCP_SERVER=y
CONFIG_ARCH="arm"
CONFIG_ARCH_BOARD="raspberrypi-pico"
CONFIG_ARCH_BOARD_RASPBERRYPI_PICO=y
CONFIG_ARCH_CHIP="rp2040"
CONFIG_ARCH_CHIP_RP2040=y
CONFIG_ARCH_RAMVECTORS=y
CONFIG_ARCH_STACKDUMP=y
CONFIG_BOARDCTL_RESET=y
CONFIG_BOARD_LOOPSPERMSEC=10450
CONFIG_BUILTIN=y
CONFIG_DEBUG_FULLOPT=y
CONFIG_DEBUG_SYMBOLS=y
CONFIG_DEV_ZERO=y
CONFIG_DISABLE_POSIX_TIMERS=y
CONFIG_ENC28J60=y
CONFIG_EXAMPLES_HELLO=y
CONFIG_FS_PROCFS=y
CONFIG_FS_PROCFS_REGISTER=y
CONFIG_FS_TMPFS=y
CONFIG_LIBUV=y
CONFIG_LIBUV_PIPE=y
CONFIG_LIBUV_TCP=y
CONFIG_LIBUV_TIMER=y
CONFIG_MAX_TASKS=16
CONFIG_NET=y
CONFIG_NETDB_DNSCLIENT=y
CONFIG_NETDB_DNSSERVER_NOADDR=y
CONFIG_NETDEVICES=y
CONFIG_NETDEV_PHY_IOCTL=y
CONFIG_NETINIT_DHCPC=y
CONFIG_NETINIT_DNS=y
CONFIG_NETINIT_DNSIPADDR=0x08080808
CONFIG_NETINIT_NOMAC=y
CONFIG_NET_BROADCAST=y
CONFIG_NET_ICMP=y
CONFIG_NET_ICMP_SOCKET=y
CONFIG_NET_LOOPBACK=y
CONFIG_NET_ROUTE=y
CONFIG_NET_SOCKOPTS=y
CONFIG_NET_TCP=y
CONFIG_NET_TCPBACKLOG=y
CONFIG_NET_TCP_KEEPALIVE=y
CONFIG_NET_UDP=y
CONFIG_NET_UDP_CHECKSUMS=y
CONFIG_NFILE_DESCRIPTORS_PER_BLOCK=16
CONFIG_NSH_ARCHINIT=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_READLINE=y
CONFIG_PIPES=y
CONFIG_RAMLOG=y
CONFIG_RAMLOG_SYSLOG=y
CONFIG_RAM_SIZE=270336
CONFIG_RAM_START=0x20000000
CONFIG_READLINE_CMD_HISTORY=y
CONFIG_RP2040_ENC28J60_INTR_GPIO=11
CONFIG_RP2040_ENC28J60_RESET_GPIO=10
CONFIG_RP2040_SPI0=y
CONFIG_RP2040_SPI0_GPIO=16
CONFIG_RP2040_SPI1=y
CONFIG_RP2040_SPI1_GPIO=12
CONFIG_RP2040_SPI=y
CONFIG_RR_INTERVAL=200
CONFIG_SCHED_HPWORK=y
CONFIG_SCHED_LPWORK=y
CONFIG_SMP=y
CONFIG_SMP_NCPUS=2
CONFIG_START_DAY=9
CONFIG_START_MONTH=2
CONFIG_START_YEAR=2021
CONFIG_SYSLOG_PROCESS_NAME=y
CONFIG_SYSLOG_TIMESTAMP=y
CONFIG_SYSTEM_ADBD=y
CONFIG_SYSTEM_DHCPC_RENEW=y
CONFIG_SYSTEM_NETDB=y
CONFIG_SYSTEM_NSH=y
CONFIG_SYSTEM_NTPC=y
CONFIG_SYSTEM_PING=y
CONFIG_SYSTEM_SPITOOL=y
CONFIG_SYSTEM_SYSTEM=y
CONFIG_SYSTEM_TASKSET=y
CONFIG_SYSTEM_TELNET_CLIENT=y
CONFIG_TESTING_GETPRIME=y
CONFIG_TESTING_OSTEST=y
CONFIG_UART0_SERIAL_CONSOLE=y
CONFIG_USER_ENTRYPOINT="adbd_main"
CONFIG_WQUEUE_NOTIFIER=y
```