### PR TITLE
system/psmq: update to v0.2.1

### DIFF
--- a/system/psmq/Kconfig
+++ b/system/psmq/Kconfig
@@ -3,14 +3,17 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+comment "psmq requires SYSTEM_EMBEDLOG and !DISABLE_MQUEUE"
+	depends on DISABLE_MQUEUE || !SYSTEM_EMBEDLOG
+
 menuconfig SYSTEM_PSMQ
-	tristate "psmq"
+	bool "psmq"
 	default n
 	depends on !DISABLE_MQUEUE && SYSTEM_EMBEDLOG
 	---help---
 		psmq is tool set which allows IPC communication in publish/subscribe way
 		created on top of posix messege queue. Full documentation is available
-		at: https://psmq.kurwinet.pl (despite the domain, it is in english).
+		at: https://psmq.bofc.pl (despite the domain, it is in english).
 
 		Library is licensed under BSD 2-clause license. See LICENSE file in
 		the downloaded code for license details.
@@ -28,30 +31,23 @@ config PSMQ_MAX_CLIENTS
 		about 12 bytes (may vary depending on architecture) for each
 		client.
 
-config PSMQ_PAYLOAD_MAX
+config PSMQ_MSG_MAX
 	int "Max size of payload"
-	default 8
+	range 6 2147483647
+	default 24
 	---help---
-		Defines maximum size of payload that can be sent via psmq.
+		Defines maximum size of message that can be sent via psmq.
+		Message consists of topic and payload. Topic is always
+		null-terminated after which payload follows. This allows
+		for some flexibility, ie if PSMQ_MSG_MAX was be 10, then
+		topic could be 3 bytes long and payload 7, but also
+		topic could take 9 bytes and payload only 1.
 
-		Both PSMQ_TOPIC_MAX and PSMQ_PAYLOAD_MAX have direct impact on size
-		of internal message structures that  are copied each time message
-		is sent.  If you set PSMQ_PAYLOAD_MAX to, let's say 20, and you are
-		sending message with payload that takes only 2 byte, then 20 bytes
-		will get copied anyway.  Same rule applies to topics.
-
-config PSMQ_TOPIC_MAX
-	int "Max length of topic"
-	default 15
-	---help---
-		Defines maximum length any topic can be.  That includes first ´/´
-		character,  but  does  not  include terminating null  character.  So
-		if  this is set to 3, then topics "/0", "/01" will be valid, but
-		"/012" will be too long.
-
-		Library will use PSMQ_TOPIC_MAX + 1 as an array size for topic.
-		This means, to prevent unnecessary paddings, use values like 7, or 15
-		or 31.
+		This value has direct impact on runtime memory usage by
+		psmq as this increases size of struct that is used when
+		allocating memory for client. This has no impact on
+		number of bytes that are sent because only actual data
+		is sent over mqueue.
 
 config PSMQD_PRIORITY
 	int "psmqd broker task priority"

--- a/system/psmq/Make.defs
+++ b/system/psmq/Make.defs
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/system/psmq/Make.defs
 #
-#   Copyright (C) 2019 Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 

--- a/system/psmq/Makefile
+++ b/system/psmq/Makefile
@@ -1,35 +1,20 @@
 ############################################################################
 # apps/system/psmq/Makefile
 #
-#   Copyright (C) 2019 Michał Łyszczek. All rights reserved.
-#   Author: Michał Łyszczek <michal.lyszczek@bofc.pl>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
@@ -40,9 +25,9 @@ UNPACK = tar -xzf
 PACKEXT = .tar.gz
 NXTOOLSDIR = $(APPDIR)/tools
 
-PSMQ_URL = https://distfiles.kurwinet.pl/psmq
-PSMQ_VERSION = 0.1.0
-PSMQ_SRC_SHA256 = 52dce7d6fcbf84243e11afdb953eea6a6eb405fd81c8e71bc556bb63090e1284
+PSMQ_URL = https://distfiles.bofc.pl/psmq
+PSMQ_VERSION = 0.2.1
+PSMQ_SRC_SHA256 = b029fa06752ad7dce89f6b899f27a08a1bd1ee0a4e1d9df407274f0322bf1946
 PSMQ_EXT = tar.gz
 PSMQ_SOURCES = psmq-$(PSMQ_VERSION)
 PSMQ_TARBALL = $(PSMQ_SOURCES).$(PSMQ_EXT)
@@ -55,20 +40,16 @@ CSRCS = $(PSMQ_SOURCES)/lib/psmq.c \
 	$(PSMQ_SOURCES)/src/broker.c \
 	$(PSMQ_SOURCES)/src/cfg.c \
 	$(PSMQ_SOURCES)/src/globals.c \
-	$(PSMQ_SOURCES)/src/topic-list.c
+	$(PSMQ_SOURCES)/src/topic-list.c \
+	$(PSMQ_SOURCES)/src/utils.c
 
 # compile-time options from Kconfig
 CFLAGS += -DPSMQ_MAX_CLIENTS=$(CONFIG_PSMQ_MAX_CLIENTS)
-CFLAGS += -DPSMQ_PAYLOAD_MAX=$(CONFIG_PSMQ_PAYLOAD_MAX)
-CFLAGS += -DPSMQ_TOPIC_MAX=$(CONFIG_PSMQ_TOPIC_MAX)
 
 # build psmq as library and disable standalone applications (apps will
 # still be compiled but into shared library rather than standalone application
 CFLAGS += -DPSMQ_LIBRARY=1
 CFLAGS += -DPSMQ_STANDALONE=0
-
-# psmq cannot be damonized in nuttx
-CFLAGS += -DPSMQ_ENABLE_DAEMON=0
 
 # nuttx has no opterr variable
 CFLAGS += -DPSMQ_NO_OPTERR=1
@@ -116,8 +97,12 @@ $(PSMQ_SOURCES): $(PSMQ_TARBALL)
 	$(Q) $(UNPACK) $<
 	$(Q) touch $@
 
-create_includes:
-	$(Q) $(CP) $(PSMQ_SOURCES)/inc/psmq.h $(APPDIR)/include/system
+$(PSMQ_SOURCES)/inc/psmq.h: $(PSMQ_SOURCES)/inc/psmq.h.in
+	@echo "Generating: $@"
+	$(Q) sed -e "s/@PSMQ_MSG_MAX@/$(CONFIG_PSMQ_MSG_MAX)/" $< > $@
+
+create_includes: $(PSMQ_SOURCES)/inc/psmq.h
+	$(Q) $(CP) $< $(APPDIR)/include/system
 
 context:: $(PSMQ_SOURCES)
 	$(Q) $(MAKE) create_includes

--- a/system/psmq/README.md
+++ b/system/psmq/README.md
@@ -4,23 +4,26 @@
 to implement publish/subscribe way of inter-process communication on top of
 POSIX message queue.
 
-Manuals, source code and more info at: https://psmq.kurwinet.pl
+Manuals, source code and more info at: https://psmq.bofc.pl
 
 Little demo using `psmqd` broker, `psmq_pub` and `psmq_sub`:
 
 Start broker and make it log to file
 
 ```
-nsh> psmqd -b/brok -p/sd/psmqd/psmqd.log
+nsh> psmqd -b/brok -p/sd/psmqd/psmqd.log &
 ```
 
-Start subscribe thread that will read all messages send on `/can/*` topic
+Start subscribe thread that will read all messages send on `/can/*` and
+`/adc/*` topic, and dump all readings to file
 
 ```
-nsh> psmq_sub -n/sub -b/brok -t/can/* -o/sd/psmq-sub/can.log
+nsh> psmq_sub -n/sub -b/brok -t/can/* -t/adc/* -o/sd/psmq-sub/can.log &
 n/connected to broker /brok
-n/subscribed to /can/*
+n/subscribed to: /can/*
+n/subscribed to: /adc/*
 n/start receiving data
+n/reply timeout set 100
 ```
 
 Publish some messages
@@ -39,14 +42,13 @@ nsh> cat /sd/psmq-sub/can.log
 ```
 
 ```
-[1970-01-01 00:00:53] topic: /can/engine/rpm, priority: 0, paylen: 3, payload:
-[1970-01-01 00:00:53] 0x0000  35 30 00                                         50.
-[1970-01-01 00:00:58] topic: /can/room/10/temp, priority: 0, paylen: 3, payload:
-[1970-01-01 00:00:58] 0x0000  32 33 00                                         23.
+[2021-05-23 17:53:59] p:0 l:   3  /can/engine/rpm  50
+[2021-05-23 17:53:59] p:0 l:   3  /adc/volt  30
+[2021-05-23 17:53:59] p:0 l:   3  /can/room/10/temp  23
 ```
 
-As you can see `/adc/volt` and `/pwm/fan1/speed` haven't been received by
-subscribe thread.
+As you can see `/pwm/fan1/speed` hasn't been received by subscribe thread,
+since we didn't subscribe to it.
 
 Content:
 


### PR DESCRIPTION
This release breaks API and ABI by making use of library way
easier and more safe. No app in a nuttx tree uses psmq, so
nothing in-tree will be broken by this change.

Updated license files to Apache 2.0.

Tested on nucleo-f091

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>