### PR TITLE
examples/termios: Small fix on a print message

### DIFF
--- a/examples/termios/termios_main.c
+++ b/examples/termios/termios_main.c
@@ -90,7 +90,7 @@ int main(int argc, FAR char *argv[])
   printf("Please, reopen the terminal with the new attributes,"
          " otherwise you will have garbage.\n"
          "You may try: picocom /dev/ttyUSB0 --baud 57600"
-         " --parity o --databits 5 --stopbits 2\n\n");
+         " --parity o --databits 7 --stopbits 2\n\n");
   fflush(stdout); /* Clean stdout buffer */
 
   /* Wait to empty the hardware buffer, otherwise the above message


### PR DESCRIPTION
## Summary

This is a small fix on an instruction message to the user, the `databits` should be 7 instead of 5 to be compliant with the code.

## Impact

From now on, if the user copy the message to paste in the terminal, it will work properly.
It wouldn't work before because the message was with a `databits` different from the configured in the example.  

## Testing
N/A
