### PR TITLE
nsh/date: Support -u option

### DIFF
--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -418,7 +418,7 @@ All of the startup-behavior is contained in `rcS.template`. The role of
   Copy of the contents of the file at `<source-path>` to the location in the
   file system indicated by `<path-path>`
 
-- `date [-s "MMM DD HH:MM:SS YYYY"]`
+- `date [-s "MMM DD HH:MM:SS YYYY"] [-u]`
 
   Show or set the current date and time.
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -155,7 +155,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_DATE
-  { "date",     cmd_date,     1, 3, "[-s \"MMM DD HH:MM:SS YYYY\"]" },
+  { "date",     cmd_date,     1, 4, "[-s \"MMM DD HH:MM:SS YYYY\"] [-u]" },
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_DD


### PR DESCRIPTION
## Summary
user can use both UTC and local time now. Please ignore the false alarm from nxstyle:
nuttx/apps/nshlib/nsh_timcmds.c:115:35: error: Multiple data definitions
https://github.com/apache/incubator-nuttx-apps/pull/745/files#diff-9b1b76b8967bda035063f8c0c11a08b300ea647f90d68c5d2dfff178e4937843L115

## Impact
New option

## Testing
run date with/without -u
