### PR TITLE
examples/termios: Adds option to disable HW flow control

### DIFF
--- a/examples/termios/Kconfig
+++ b/examples/termios/Kconfig
@@ -21,4 +21,10 @@ config EXAMPLES_TERMIOS_STACKSIZE
 	int "Termios stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config EXAMPLES_TERMIOS_DIS_HW_FC
+	bool "Disable HW flow control"
+	default n
+	---help---
+		Disable HW flow control using TERMIOS.
+
 endif

--- a/examples/termios/termios_main.c
+++ b/examples/termios/termios_main.c
@@ -87,10 +87,22 @@ int main(int argc, FAR char *argv[])
   tio.c_cflag &= ~CSIZE; /* Clean the bits */
   tio.c_cflag |= CS7;    /* 7 bits */
 
+#ifdef CONFIG_EXAMPLES_TERMIOS_DIS_HW_FC
+
+  /* Disable the HW flow control */
+
+  tio.c_cflag &= ~CCTS_OFLOW;    /* Output flow control */
+  tio.c_cflag &= ~CRTS_IFLOW;    /* Input flow control */
+
+  printf("Disabled HW Flow Control\n");
+#endif
+
   printf("Please, reopen the terminal with the new attributes,"
-         " otherwise you will have garbage.\n"
+         " otherwise you will have garbage or a stuck terminal.\n"
+         "If you disabled HW flow control, try disconnecting RTS and CTS.\n"
          "You may try: picocom /dev/ttyUSB0 --baud 57600"
          " --parity o --databits 7 --stopbits 2\n\n");
+
   fflush(stdout); /* Clean stdout buffer */
 
   /* Wait to empty the hardware buffer, otherwise the above message
@@ -98,7 +110,7 @@ int main(int argc, FAR char *argv[])
    * before the hardware buffer gets empty. A small delay is enough.
    */
 
-  usleep(100);
+  sleep(1);
 
   /* Change the attributes now. */
 


### PR DESCRIPTION
## Summary
This PR adds a small feature to the termios example.
Exposing how to disable the HW flow control using the termios interface.

## Impact
N/A

## Testing

First I configured the HW flow control in my device (ESP32-C3 - this PR support will come), then I ran this example and after it I could disable the hw flow control from picocom and also disconnect the RTS and CTS line and the communication was successful.

P.S: Note that I also increased the delay before setting the configuration. It was done because less fast chips (like ESP32-C3) requires more time to drain out the printf message before re-configuring the serial parameters. 

