### PR TITLE
nimble: Update version to cd8ab38c3da91b71dd428979153a408f38d3b02e

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -9,7 +9,7 @@ config NIMBLE
 if NIMBLE
   config NIMBLE_REF
   string "Version"
-  default "7b5b5e5b512133e50ef8a517b13e7269f9c821fd"
+  default "cd8ab38c3da91b71dd428979153a408f38d3b02e"
   ---help---
     Git ref name to use when downloading from nimBLE repo
 endif

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -48,6 +48,6 @@ distclean::
 
 # nimBLE assumes this flag since it expects undefined macros to be zero value
 
-CFLAGS += -Wno-undef
+CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
which contain the following fix(https://github.com/apache/mynewt-nimble/pull/979):
```
commit cd8ab38c3da91b71dd428979153a408f38d3b02e
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Thu May 20 15:43:50 2021 +0800

nuttx: fix error: use of undeclared identifier 'ENOMEM'
```

## Impact
Minor

## Testing
Pass CI
