### PR TITLE
hdc1008_demo: set intial measurement mode

### DIFF
--- a/examples/hdc1008_demo/hdc1008_main.c
+++ b/examples/hdc1008_demo/hdc1008_main.c
@@ -69,6 +69,14 @@ int main(int argc, FAR char *argv[])
 
   /* Read both t and rh */
 
+  ret = ioctl(fd, SNIOC_SET_OPERATIONAL_MODE, HDC1008_MEAS_T_AND_RH);
+  if (ret < 0)
+    {
+      printf("Failed to set temperature and humidity measurement mode: %d\n",
+             errno);
+      goto out;
+    }
+
   ret = read(fd, buf, sizeof(buf));
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
No mode was set before the first read by the app.
The first time the app was run, it worked properly, reading temperature and humidity on the first read(). But subsequent reads returned humidity only since that was last mode set up. Also, the ioctl read was returning invalid results.

First run of the app:
```
nsh> hdc1008
Temperature and humidity
========================
data=20.54 56.9

Temperature and humidity (ioctl)
================================
t=20.54, h=56.9

Temperature, 11 bit resolution
==============================
data=20.78

Temperature, 14 bit resolution
==============================
data=20.69

Humidity, 8 bit resolution
===========
data=57.1

Humidity, 11 bit resolution
===========
data=56.9

Humidity, 14 bit resolution
===========
data=56.9
```

Second run of the app:
```nsh> hdc1008
Temperature and humidity
========================
data=56.9

Temperature and humidity (ioctl)
================================
t=2684430.32, h=56.9

Temperature, 11 bit resolution
==============================
data=20.71

Temperature, 14 bit resolution
==============================
data=20.72

Humidity, 8 bit resolution
===========
data=57.3

Humidity, 11 bit resolution
===========
data=56.9

Humidity, 14 bit resolution
===========
data=56.9
```

## Impact
hdc1008 app only

## Testing
Tested on custom board.
Now, every run of the app returns temperature and humidity on the first read and the ioctl read works properly too.

```
nsh> hdc1008
Temperature and humidity
========================
data=20.94 56.0

Temperature and humidity (ioctl)
================================
t=20.94, h=56.0

[...]

nsh> hdc1008
Temperature and humidity
========================
data=20.97 55.9

Temperature and humidity (ioctl)
================================
t=20.97, h=55.9

[...]
```

Thanks!
