### PR TITLE
ci: change sim01 and sim02 to sim-01 and sim-02

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim01, sim02, xtensa]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim-01, sim-02, xtensa]
 
     steps:
       - name: Download Source Artifact
@@ -155,7 +155,7 @@ jobs:
     needs: Fetch-Source
     strategy:
       matrix:
-        boards: [macos, sim01, sim02]
+        boards: [macos, sim-01, sim-02]
     steps:
       - name: Download Source Artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
## Summary
follow up the kernel side chnage(https://github.com/apache/incubator-nuttx/pull/3710):
```
commit 09a0ed111c0c193a57b2a538e23c2b6a6e9cdf26
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Thu May 13 21:28:43 2021 +0800

tools/ci: Rename sim0x.dat to sim-0x.dat to align with arm-xx.dat

To avoid the build break sim0x.dat will remove in the upcoming patch
```

## Impact

## Testing
Pass CI

