### PR TITLE
examples/nxflat: fixed an issue with the symbol table creation

### DIFF
--- a/examples/nxflat/tests/Makefile
+++ b/examples/nxflat/tests/Makefile
@@ -90,7 +90,7 @@ $(DIRLIST_SRC): install
 # Create the exported symbol table list from the derived *-thunk.S files
 
 $(SYMTAB_SRC): install
-	$(Q) $(APPDIR)/tools/mksymtab.sh $(ROMFS_DIR) g_nxflat >$@.tmp
+	$(Q) $(APPDIR)/tools/mksymtab.sh $(TESTS_DIR) g_nxflat >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Clean each subdirectory


### PR DESCRIPTION
The issue is described here: https://github.com/apache/incubator-nuttx/issues/3737#issuecomment-844574935