### PR TITLE
system/embedlog: update to v0.6.0

### DIFF
--- a/examples/embedlog/Make.defs
+++ b/examples/embedlog/Make.defs
@@ -2,35 +2,20 @@
 # apps/examples/embedlog/Make.defs
 # Adds selected applications to apps/ build
 #
-#   Copyright (C) 2019 Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 

--- a/examples/embedlog/Makefile
+++ b/examples/embedlog/Makefile
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/examples/embedlog/Makefile
 #
-#   Copyright (C) 2019 Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 

--- a/examples/embedlog/embedlog_main.c
+++ b/examples/embedlog/embedlog_main.c
@@ -1,35 +1,20 @@
 /****************************************************************************
- * examples/embedlog/embedlog_main.c
+ * apps/examples/embedlog/embedlog_main.c
  *
- *   Copyright (C) 2019 Michał Łyszczek. All rights reserved.
- *   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -69,7 +54,7 @@
  * object. see el_options(3) to see learn more about it.
  */
 
-static struct el_options g_el;
+static struct el g_el;
 
 /****************************************************************************
  * Private Functions

--- a/system/embedlog/Kconfig
+++ b/system/embedlog/Kconfig
@@ -8,7 +8,7 @@ menuconfig SYSTEM_EMBEDLOG
 	default n
 	---help---
 		Highly configurable logger for embedded devices. Documentation and
-		more info available on: https://embedlog.kurwinet.pl (don't worry,
+		more info available on: https://embedlog.bofc.pl (don't worry,
 		it's in english). Note: none of the options define how embedlog
 		will behave, it will simply configure whether given feature can be
 		enabled in runtime or no. So enabling CONFIG_EMBEDLOG_ENABLE_TIMESTAMP
@@ -22,6 +22,28 @@ menuconfig SYSTEM_EMBEDLOG
 		the downloaded code for license details
 
 if SYSTEM_EMBEDLOG
+
+config EMBEDLOG_ENABLE_PTHREAD
+	bool "Enable thread safety"
+	depends on !DISABLE_PTHREAD
+	default n
+	---help---
+		When enabled, you will be able to configure embedlog to use
+		EL_THREAD_SAFE option, which will provide full thread safety in all
+		circumstances. When printing to stdout or syslog, embedlog is
+		half thread-safe. Buffer is allocated for each print call, so
+		different calls will not interfere with each other, but once
+		buffer is handed over to the kernel, logs might get mangled.
+		To make sure this does not happen, enable this and enable
+		EL_THREAD_SAFE option in runtime.
+
+		When multiple threads print to single file, this must be
+		enabled, as there are global states in each 'el' object. If two
+		'el' objects print into two separate files, you do not need
+		thread safety.
+
+comment "DISABLE_PTHREAD must be disabled to use thread safety"
+	depends on DISABLE_PTHREAD
 
 config EMBEDLOG_ENABLE_OUT_FILE
 	bool "Enable logging to file"
@@ -107,7 +129,7 @@ config EMBEDLOG_PREFIX_MAX
 		Maximum length of prefix that can be printed. If prefix exceeds this
 		value it will be truncated.
 
-endif #EMBEDLOG_ENABLE_PREFIX
+endif # EMBEDLOG_ENABLE_PREFIX
 
 config EMBEDLOG_ENABLE_FINFO
 	bool "Enable file info"
@@ -119,7 +141,7 @@ config EMBEDLOG_ENABLE_FINFO
 if EMBEDLOG_ENABLE_FINFO
 
 config EMBEDLOG_FLEN_MAX
-	int "max file name in finfo"
+	int "Max file name in finfo"
 	default 16
 	---help---
 		finfo look like this
@@ -129,7 +151,31 @@ config EMBEDLOG_FLEN_MAX
 		this parameter defines how long "filename.c" can be, if file name
 		exceeds this value it will be truncated.
 
+config EMBEDLOG_ENABLE_FUNCINFO
+	bool "Enable function info in log"
+	default y
+	---help---
+		When enabled, embedlog can be configured to add information
+		about function name from which log originated. This uses __func__
+		macro, so you need compiler that supports that. This macro was
+		introduced in c99 standard.
+
+if EMBEDLOG_ENABLE_FUNCINFO
+
+config EMBEDLOG_FUNCLEN_MAX
+	int "Max length of function to print"
+	default 16
+	---help---
+		Max length of function name to print. If function is longer than
+		this value, it will be truncated. This directly impacts size of
+		buffer for each 'el' object allocated.
+
+endif # EMBEDLOG_ENABLE_FUNCINFO
+
 endif # EMBEDLOG_ENABLE_FINFO
+
+comment "Function info requires EMBEDLOG_ENABLE_FINFO"
+	depends on !EMBEDLOG_ENABLE_FINFO
 
 config EMBEDLOG_ENABLE_COLORS
 	bool "Enable output colors"
@@ -155,7 +201,25 @@ config EMBEDLOG_MEM_LINE_SIZE
 	default 16
 	---help---
 		How many bytes of memory to print in a single line of el_pmemory call.
-		Check https://embedlog.kurwinet.pl/manuals/el_pmemory.3.html
+		Check https://embedlog.bofc.pl/manuals/el_pmemory.3.html
 		for more information about this.
 
+config EMBEDLOG_DEMO_PROGRAMS
+	bool "Compile demo programs"
+	default n
+	---help---
+		Compile demo programs that visualise how embedlog works. Also good
+		for checking if embedlog behaves corectly.
+
+if EMBEDLOG_DEMO_PROGRAMS
+
+config EMBEDLOG_DEMO_PROGRAMS_PRIORITY
+	int "embedlog demo programs task priority"
+	default 100
+
+config EMBEDLOG_DEMO_PROGRAMS_STACKSIZE
+	int "embedlog demo programs stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif # EMBEDLOG_DEMO_PROGRAMS
 endif # SYSTEM_EMBEDLOG

--- a/system/embedlog/Make.defs
+++ b/system/embedlog/Make.defs
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/system/embedlog/Make.defs
 #
-#   Copyright (C) 2018 Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 

--- a/system/embedlog/Makefile
+++ b/system/embedlog/Makefile
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/system/embedlog/Makefile
 #
-#   Copyright (C) Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
@@ -40,21 +25,23 @@ UNPACK = tar -xzf
 PACKEXT = .tar.gz
 NXTOOLSDIR = $(APPDIR)/tools
 
-EMBEDLOG_URL = https://distfiles.kurwinet.pl/embedlog
-EMBEDLOG_VERSION = 0.4.0
-EMBEDLOG_SRC_SHA256 = 832c50e0f99d730bed25caed1c4745eca02882a9204c6ad41f715a269293c5a8
+EMBEDLOG_URL = https://distfiles.bofc.pl/embedlog
+EMBEDLOG_VERSION = 0.6.0
+EMBEDLOG_SRC_SHA256 = f5f15dd124d113c7c8cc286f17fc633e1ade90acb6633dc98277968ab2a149d5
 EMBEDLOG_EXT = tar.gz
 EMBEDLOG_SOURCES = embedlog-$(EMBEDLOG_VERSION)
 EMBEDLOG_TARBALL = $(EMBEDLOG_SOURCES).$(EMBEDLOG_EXT)
 
 CFLAGS += ${shell $(INCDIR) "$(CC)" $(APPDIR)$(DELIM)include$(DELIM)system}
 
-CSRCS = embedlog/src/el-options.c \
-	embedlog/src/el-perror.c \
-	embedlog/src/el-pmemory.c \
-	embedlog/src/el-print.c \
-	embedlog/src/el-puts.c \
-	embedlog/src/el-ts.c
+CSRCS = $(EMBEDLOG_SOURCES)/src/el-options.c \
+	$(EMBEDLOG_SOURCES)/src/el-perror.c \
+	$(EMBEDLOG_SOURCES)/src/el-pmemory.c \
+	$(EMBEDLOG_SOURCES)/src/el-print.c \
+	$(EMBEDLOG_SOURCES)/src/el-puts.c \
+	$(EMBEDLOG_SOURCES)/src/el-ts.c \
+	$(EMBEDLOG_SOURCES)/src/el-flush.c \
+	$(EMBEDLOG_SOURCES)/src/el-utils.c \
 
 # compile-time configuration of embedlog
 
@@ -89,9 +76,16 @@ else
 	CFLAGS += -DEL_PREFIX_MAX=0
 endif
 
+ifeq ($(CONFIG_EMBEDLOG_ENABLE_FUNCINFO),y)
+	CFLAGS += -DENABLE_FUNCINFO
+	CFLAGS += -DEL_FUNCLEN_MAX=$(CONFIG_EMBEDLOG_FUNCLEN_MAX)
+else
+	CFLAGS += -DENABLE_FUNCINFO=0
+	CFLAGS += -DEL_FUNCLEN_MAX=0
+endif
+
 ifeq ($(CONFIG_EMBEDLOG_ENABLE_FINFO),y)
 	CFLAGS += -DENABLE_FINFO
-	CFLAGS += -DNOFINFO=0
 	CFLAGS += -DEL_FLEN_MAX=$(CONFIG_EMBEDLOG_FLEN_MAX)
 else
 	CFLAGS += -DENABLE_FINFO=0
@@ -113,24 +107,32 @@ endif
 
 ifeq ($(CONFIG_EMBEDLOG_ENABLE_OUT_FILE),y)
 	CFLAGS += -DENABLE_OUT_FILE
-	CSRCS += embedlog/src/el-file.c
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-file.c
 else
 	CFLAGS += -DENABLE_OUT_FILE=0
 endif
 
 ifeq ($(CONFIG_EMBEDLOG_ENABLE_BINARY_LOGS),y)
 	CFLAGS += -DENABLE_BINARY_LOGS
-	CSRCS += embedlog/src/el-pbinary.c
-	CSRCS += embedlog/src/el-encode-number.c
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-pbinary.c
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-encode-number.c
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-decode-number.c
 else
 	CFLAGS += -DENABLE_BINARY_LOGS=0
 endif
 
 ifeq ($(CONFIG_EMBEDLOG_ENABLE_OUT_TTY),y)
 	CFLAGS += -DENABLE_OUT_TTY
-	CSRCS += embedlog/src/el-tty.c
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-tty.c
 else
 	CFLAGS += -DENABLE_OUT_TTY=0
+endif
+
+ifeq ($(CONFIG_EMBEDLOG_ENABLE_PTHREAD),y)
+	CFLAGS += -DENABLE_PTHREAD
+	CSRCS += $(EMBEDLOG_SOURCES)/src/el-lock.c
+else
+	CFLAGS += -DENABLE_PTHREAD=0
 endif
 
 ifeq ($(CONFIG_SERIAL_TERMIOS),y)
@@ -158,6 +160,9 @@ CFLAGS += -DHAVE_UNISTD_H
 CFLAGS += -DHAVE_FSYNC
 CFLAGS += -DHAVE_FILENO
 CFLAGS += -DENABLE_COLORS_EXTENDED=0
+# symlinks are only supported on pseudofs, where nobody is going to
+# store logfiles, thus symlinks are useless on nuttx
+CFLAGS += -DHAVE_SYMLINK=0
 
 # nuttx has its own snprintf implementation, disable internal snprintf
 # implementation
@@ -170,6 +175,41 @@ CFLAGS += -DENABLE_OUT_NET=0
 
 # nuttx does not implement clock() function
 CFLAGS += -DENABLE_CLOCK=0
+
+ifeq ($(CONFIG_EMBEDLOG_DEMO_PROGRAMS),y)
+	# build demo programs as library instead of standalone programs
+	CFLAGS += -DEMBEDLOG_DEMO_LIBRARY
+
+	PROGNAME   = el_demo_print_memory
+	PRIORITY   = $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE  = $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC    = $(EMBEDLOG_SOURCES)/examples/print-memory.c
+
+	PROGNAME  += el_demo_print_options
+	PRIORITY  += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC   += $(EMBEDLOG_SOURCES)/examples/print-options.c
+
+	PROGNAME  += el_demo_print_simple
+	PRIORITY  += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC   += $(EMBEDLOG_SOURCES)/examples/print-simple.c
+
+	PROGNAME  += el_demo_print_thread_safe
+	PRIORITY  += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC   += $(EMBEDLOG_SOURCES)/examples/print-thread-safe.c
+
+	PROGNAME  += el_demo_print_to_file
+	PRIORITY  += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC   += $(EMBEDLOG_SOURCES)/examples/print-to-file.c
+
+	PROGNAME  += el_demo_print_tty
+	PRIORITY  += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_PRIORITY)
+	STACKSIZE += $(CONFIG_EMBEDLOG_DEMO_PROGRAMS_STACKSIZE)
+	MAINSRC   += $(EMBEDLOG_SOURCES)/examples/print-tty.c
+endif
 
 # building of embedlog
 
@@ -184,14 +224,20 @@ $(EMBEDLOG_SOURCES): $(EMBEDLOG_TARBALL)
 	$(Q) $(UNPACK) $<
 	$(Q) touch $@
 
-embedlog: $(EMBEDLOG_SOURCES)
-	$(call DELDIR, $@)
-	$(Q) $(CP) $< $@
+$(EMBEDLOG_SOURCES)/include/embedlog.h: $(EMBEDLOG_SOURCES)/include/embedlog.h.in
+	@echo "Generating: $@"
+	$(Q) sed -e "s/@ENABLE_OUT_FILE@/$(CONFIG_EMBEDLOG_ENABLE_OUT_FILE)/" \
+	    -e "s/@ENABLE_OUT_TTY@/$(CONFIG_EMBEDLOG_ENABLE_OUT_TTY)/" \
+	    -e "s/@ENABLE_PREFIX@/$(CONFIG_EMBEDLOG_ENABLE_PREFIX)/" \
+	    -e "s/@ENABLE_OUT_CUSTOM@/$(CONFIG_EMBEDLOG_ENABLE_OUT_CUSTOM)/" \
+	    -e "s/@ENABLE_PTHREAD@/$(CONFIG_EMBEDLOG_ENABLE_PTHREAD)/" $< > $@
+	$(Q) sed -i -e "s/^#if y$$/#if 1/" \
+	    -e "s/^#if $$/#if 0/" -e "s/^#if n$$/#if 0/" $@
 
-create_includes:
-	$(Q) $(CP) $(EMBEDLOG_SOURCES)/include/embedlog.h $(APPDIR)/include/system
+create_includes: $(EMBEDLOG_SOURCES)/include/embedlog.h
+	$(Q) $(CP) $< $(APPDIR)/include/system
 
-context:: embedlog
+context:: $(EMBEDLOG_SOURCES)
 	$(Q) $(MAKE) create_includes
 
 clean::
@@ -199,7 +245,6 @@ clean::
 	$(Q) $(foreach COBJ, $(COBJS), $(call DELFILE, $(COBJ)))
 
 distclean::
-	$(Q) $(call DELDIR, embedlog)
 	$(Q) $(call DELDIR, $(EMBEDLOG_SOURCES))
 	$(Q) $(call DELDIR, $(EMBEDLOG_TARBALL))
 


### PR DESCRIPTION
Changes from v0.4.0
- add thread safety code
- add option to print function info (name) in logs
- abi/api stabilization
- bug fixes + increased reliability

Tested on nucleo-f091

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>