### PR TITLE
ostest: Include errno.h in timedmutex.c

### DIFF
--- a/testing/ostest/timedmutex.c
+++ b/testing/ostest/timedmutex.c
@@ -37,10 +37,12 @@
  * Included Files
  ****************************************************************************/
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <pthread.h>
 #include <time.h>
+
 #include "ostest.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Simple fix

## Impact
Minor

## Testing
Pass CI
