### PR TITLE
graphics/twm4nx: Fix error: 'sleep' was not declared in this scope

### DIFF
--- a/graphics/twm4nx/apps/cclock.cxx
+++ b/graphics/twm4nx/apps/cclock.cxx
@@ -44,6 +44,7 @@
 #include <cstring>
 #include <csched>
 #include <cassert>
+#include <cunistd>
 
 #include <semaphore.h>
 #include <debug.h>


### PR DESCRIPTION
## Summary
Fix the error reported here:
https://github.com/apache/incubator-nuttx/pull/3712/checks?check_run_id=2649571891

## Impact
Minor

## Testing
Pass CI
