### PR TITLE
Update WAMR

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -12,7 +12,7 @@ if INTERPRETERS_WAMR
 
 config INTERPRETERS_WAMR_VERSION
 	string "WAMR Version"
-	default "09-29-2020"
+	default "04-15-2021"
 	---help---
 	Version 09-29-2020 and later (include main) supported.
 

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -55,6 +55,7 @@ $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) echo "Unpacking $(WAMR_TARBALL) to $(WAMR_UNPACK)"
 	$(Q) unzip $(WAMR_TARBALL)
 	$(Q) mv wasm-micro-runtime-$(WAMR_VERSION_STUB)$(WAMR_VERSION) $(WAMR_UNPACK)
+	$(Q) touch $(WAMR_UNPACK)
 
 context:: $(WAMR_UNPACK)
 


### PR DESCRIPTION
## Summary

- This PR consists of the following 2 commits
- commit 1: interpreters: wamr: Change the default version to "03-25-2021"
   - This commit changes the default version to "03-25-2021"
      to fix a compile error for Cortex-M target
- commit 2: interpreters: wamr: Add touch in Makefile to avoid unnecessary mv

## Impact

- WASM micro runtime (WAMR)
- NOTE: There are still compile warnings in the WAMR which should be fixed later

## Testing

- Tested with spresense
