### PR TITLE
Check CONFIG_BOARDCTL_ROMDISK is set for boardctl(BOARDIOC_ROMDISK) call.

### DIFF
--- a/examples/nxflat/nxflat_main.c
+++ b/examples/nxflat/nxflat_main.c
@@ -62,10 +62,6 @@
  * are required -- only the more obvious.
  */
 
-#ifdef CONFIG_BINFMT_DISABLE
-#  error "The binary loader is disabled (CONFIG_BINFMT_DISABLE)!"
-#endif
-
 #ifndef CONFIG_NXFLAT
 #  error "You must select CONFIG_NXFLAT in your configuration file"
 #endif
@@ -82,6 +78,9 @@
 #  error "You must not disable loadable modules via CONFIG_BINFMT_DISABLE in your configuration file"
 #endif
 
+#ifndef CONFIG_BOARDCTL_ROMDISK
+#  error "CONFIG_BOARDCTL_ROMDISK should be enabled in the configuration file"
+#endif
 /* Describe the ROMFS file system */
 
 #define SECTORSIZE   512

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -95,6 +95,10 @@
 #  ifdef CONFIG_DISABLE_MOUNTPOINT
 #    error "You must not disable mountpoints via CONFIG_DISABLE_MOUNTPOINT in your configuration file"
 #  endif
+
+#ifndef CONFIG_BOARDCTL_ROMDISK
+#  error "CONFIG_BOARDCTL_ROMDISK should be enabled in the configuration file"
+#endif
 #endif
 
 #ifdef CONFIG_THTTPD_BINFS


### PR DESCRIPTION
## Summary
Please refer to this error: https://github.com/apache/incubator-nuttx-apps/issues/246#issuecomment-844306537

Solution: Add check for CONFIG_BOARDCTL_ROMDISK because CONFIG_BOARDCTL_ROMDISK must be set to enable boardctl(BOARDIOC_ROMDISK) in these 2 files:
    examples/nxflat/nxflat_main.c
    examples/thttpd/thttpd_main.c (Added the check to thttpd_main.c for consistency)
 
## Impact
boardctl(BOARDIOC_ROMDISK) is enabled 

## Testing

