### PR TITLE
Apps Issue #246: Replace romdisk_register() with boardctl(BOARDIOC_ROMDISK)

### DIFF
--- a/examples/unionfs/unionfs_main.c
+++ b/examples/unionfs/unionfs_main.c
@@ -43,6 +43,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <sys/boardctl.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -128,15 +129,21 @@
 int main(int argc, FAR char *argv[])
 {
   int ret;
+  struct boardioc_romdisk_s desc;
 
   /* Create a RAM disk for file system 1 */
 
-  ret = romdisk_register(CONFIG_EXAMPLES_UNIONFS_RAMDEVNO_A, atestdir_img,
-                         NSECTORS(atestdir_img_len),
-                         CONFIG_EXAMPLES_UNIONFS_SECTORSIZE);
+  desc.minor    = CONFIG_EXAMPLES_UNIONFS_RAMDEVNO_A;       /* Minor device number of the ROM disk. */
+  desc.nsectors = NSECTORS(atestdir_img_len);               /* The number of sectors in the ROM disk */
+  desc.sectsize = CONFIG_EXAMPLES_UNIONFS_SECTORSIZE;       /* The size of one sector in bytes */
+  desc.image    = (FAR uint8_t *)atestdir_img;              /* File system image */
+
+  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
+
   if (ret < 0)
     {
-      printf("ERROR: Failed to create file system 1 RAM disk\n");
+      printf("ERROR: Failed to create file system 1 RAM disk: %s\n",
+             strerror(errno));
       return EXIT_FAILURE;
     }
 
@@ -149,18 +156,22 @@ int main(int argc, FAR char *argv[])
               MS_RDONLY, NULL);
   if (ret < 0)
     {
-      printf("ERROR: File system 1 mount failed: %d\n", errno);
+      printf("ERROR: File system 1 mount failed: %s\n", strerror(errno));
       return EXIT_FAILURE;
     }
 
-  /* Create a RAM disk for file system 2 */
+  /* Create a RAM disk for file system 2  */
 
-  ret = romdisk_register(CONFIG_EXAMPLES_UNIONFS_RAMDEVNO_B, btestdir_img,
-                         NSECTORS(btestdir_img_len),
-                         CONFIG_EXAMPLES_UNIONFS_SECTORSIZE);
+  desc.minor    = CONFIG_EXAMPLES_UNIONFS_RAMDEVNO_B;      /* Minor device number of the ROM disk. */
+  desc.nsectors = NSECTORS(btestdir_img_len);              /* The number of sectors in the ROM disk */
+  desc.image    = (FAR uint8_t *)btestdir_img;             /* File system image */
+
+  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
+
   if (ret < 0)
     {
-      printf("ERROR: Failed to register file system 1: %d\n", ret);
+      printf("ERROR: Failed to create file system 2 RAM disk: %s\n",
+             strerror(errno));
       return EXIT_FAILURE;
     }
 
@@ -173,7 +184,7 @@ int main(int argc, FAR char *argv[])
               MS_RDONLY, NULL);
   if (ret < 0)
     {
-      printf("ERROR: Failed to register file system 1: %d\n", ret);
+      printf("ERROR: File system 2 mount failed: %s\n", strerror(errno));
       return EXIT_FAILURE;
     }
 


### PR DESCRIPTION

## Summary

C file changes:
   examples/bastest/bastest_main.c
   examples/elf/elf_main.c
   examples/module/module_main.c
   examples/posix_spawn/spawn_main.c
   examples/romfs/romfs_main.c
   examples/sotest/sotest_main.c
   examples/unionfs/unionfs_main.c

## Impact
Depends on defconfig changes in nuttx. PR is https://github.com/apache/incubator-nuttx/pull/3689

## Testing
Tested on local simulator
