### PR TITLE
examples/foc/foc_float_thr.c: fix incorect variable type

### DIFF
--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -75,7 +75,7 @@ struct foc_motor_f32_s
   int                           foc_mode;     /* FOC mode */
   float                         vbus;         /* Power bus voltage */
   float                         angle_now;    /* Phase angle now */
-  b16_t                         angle_ol;     /* Phase angle open-loop */
+  float                         angle_ol;     /* Phase angle open-loop */
   float                         vel_set;      /* Velocity setting now */
   float                         vel_now;      /* Velocity now */
   float                         vel_des;      /* Velocity destination */


### PR DESCRIPTION
## Summary
examples/foc/foc_float_thr.c: fix incorect variable type

## Impact
Controller motor works much smoother for f32 implementation

## Testing
nucleo-g431rb/ihm16m1_f32
