### PR TITLE
Change NSH kill cmd to accept SIGTERM as default

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -261,7 +261,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_KILL
-  { "kill",     cmd_kill,     3, 3, "-<signal> <pid>" },
+  { "kill",     cmd_kill,     2, 3, "[-<signal>] <pid>" },
 #endif
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT


### PR DESCRIPTION
## Summary
nsh kill cmd can be executed with no signal option.
SIGTERM is the default signal, as in unix kill command.
**nsh>** kill [-\<signal\>] \<pid\>

## Impact
Using SIGTERM as default signal makes nsh kill command to get closer to the unix version.
Given that NuttX allows to change the signal number of any signal and that default signal# for SIGTERM in NuttX is 12 (and 15 for POSIX signal), it is hard to guess what signal should be used to nicely kill a task.
Thus by using a default SIGTERM signal in kill command, the user just has to use the "kill \<pid\>" to always terminate a task.

## Testing
Tested in flat mode with CONFIG_SIG_DEFAULT=y as well as undefined.
