### PR TITLE
iperf: Do not busy loop on a connection closed by the peer

### DIFF
--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -338,7 +338,20 @@ static int iperf_run_tcp_server(void)
       while (!s_iperf_ctrl.finish)
         {
           actual_recv = recv(sockfd, buffer, want_recv, 0);
-          if (actual_recv < 0)
+          if (actual_recv == 0)
+            {
+              printf("closed by the peer: %s,%d\n",
+                     inet_ntoa(remote_addr.sin_addr),
+                     htons(remote_addr.sin_port));
+
+              /* Note: unlike the original iperf, this implementation
+               * exits after finishing a single connection.
+               */
+
+              s_iperf_ctrl.finish = true;
+              break;
+            }
+          else if (actual_recv < 0)
             {
               iperf_show_socket_error_reason("tcp server recv",
                                              listen_socket);


### PR DESCRIPTION

## Summary
iperf: Do not busy loop on a connection closed by the peer

## Impact

## Testing
Tested on esp32-devkitc.

The peer was iperf on NetBSD.
> iperf version 2.0.5 (08 Jul 2010) pthreads

