### PR TITLE
webclient: Fix buffer overruns in header parsing

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -376,9 +376,20 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
 
   while (offset < ws->datend)
     {
+      bool got_nl;
+
       ws->line[ndx] = ws->buffer[offset];
-      if (ws->line[ndx] == ISO_NL)
+      got_nl = ws->line[ndx] == ISO_NL;
+      if (got_nl || ndx == CONFIG_WEBCLIENT_MAXHTTPLINE - 1)
         {
+          if (!got_nl)
+            {
+              nerr("ERROR: HTTP status line didn't fit "
+                   "CONFIG_WEBCLIENT_MAXHTTPLINE: %.*s\n",
+                   ndx, ws->line);
+              return -E2BIG;
+            }
+
           ws->line[ndx] = '\0';
           if ((strncmp(ws->line, g_http10, strlen(g_http10)) == 0) ||
               (strncmp(ws->line, g_http11, strlen(g_http11)) == 0))

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -447,6 +447,7 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
            */
 
           ws->state = WEBCLIENT_STATE_HEADERS;
+          ndx = 0;
           break;
         }
       else

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -406,6 +406,7 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
                 }
 
               ctx->http_status = http_status;
+              ninfo("Got HTTP status %lu\n", http_status);
               if (ctx->http_reason != NULL)
                 {
                   strncpy(ctx->http_reason,
@@ -525,6 +526,7 @@ static inline int wget_parseheaders(struct wget_s *ws)
 
           if (ndx > 0) /* Should always be true */
             {
+              ninfo("Got HTTP header line: %.*s\n", ndx - 1, &ws->line[0]);
               if (ws->line[0] == ISO_CR)
                 {
                   /* This was the last header line (i.e., and empty "\r\n"),


### PR DESCRIPTION
## Summary
webclient: Fix buffer overruns in header parsing
## Impact

## Testing
tested on macOS.
