### PR TITLE
Apps Issue #246:Replace romdisk_register() with boardctl(BOARDIOC_ROMDISK)

### DIFF
--- a/examples/nxflat/nxflat_main.c
+++ b/examples/nxflat/nxflat_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/nxflat/nxflat_main.c
+ * apps/examples/nxflat/nxflat_main.c
  *
  *   Copyright (C) 2009, 2011, 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -41,6 +41,7 @@
 #include <nuttx/compiler.h>
 
 #include <sys/mount.h>
+#include <sys/boardctl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -153,12 +154,18 @@ int main(int argc, FAR char *argv[])
   FAR char *args[1];
   int ret;
   int i;
+  struct boardioc_romdisk_s desc;
 
   /* Create a ROM disk for the ROMFS filesystem */
 
   message("Registering romdisk\n");
-  ret = romdisk_register(0, (FAR uint8_t *)romfs_img,
-                         NSECTORS(romfs_img_len), SECTORSIZE);
+
+  desc.minor    = 0;                                    /* Minor device number of the ROM disk. */
+  desc.nsectors = NSECTORS(romfs_img_len);              /* The number of sectors in the ROM disk */
+  desc.sectsize = SECTORSIZE;                           /* The size of one sector in bytes */
+  desc.image    = (FAR uint8_t *)romfs_img;             /* File system image */
+
+  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
   if (ret < 0)
     {
       errmsg("ERROR: romdisk_register failed: %d\n", ret);
@@ -173,7 +180,7 @@ int main(int argc, FAR char *argv[])
   ret = mount(ROMFSDEV, MOUNTPT, "romfs", MS_RDONLY, NULL);
   if (ret < 0)
     {
-      errmsg("ERROR: mount(%s,%s,romfs) failed: %s\n",
+      errmsg("ERROR: mount(%s,%s,romfs) failed: %d\n",
              ROMFSDEV, MOUNTPT, errno);
     }
 

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/thttpd/thttpd_main.c
+ * apps/examples/thttpd/thttpd_main.c
  *
  *   Copyright (C) 2009-2012 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -58,6 +58,10 @@
 #include "netutils/thttpd.h"
 
 #include <nuttx/drivers/ramdisk.h>
+
+#ifdef CONFIG_THTTPD_NXFLAT
+#  include <sys/boardctl.h>
+#endif
 
 #ifdef CONFIG_THTTPD_BINFS
 #  include <nuttx/fs/unionfs.h>
@@ -204,6 +208,9 @@ int main(int argc, FAR char *argv[])
 #endif
   char *thttpd_argv = "thttpd";
   int ret;
+#ifdef CONFIG_THTTPD_NXFLAT
+  struct boardioc_romdisk_s desc;
+#endif
 
   /* Configure SLIP */
 
@@ -252,12 +259,18 @@ int main(int argc, FAR char *argv[])
 
   netlib_ifup("eth0");
 
+#ifdef CONFIG_THTTPD_NXFLAT
   /* Create a ROM disk for the ROMFS filesystem */
 
   printf("Registering romdisk\n");
 
-  ret = romdisk_register(0, (uint8_t *)romfs_img, NSECTORS(romfs_img_len),
-                         SECTORSIZE);
+  desc.minor    = 0;                                    /* Minor device number of the ROM disk. */
+  desc.nsectors = NSECTORS(romfs_img_len);              /* The number of sectors in the ROM disk */
+  desc.sectsize = SECTORSIZE;                           /* The size of one sector in bytes */
+  desc.image    = (FAR uint8_t *)romfs_img;             /* File system image */
+
+  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
+
   if (ret < 0)
     {
       printf("ERROR: romdisk_register failed: %d\n", ret);
@@ -275,6 +288,7 @@ int main(int argc, FAR char *argv[])
       printf("ERROR: mount(%s,%s,romfs) failed: %d\n",
              ROMFSDEV, ROMFS_MOUNTPT, errno);
     }
+#endif
 
 #ifdef CONFIG_THTTPD_BINFS
   /* Mount the BINFS file system */


### PR DESCRIPTION
## Summary
The original PR is: https://github.com/apache/incubator-nuttx-apps/pull/709

examples/nxflat/nxflat_main.c and examples/thttpd/thttpd_main.c are listed in Apps issue #246 but were not included in the original PR (linked above). This PR contains the change  from romdisk_register() to boardctl(BOARDIOC_ROMDISK) for examples/nxflat/nxflat_main.c and examples/thttpd/thttpd_main.c.

## Impact
None

## Testing
Change from romdisk_register() to boardctl() has been tested in the original PR.
