### PR TITLE
readline: Reset offset when top command is issued repeateadly

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -708,13 +708,14 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                     }
 
                   g_cmdhist.buf[g_cmdhist.head][i] = '\0';
-                  g_cmdhist.offset = 1;
 
                   if (g_cmdhist.len < RL_CMDHIST_LEN)
                     {
                       g_cmdhist.len++;
                     }
                 }
+
+              g_cmdhist.offset = 1;
             }
 #endif /* CONFIG_READLINE_CMD_HISTORY */
 


### PR DESCRIPTION
## Summary
This PR intends to provide a fix to readline command history when the top (i.e. last issued) command is issued twice.

Steps to reproduce the issue:
```shell
NuttShell (NSH) NuttX-10.1.0-RC1
nsh> ls    # Issued the ls command
/:
 dev/
 proc/
nsh> pwd   # Issued the pwd command
/
nsh> pwd   # UP key pressed here, pwd shown as expected
/
nsh> ls    # UP key pressed again, ls erroneously shown
```

## Impact
NSH with `CONFIG_READLINE_CMD_HISTORY` enabled.

## Testing
Reproduced the issue with `sim:nsh` and checked that the provided patch fixes the issue.
