### PR TITLE
nsh: Add debug.h inclusion in nsh_command.c

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <string.h>
+#include <assert.h>
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
 #  include <nuttx/lib/builtin.h>


### PR DESCRIPTION
## Summary
Fix the build break at:
https://github.com/apache/incubator-nuttx/pull/3738/checks?check_run_id=2652977519

## Impact
Minor

## Testing
Pass CI
