### PR TITLE
Add initial support libtommath and libtomcrypt libraries

### DIFF
--- a/crypto/.gitignore
+++ b/crypto/.gitignore
@@ -1,0 +1,1 @@
+/Kconfig

--- a/crypto/Make.defs
+++ b/crypto/Make.defs
@@ -1,0 +1,21 @@
+############################################################################
+# apps/crypto/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(wildcard $(APPDIR)/crypto/*/Make.defs)

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -1,0 +1,23 @@
+############################################################################
+# apps/crypto/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+MENUDESC = "Cryptography Library Support"
+
+include $(APPDIR)/Directory.mk

--- a/crypto/libtomcrypt/.gitignore
+++ b/crypto/libtomcrypt/.gitignore
@@ -1,0 +1,2 @@
+/libtomcrypt
+/*.zip

--- a/crypto/libtomcrypt/Kconfig
+++ b/crypto/libtomcrypt/Kconfig
@@ -1,0 +1,57 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig CRYPTO_LIBTOMCRYPT
+	bool "LibTomCrypt CrypographyLibrary"
+	default n
+	select MATH_LIBTOMMATH
+	---help---
+		LibTomCrypt is a fairly comprehensive, modular and portable
+		cryptographic toolkit that provides developers with a vast array
+		of well known published block ciphers, one-way hash functions,
+		chaining modes, pseudo-random number generators, public key
+		cryptography and a plethora of other routines. 
+
+if CRYPTO_LIBTOMCRYPT
+
+config LIBTOMCRYPT_VERSION
+	string "LibTomCrypt Version"
+	default "1.18.2"
+
+menuconfig LIBTOMCRYPT_DEMOS
+	bool "LibTomCrypt Library Demos"
+	default n
+	---help---
+		LibTomCrypt demo and test applications.
+
+if LIBTOMCRYPT_DEMOS
+
+config LIBTOMCRYPT_LTCRYPT
+        tristate "LibTomCrypt ltcrypt"
+        default n
+        ---help---
+                Demo encrypt/decrypt application
+
+if LIBTOMCRYPT_LTCRYPT
+
+config LIBTOMCRYPT_LTCRYPT_PROGNAME
+        string "ltcrypt program name"
+        default "ltcrypt"
+        ---help---
+                LibTomMath ltcrypt application name
+
+config LIBTOMCRYPT_LTCRYPT_PRIORITY
+        int "ltcrypt application priority"
+        default 100
+
+config LIBTOMCRYPT_LTCRYPT_STACKSIZE
+        int "ltcrypt application stack size"
+        default DEFAULT_TASK_STACKSIZE
+
+endif # LIBTOMCRYPT_LTCRYPT
+
+endif # LIBTOMCRYPT_DEMOS
+
+endif # CRYPTO_LIBTOMCRYPT

--- a/crypto/libtomcrypt/Make.defs
+++ b/crypto/libtomcrypt/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# apps/crypto/libtomcrypt/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_CRYPTO_LIBTOMCRYPT),y)
+CONFIGURED_APPS += $(APPDIR)/crypto/libtomcrypt
+
+# It allows `<tomcrypt.h>` import.
+
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/libtomcrypt/libtomcrypt/src/headers/}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/libtomcrypt/libtomcrypt/src/headers/}
+endif

--- a/crypto/libtomcrypt/Makefile
+++ b/crypto/libtomcrypt/Makefile
@@ -1,0 +1,224 @@
+############################################################################
+# apps/crypto/libtomcrypt/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+
+CSRCS += libtomcrypt/src/ciphers/aes/aes.c libtomcrypt/src/ciphers/aes/aes_tab.c libtomcrypt/src/ciphers/anubis.c libtomcrypt/src/ciphers/blowfish.c \
+libtomcrypt/src/ciphers/camellia.c libtomcrypt/src/ciphers/cast5.c libtomcrypt/src/ciphers/des.c libtomcrypt/src/ciphers/kasumi.c libtomcrypt/src/ciphers/khazad.c \
+libtomcrypt/src/ciphers/kseed.c libtomcrypt/src/ciphers/multi2.c libtomcrypt/src/ciphers/noekeon.c libtomcrypt/src/ciphers/rc2.c libtomcrypt/src/ciphers/rc5.c \
+libtomcrypt/src/ciphers/rc6.c libtomcrypt/src/ciphers/safer/safer.c libtomcrypt/src/ciphers/safer/saferp.c libtomcrypt/src/ciphers/skipjack.c \
+libtomcrypt/src/ciphers/twofish/twofish.c libtomcrypt/src/ciphers/xtea.c libtomcrypt/src/encauth/ccm/ccm_add_aad.c \
+libtomcrypt/src/encauth/ccm/ccm_add_nonce.c libtomcrypt/src/encauth/ccm/ccm_done.c libtomcrypt/src/encauth/ccm/ccm_init.c \
+libtomcrypt/src/encauth/ccm/ccm_memory.c libtomcrypt/src/encauth/ccm/ccm_process.c libtomcrypt/src/encauth/ccm/ccm_reset.c \
+libtomcrypt/src/encauth/ccm/ccm_test.c libtomcrypt/src/encauth/chachapoly/chacha20poly1305_add_aad.c \
+libtomcrypt/src/encauth/chachapoly/chacha20poly1305_decrypt.c libtomcrypt/src/encauth/chachapoly/chacha20poly1305_done.c \
+libtomcrypt/src/encauth/chachapoly/chacha20poly1305_encrypt.c libtomcrypt/src/encauth/chachapoly/chacha20poly1305_init.c \
+libtomcrypt/src/encauth/chachapoly/chacha20poly1305_memory.c libtomcrypt/src/encauth/chachapoly/chacha20poly1305_setiv.c \
+libtomcrypt/src/encauth/chachapoly/chacha20poly1305_setiv_rfc7905.c \
+libtomcrypt/src/encauth/chachapoly/chacha20poly1305_test.c libtomcrypt/src/encauth/eax/eax_addheader.c \
+libtomcrypt/src/encauth/eax/eax_decrypt.c libtomcrypt/src/encauth/eax/eax_decrypt_verify_memory.c libtomcrypt/src/encauth/eax/eax_done.c \
+libtomcrypt/src/encauth/eax/eax_encrypt.c libtomcrypt/src/encauth/eax/eax_encrypt_authenticate_memory.c \
+libtomcrypt/src/encauth/eax/eax_init.c libtomcrypt/src/encauth/eax/eax_test.c libtomcrypt/src/encauth/gcm/gcm_add_aad.c \
+libtomcrypt/src/encauth/gcm/gcm_add_iv.c libtomcrypt/src/encauth/gcm/gcm_done.c libtomcrypt/src/encauth/gcm/gcm_gf_mult.c \
+libtomcrypt/src/encauth/gcm/gcm_init.c libtomcrypt/src/encauth/gcm/gcm_memory.c libtomcrypt/src/encauth/gcm/gcm_mult_h.c \
+libtomcrypt/src/encauth/gcm/gcm_process.c libtomcrypt/src/encauth/gcm/gcm_reset.c libtomcrypt/src/encauth/gcm/gcm_test.c \
+libtomcrypt/src/encauth/ocb/ocb_decrypt.c libtomcrypt/src/encauth/ocb/ocb_decrypt_verify_memory.c \
+libtomcrypt/src/encauth/ocb/ocb_done_decrypt.c libtomcrypt/src/encauth/ocb/ocb_done_encrypt.c libtomcrypt/src/encauth/ocb/ocb_encrypt.c \
+libtomcrypt/src/encauth/ocb/ocb_encrypt_authenticate_memory.c libtomcrypt/src/encauth/ocb/ocb_init.c libtomcrypt/src/encauth/ocb/ocb_ntz.c \
+libtomcrypt/src/encauth/ocb/ocb_shift_xor.c libtomcrypt/src/encauth/ocb/ocb_test.c libtomcrypt/src/encauth/ocb/s_ocb_done.c \
+libtomcrypt/src/encauth/ocb3/ocb3_add_aad.c libtomcrypt/src/encauth/ocb3/ocb3_decrypt.c libtomcrypt/src/encauth/ocb3/ocb3_decrypt_last.c \
+libtomcrypt/src/encauth/ocb3/ocb3_decrypt_verify_memory.c libtomcrypt/src/encauth/ocb3/ocb3_done.c \
+libtomcrypt/src/encauth/ocb3/ocb3_encrypt.c libtomcrypt/src/encauth/ocb3/ocb3_encrypt_authenticate_memory.c \
+libtomcrypt/src/encauth/ocb3/ocb3_encrypt_last.c libtomcrypt/src/encauth/ocb3/ocb3_init.c libtomcrypt/src/encauth/ocb3/ocb3_int_ntz.c \
+libtomcrypt/src/encauth/ocb3/ocb3_int_xor_blocks.c libtomcrypt/src/encauth/ocb3/ocb3_test.c libtomcrypt/src/hashes/blake2b.c \
+libtomcrypt/src/hashes/blake2s.c libtomcrypt/src/hashes/chc/chc.c libtomcrypt/src/hashes/helper/hash_file.c \
+libtomcrypt/src/hashes/helper/hash_filehandle.c libtomcrypt/src/hashes/helper/hash_memory.c \
+libtomcrypt/src/hashes/helper/hash_memory_multi.c libtomcrypt/src/hashes/md2.c libtomcrypt/src/hashes/md4.c libtomcrypt/src/hashes/md5.c \
+libtomcrypt/src/hashes/rmd128.c libtomcrypt/src/hashes/rmd160.c libtomcrypt/src/hashes/rmd256.c libtomcrypt/src/hashes/rmd320.c libtomcrypt/src/hashes/sha1.c \
+libtomcrypt/src/hashes/sha2/sha224.c libtomcrypt/src/hashes/sha2/sha256.c libtomcrypt/src/hashes/sha2/sha384.c libtomcrypt/src/hashes/sha2/sha512.c \
+libtomcrypt/src/hashes/sha2/sha512_224.c libtomcrypt/src/hashes/sha2/sha512_256.c libtomcrypt/src/hashes/sha3.c libtomcrypt/src/hashes/sha3_test.c \
+libtomcrypt/src/hashes/tiger.c libtomcrypt/src/hashes/whirl/whirl.c libtomcrypt/src/mac/blake2/blake2bmac.c \
+libtomcrypt/src/mac/blake2/blake2bmac_file.c libtomcrypt/src/mac/blake2/blake2bmac_memory.c \
+libtomcrypt/src/mac/blake2/blake2bmac_memory_multi.c libtomcrypt/src/mac/blake2/blake2bmac_test.c libtomcrypt/src/mac/blake2/blake2smac.c \
+libtomcrypt/src/mac/blake2/blake2smac_file.c libtomcrypt/src/mac/blake2/blake2smac_memory.c \
+libtomcrypt/src/mac/blake2/blake2smac_memory_multi.c libtomcrypt/src/mac/blake2/blake2smac_test.c libtomcrypt/src/mac/f9/f9_done.c \
+libtomcrypt/src/mac/f9/f9_file.c libtomcrypt/src/mac/f9/f9_init.c libtomcrypt/src/mac/f9/f9_memory.c libtomcrypt/src/mac/f9/f9_memory_multi.c \
+libtomcrypt/src/mac/f9/f9_process.c libtomcrypt/src/mac/f9/f9_test.c libtomcrypt/src/mac/hmac/hmac_done.c libtomcrypt/src/mac/hmac/hmac_file.c \
+libtomcrypt/src/mac/hmac/hmac_init.c libtomcrypt/src/mac/hmac/hmac_memory.c libtomcrypt/src/mac/hmac/hmac_memory_multi.c \
+libtomcrypt/src/mac/hmac/hmac_process.c libtomcrypt/src/mac/hmac/hmac_test.c libtomcrypt/src/mac/omac/omac_done.c libtomcrypt/src/mac/omac/omac_file.c \
+libtomcrypt/src/mac/omac/omac_init.c libtomcrypt/src/mac/omac/omac_memory.c libtomcrypt/src/mac/omac/omac_memory_multi.c \
+libtomcrypt/src/mac/omac/omac_process.c libtomcrypt/src/mac/omac/omac_test.c libtomcrypt/src/mac/pelican/pelican.c \
+libtomcrypt/src/mac/pelican/pelican_memory.c libtomcrypt/src/mac/pelican/pelican_test.c libtomcrypt/src/mac/pmac/pmac_done.c \
+libtomcrypt/src/mac/pmac/pmac_file.c libtomcrypt/src/mac/pmac/pmac_init.c libtomcrypt/src/mac/pmac/pmac_memory.c \
+libtomcrypt/src/mac/pmac/pmac_memory_multi.c libtomcrypt/src/mac/pmac/pmac_ntz.c libtomcrypt/src/mac/pmac/pmac_process.c \
+libtomcrypt/src/mac/pmac/pmac_shift_xor.c libtomcrypt/src/mac/pmac/pmac_test.c libtomcrypt/src/mac/poly1305/poly1305.c \
+libtomcrypt/src/mac/poly1305/poly1305_file.c libtomcrypt/src/mac/poly1305/poly1305_memory.c \
+libtomcrypt/src/mac/poly1305/poly1305_memory_multi.c libtomcrypt/src/mac/poly1305/poly1305_test.c libtomcrypt/src/mac/xcbc/xcbc_done.c \
+libtomcrypt/src/mac/xcbc/xcbc_file.c libtomcrypt/src/mac/xcbc/xcbc_init.c libtomcrypt/src/mac/xcbc/xcbc_memory.c \
+libtomcrypt/src/mac/xcbc/xcbc_memory_multi.c libtomcrypt/src/mac/xcbc/xcbc_process.c libtomcrypt/src/mac/xcbc/xcbc_test.c \
+libtomcrypt/src/math/fp/ltc_ecc_fp_mulmod.c libtomcrypt/src/math/gmp_desc.c libtomcrypt/src/math/ltm_desc.c libtomcrypt/src/math/multi.c \
+libtomcrypt/src/math/radix_to_bin.c libtomcrypt/src/math/rand_bn.c libtomcrypt/src/math/rand_prime.c libtomcrypt/src/math/tfm_desc.c libtomcrypt/src/misc/adler32.c \
+libtomcrypt/src/misc/base64/base64_decode.c libtomcrypt/src/misc/base64/base64_encode.c libtomcrypt/src/misc/burn_stack.c \
+libtomcrypt/src/misc/compare_testvector.c libtomcrypt/src/misc/crc32.c libtomcrypt/src/misc/crypt/crypt.c libtomcrypt/src/misc/crypt/crypt_argchk.c \
+libtomcrypt/src/misc/crypt/crypt_cipher_descriptor.c libtomcrypt/src/misc/crypt/crypt_cipher_is_valid.c \
+libtomcrypt/src/misc/crypt/crypt_constants.c libtomcrypt/src/misc/crypt/crypt_find_cipher.c \
+libtomcrypt/src/misc/crypt/crypt_find_cipher_any.c libtomcrypt/src/misc/crypt/crypt_find_cipher_id.c \
+libtomcrypt/src/misc/crypt/crypt_find_hash.c libtomcrypt/src/misc/crypt/crypt_find_hash_any.c \
+libtomcrypt/src/misc/crypt/crypt_find_hash_id.c libtomcrypt/src/misc/crypt/crypt_find_hash_oid.c \
+libtomcrypt/src/misc/crypt/crypt_find_prng.c libtomcrypt/src/misc/crypt/crypt_fsa.c libtomcrypt/src/misc/crypt/crypt_hash_descriptor.c \
+libtomcrypt/src/misc/crypt/crypt_hash_is_valid.c libtomcrypt/src/misc/crypt/crypt_inits.c \
+libtomcrypt/src/misc/crypt/crypt_ltc_mp_descriptor.c libtomcrypt/src/misc/crypt/crypt_prng_descriptor.c \
+libtomcrypt/src/misc/crypt/crypt_prng_is_valid.c libtomcrypt/src/misc/crypt/crypt_prng_rng_descriptor.c \
+libtomcrypt/src/misc/crypt/crypt_register_all_ciphers.c libtomcrypt/src/misc/crypt/crypt_register_all_hashes.c \
+libtomcrypt/src/misc/crypt/crypt_register_all_prngs.c libtomcrypt/src/misc/crypt/crypt_register_cipher.c \
+libtomcrypt/src/misc/crypt/crypt_register_hash.c libtomcrypt/src/misc/crypt/crypt_register_prng.c libtomcrypt/src/misc/crypt/crypt_sizes.c \
+libtomcrypt/src/misc/crypt/crypt_unregister_cipher.c libtomcrypt/src/misc/crypt/crypt_unregister_hash.c \
+libtomcrypt/src/misc/crypt/crypt_unregister_prng.c libtomcrypt/src/misc/error_to_string.c libtomcrypt/src/misc/hkdf/hkdf.c \
+libtomcrypt/src/misc/hkdf/hkdf_test.c libtomcrypt/src/misc/mem_neq.c libtomcrypt/src/misc/pk_get_oid.c libtomcrypt/src/misc/pkcs5/pkcs_5_1.c \
+libtomcrypt/src/misc/pkcs5/pkcs_5_2.c libtomcrypt/src/misc/pkcs5/pkcs_5_test.c libtomcrypt/src/misc/zeromem.c libtomcrypt/src/modes/cbc/cbc_decrypt.c \
+libtomcrypt/src/modes/cbc/cbc_done.c libtomcrypt/src/modes/cbc/cbc_encrypt.c libtomcrypt/src/modes/cbc/cbc_getiv.c \
+libtomcrypt/src/modes/cbc/cbc_setiv.c libtomcrypt/src/modes/cbc/cbc_start.c libtomcrypt/src/modes/cfb/cfb_decrypt.c \
+libtomcrypt/src/modes/cfb/cfb_done.c libtomcrypt/src/modes/cfb/cfb_encrypt.c libtomcrypt/src/modes/cfb/cfb_getiv.c \
+libtomcrypt/src/modes/cfb/cfb_setiv.c libtomcrypt/src/modes/cfb/cfb_start.c libtomcrypt/src/modes/ctr/ctr_decrypt.c \
+libtomcrypt/src/modes/ctr/ctr_done.c libtomcrypt/src/modes/ctr/ctr_encrypt.c libtomcrypt/src/modes/ctr/ctr_getiv.c \
+libtomcrypt/src/modes/ctr/ctr_setiv.c libtomcrypt/src/modes/ctr/ctr_start.c libtomcrypt/src/modes/ctr/ctr_test.c \
+libtomcrypt/src/modes/ecb/ecb_decrypt.c libtomcrypt/src/modes/ecb/ecb_done.c libtomcrypt/src/modes/ecb/ecb_encrypt.c \
+libtomcrypt/src/modes/ecb/ecb_start.c libtomcrypt/src/modes/f8/f8_decrypt.c libtomcrypt/src/modes/f8/f8_done.c libtomcrypt/src/modes/f8/f8_encrypt.c \
+libtomcrypt/src/modes/f8/f8_getiv.c libtomcrypt/src/modes/f8/f8_setiv.c libtomcrypt/src/modes/f8/f8_start.c libtomcrypt/src/modes/f8/f8_test_mode.c \
+libtomcrypt/src/modes/lrw/lrw_decrypt.c libtomcrypt/src/modes/lrw/lrw_done.c libtomcrypt/src/modes/lrw/lrw_encrypt.c \
+libtomcrypt/src/modes/lrw/lrw_getiv.c libtomcrypt/src/modes/lrw/lrw_process.c libtomcrypt/src/modes/lrw/lrw_setiv.c \
+libtomcrypt/src/modes/lrw/lrw_start.c libtomcrypt/src/modes/lrw/lrw_test.c libtomcrypt/src/modes/ofb/ofb_decrypt.c libtomcrypt/src/modes/ofb/ofb_done.c \
+libtomcrypt/src/modes/ofb/ofb_encrypt.c libtomcrypt/src/modes/ofb/ofb_getiv.c libtomcrypt/src/modes/ofb/ofb_setiv.c \
+libtomcrypt/src/modes/ofb/ofb_start.c libtomcrypt/src/modes/xts/xts_decrypt.c libtomcrypt/src/modes/xts/xts_done.c \
+libtomcrypt/src/modes/xts/xts_encrypt.c libtomcrypt/src/modes/xts/xts_init.c libtomcrypt/src/modes/xts/xts_mult_x.c \
+libtomcrypt/src/modes/xts/xts_test.c libtomcrypt/src/pk/asn1/der/bit/der_decode_bit_string.c \
+libtomcrypt/src/pk/asn1/der/bit/der_decode_raw_bit_string.c libtomcrypt/src/pk/asn1/der/bit/der_encode_bit_string.c \
+libtomcrypt/src/pk/asn1/der/bit/der_encode_raw_bit_string.c libtomcrypt/src/pk/asn1/der/bit/der_length_bit_string.c \
+libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c libtomcrypt/src/pk/asn1/der/boolean/der_encode_boolean.c \
+libtomcrypt/src/pk/asn1/der/boolean/der_length_boolean.c libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c \
+libtomcrypt/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c \
+libtomcrypt/src/pk/asn1/der/generalizedtime/der_encode_generalizedtime.c \
+libtomcrypt/src/pk/asn1/der/generalizedtime/der_length_generalizedtime.c \
+libtomcrypt/src/pk/asn1/der/ia5/der_decode_ia5_string.c libtomcrypt/src/pk/asn1/der/ia5/der_encode_ia5_string.c \
+libtomcrypt/src/pk/asn1/der/ia5/der_length_ia5_string.c libtomcrypt/src/pk/asn1/der/integer/der_decode_integer.c \
+libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c libtomcrypt/src/pk/asn1/der/integer/der_length_integer.c \
+libtomcrypt/src/pk/asn1/der/object_identifier/der_decode_object_identifier.c \
+libtomcrypt/src/pk/asn1/der/object_identifier/der_encode_object_identifier.c \
+libtomcrypt/src/pk/asn1/der/object_identifier/der_length_object_identifier.c \
+libtomcrypt/src/pk/asn1/der/octet/der_decode_octet_string.c libtomcrypt/src/pk/asn1/der/octet/der_encode_octet_string.c \
+libtomcrypt/src/pk/asn1/der/octet/der_length_octet_string.c \
+libtomcrypt/src/pk/asn1/der/printable_string/der_decode_printable_string.c \
+libtomcrypt/src/pk/asn1/der/printable_string/der_encode_printable_string.c \
+libtomcrypt/src/pk/asn1/der/printable_string/der_length_printable_string.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_ex.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c \
+libtomcrypt/src/pk/asn1/der/sequence/der_sequence_shrink.c libtomcrypt/src/pk/asn1/der/set/der_encode_set.c \
+libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c libtomcrypt/src/pk/asn1/der/short_integer/der_decode_short_integer.c \
+libtomcrypt/src/pk/asn1/der/short_integer/der_encode_short_integer.c \
+libtomcrypt/src/pk/asn1/der/short_integer/der_length_short_integer.c \
+libtomcrypt/src/pk/asn1/der/teletex_string/der_decode_teletex_string.c \
+libtomcrypt/src/pk/asn1/der/teletex_string/der_length_teletex_string.c \
+libtomcrypt/src/pk/asn1/der/utctime/der_decode_utctime.c libtomcrypt/src/pk/asn1/der/utctime/der_encode_utctime.c \
+libtomcrypt/src/pk/asn1/der/utctime/der_length_utctime.c libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c \
+libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c libtomcrypt/src/pk/asn1/der/utf8/der_length_utf8_string.c \
+libtomcrypt/src/pk/dh/dh.c libtomcrypt/src/pk/dh/dh_check_pubkey.c libtomcrypt/src/pk/dh/dh_export.c libtomcrypt/src/pk/dh/dh_export_key.c \
+libtomcrypt/src/pk/dh/dh_free.c libtomcrypt/src/pk/dh/dh_generate_key.c libtomcrypt/src/pk/dh/dh_import.c libtomcrypt/src/pk/dh/dh_set.c \
+libtomcrypt/src/pk/dh/dh_set_pg_dhparam.c libtomcrypt/src/pk/dh/dh_shared_secret.c libtomcrypt/src/pk/dsa/dsa_decrypt_key.c \
+libtomcrypt/src/pk/dsa/dsa_encrypt_key.c libtomcrypt/src/pk/dsa/dsa_export.c libtomcrypt/src/pk/dsa/dsa_free.c \
+libtomcrypt/src/pk/dsa/dsa_generate_key.c libtomcrypt/src/pk/dsa/dsa_generate_pqg.c libtomcrypt/src/pk/dsa/dsa_import.c \
+libtomcrypt/src/pk/dsa/dsa_make_key.c libtomcrypt/src/pk/dsa/dsa_set.c libtomcrypt/src/pk/dsa/dsa_set_pqg_dsaparam.c \
+libtomcrypt/src/pk/dsa/dsa_shared_secret.c libtomcrypt/src/pk/dsa/dsa_sign_hash.c libtomcrypt/src/pk/dsa/dsa_verify_hash.c \
+libtomcrypt/src/pk/dsa/dsa_verify_key.c libtomcrypt/src/pk/ecc/ecc.c libtomcrypt/src/pk/ecc/ecc_ansi_x963_export.c \
+libtomcrypt/src/pk/ecc/ecc_ansi_x963_import.c libtomcrypt/src/pk/ecc/ecc_decrypt_key.c libtomcrypt/src/pk/ecc/ecc_encrypt_key.c \
+libtomcrypt/src/pk/ecc/ecc_export.c libtomcrypt/src/pk/ecc/ecc_free.c libtomcrypt/src/pk/ecc/ecc_get_size.c libtomcrypt/src/pk/ecc/ecc_import.c \
+libtomcrypt/src/pk/ecc/ecc_make_key.c libtomcrypt/src/pk/ecc/ecc_shared_secret.c libtomcrypt/src/pk/ecc/ecc_sign_hash.c \
+libtomcrypt/src/pk/ecc/ecc_sizes.c libtomcrypt/src/pk/ecc/ecc_test.c libtomcrypt/src/pk/ecc/ecc_verify_hash.c \
+libtomcrypt/src/pk/ecc/ltc_ecc_is_valid_idx.c libtomcrypt/src/pk/ecc/ltc_ecc_map.c libtomcrypt/src/pk/ecc/ltc_ecc_mul2add.c \
+libtomcrypt/src/pk/ecc/ltc_ecc_mulmod.c libtomcrypt/src/pk/ecc/ltc_ecc_mulmod_timing.c libtomcrypt/src/pk/ecc/ltc_ecc_points.c \
+libtomcrypt/src/pk/ecc/ltc_ecc_projective_add_point.c libtomcrypt/src/pk/ecc/ltc_ecc_projective_dbl_point.c \
+libtomcrypt/src/pk/katja/katja_decrypt_key.c libtomcrypt/src/pk/katja/katja_encrypt_key.c libtomcrypt/src/pk/katja/katja_export.c \
+libtomcrypt/src/pk/katja/katja_exptmod.c libtomcrypt/src/pk/katja/katja_free.c libtomcrypt/src/pk/katja/katja_import.c \
+libtomcrypt/src/pk/katja/katja_make_key.c libtomcrypt/src/pk/pkcs1/pkcs_1_i2osp.c libtomcrypt/src/pk/pkcs1/pkcs_1_mgf1.c \
+libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c libtomcrypt/src/pk/pkcs1/pkcs_1_os2ip.c \
+libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_decode.c \
+libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_encode.c libtomcrypt/src/pk/rsa/rsa_decrypt_key.c libtomcrypt/src/pk/rsa/rsa_encrypt_key.c \
+libtomcrypt/src/pk/rsa/rsa_export.c libtomcrypt/src/pk/rsa/rsa_exptmod.c libtomcrypt/src/pk/rsa/rsa_free.c libtomcrypt/src/pk/rsa/rsa_get_size.c \
+libtomcrypt/src/pk/rsa/rsa_import.c libtomcrypt/src/pk/rsa/rsa_import_pkcs8.c libtomcrypt/src/pk/rsa/rsa_import_x509.c \
+libtomcrypt/src/pk/rsa/rsa_make_key.c libtomcrypt/src/pk/rsa/rsa_set.c libtomcrypt/src/pk/rsa/rsa_sign_hash.c \
+libtomcrypt/src/pk/rsa/rsa_sign_saltlen_get.c libtomcrypt/src/pk/rsa/rsa_verify_hash.c libtomcrypt/src/prngs/chacha20.c libtomcrypt/src/prngs/fortuna.c \
+libtomcrypt/src/prngs/rc4.c libtomcrypt/src/prngs/rng_get_bytes.c libtomcrypt/src/prngs/rng_make_prng.c libtomcrypt/src/prngs/sober128.c \
+libtomcrypt/src/prngs/sprng.c libtomcrypt/src/prngs/yarrow.c libtomcrypt/src/stream/chacha/chacha_crypt.c libtomcrypt/src/stream/chacha/chacha_done.c \
+libtomcrypt/src/stream/chacha/chacha_ivctr32.c libtomcrypt/src/stream/chacha/chacha_ivctr64.c \
+libtomcrypt/src/stream/chacha/chacha_keystream.c libtomcrypt/src/stream/chacha/chacha_setup.c libtomcrypt/src/stream/chacha/chacha_test.c \
+libtomcrypt/src/stream/rc4/rc4_stream.c libtomcrypt/src/stream/rc4/rc4_test.c libtomcrypt/src/stream/sober128/sober128_stream.c \
+libtomcrypt/src/stream/sober128/sober128_test.c
+
+CFLAGS += -DLTC_SOURCE -DLTM_DESC
+CFLAGS += -Wno-deprecated-declarations
+
+#CFLAGS += -Wno-format -DLTC_SOURCE
+
+ifneq ($(CONFIG_LIBTOMCRYPT_DEMOS),)
+
+ifneq ($(CONFIG_LIBTOMCRYPT_LTCRYPT),)
+MAINSRC += libtomcrypt/demos/ltcrypt.c
+
+PROGNAME += $(CONFIG_LIBTOMCRYPT_LTCRYPT_PROGNAME)
+PRIORITY += $(CONFIG_LIBTOMCRYPT_LTCRYPT_PRIORITY)
+STACKSIZE += $(CONFIG_LIBTOMCRYPT_LTCRYPT_STACKSIZE)
+endif
+
+endif
+
+CONFIG_LIBTOMCRYPT_URL ?= "https://github.com/libtom/libtomcrypt/archive"
+
+LIBTOMCRYPT_UNPACKNAME = libtomcrypt
+LIBTOMCRYPT_VERSION = $(patsubst "%",%,$(strip $(CONFIG_LIBTOMCRYPT_VERSION)))
+LIBTOMCRYPT_ZIP = v$(LIBTOMCRYPT_VERSION).zip
+
+UNPACK ?= unzip -o
+
+$(LIBTOMCRYPT_ZIP):
+	@echo "Downloading: $(LIBTOMCRYPT_ZIP)"
+	$(Q) curl -O -L $(CONFIG_LIBTOMCRYPT_URL)/$(LIBTOMCRYPT_ZIP)
+
+$(LIBTOMCRYPT_UNPACKNAME): $(LIBTOMCRYPT_ZIP)
+	@echo "Unpacking: $(LIBTOMCRYPT_ZIP) -> $(LIBTOMCRYPT_UNPACKNAME)"
+	$(Q) $(UNPACK) $(LIBTOMCRYPT_ZIP)
+	$(Q) mv	libtomcrypt-$(LIBTOMCRYPT_VERSION) $(LIBTOMCRYPT_UNPACKNAME)
+	$(Q) echo "Patching $(LIBTOMCRYPT_UNPACKNAME)"
+	$(Q) patch -p0 < digit-bit.patch # Update deprecated macro from ltm
+	$(Q) patch -p0 < ltcrypt-flush.patch # Missing stdout flush in demo app
+	$(Q) touch $(LIBTOMCRYPT_UNPACKNAME)
+
+context:: $(LIBTOMCRYPT_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(LIBTOMCRYPT_UNPACKNAME))
+	$(call DELFILE, $(LIBTOMCRYPT_ZIP))
+
+include $(APPDIR)/Application.mk

--- a/crypto/libtomcrypt/digit-bit.patch
+++ b/crypto/libtomcrypt/digit-bit.patch
@@ -1,0 +1,11 @@
+--- libtomcrypt/src/math/ltm_desc.c	2018-07-01 13:49:01.000000000 -0700
++++ libtomcrypt/src/math/ltm_desc.c.new	2021-06-06 22:42:12.877254274 -0700
+@@ -420,7 +420,7 @@
+ const ltc_math_descriptor ltm_desc = {
+ 
+    "LibTomMath",
+-   (int)DIGIT_BIT,
++   (int)MP_DIGIT_BIT,
+ 
+    &init,
+    &init_copy,

--- a/crypto/libtomcrypt/ltcrypt-flush.patch
+++ b/crypto/libtomcrypt/ltcrypt-flush.patch
@@ -1,0 +1,10 @@
+--- libtomcrypt/demos/ltcrypt.c	2018-07-01 13:49:01.000000000 -0700
++++ libtomcrypt/demos/ltcrypt.c.new	2021-06-06 22:49:02.810188768 -0700
+@@ -119,6 +119,7 @@
+    }
+ 
+    printf("\nEnter key: ");
++   fflush(stdout);
+    if(fgets((char *)tmpkey,sizeof(tmpkey), stdin) == NULL)
+       exit(-1);
+    outlen = sizeof(key);

--- a/math/.gitignore
+++ b/math/.gitignore
@@ -1,0 +1,1 @@
+/Kconfig

--- a/math/Make.defs
+++ b/math/Make.defs
@@ -1,0 +1,21 @@
+############################################################################
+# apps/math/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(wildcard $(APPDIR)/math/*/Make.defs)

--- a/math/Makefile
+++ b/math/Makefile
@@ -1,0 +1,23 @@
+############################################################################
+# apps/math/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+MENUDESC = "Math Library Support"
+
+include $(APPDIR)/Directory.mk

--- a/math/libtommath/.gitignore
+++ b/math/libtommath/.gitignore
@@ -1,0 +1,2 @@
+/libtommath
+/*.zip

--- a/math/libtommath/Kconfig
+++ b/math/libtommath/Kconfig
@@ -1,0 +1,101 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig MATH_LIBTOMMATH
+	bool "LibTomMath MPI Math Library"
+	default n
+	---help---
+		LibTomMath, a free open source portable number theoretic
+		multiple-precision integer (MPI) library written entirely in C
+
+if MATH_LIBTOMMATH
+
+config LIBTOMMATH_VERSION
+	string "LibTomMath Version"
+	default "1.2.0"
+
+menuconfig LIBTOMMATH_DEMOS
+	bool "LibTomMath MPI Math Library Demos"
+	default n
+	---help---
+		LibTomMath demo and test applications.
+
+if LIBTOMMATH_DEMOS
+
+config LIBTOMMATH_TEST
+        tristate "LibTomMath Test"
+        default n
+        ---help---
+                Demo test application for LibTomMath
+
+if LIBTOMMATH_TEST
+
+config LIBTOMMATH_TEST_PROGNAME
+        string "Test program name"
+        default "tommath_test"
+        ---help---
+                LibTomMath test application name
+
+config LIBTOMMATH_TEST_PRIORITY
+        int "Test application priority"
+        default 100
+
+config LIBTOMMATH_TEST_STACKSIZE
+        int "Test application stack size"
+        default DEFAULT_TASK_STACKSIZE
+
+endif # LIBTOMMATH_TEST
+
+config LIBTOMMATH_OPPONENT_MTEST
+        tristate "LibTomMath MTest"
+        default n
+        ---help---
+                Demo mtest application for LibTomMath
+
+if LIBTOMMATH_OPPONENT_MTEST
+
+config LIBTOMMATH_MTEST_OPPONENT_PROGNAME
+        string "MTest program name"
+        default "tommath_mtest"
+        ---help---
+                LibTomMath mtest application name
+
+config LIBTOMMATH_MTEST_OPPONENT_PRIORITY
+        int "MTest application priority"
+        default 100
+
+config LIBTOMMATH_MTEST_OPPONENT_STACKSIZE
+        int "MTest application stack size"
+        default DEFAULT_TASK_STACKSIZE
+
+endif # LIBTOMMATH_OPPONENT_MTEST
+
+config LIBTOMMATH_TIMING
+        tristate "LibTomMath Timing"
+        default n
+        ---help---
+                Demo timing test application for LibTomMath
+
+if LIBTOMMATH_TIMING
+
+config LIBTOMMATH_TIMING_PROGNAME
+        string "Timing program name"
+        default "tommath_timing"
+        ---help---
+                LibTomMath test application name
+
+config LIBTOMMATH_TIMING_PRIORITY
+        int "Timing application priority"
+        default 100
+
+config LIBTOMMATH_TIMING_STACKSIZE
+        int "Timing application stack size"
+        default DEFAULT_TASK_STACKSIZE
+
+endif # LIBTOMMATH_TIMING
+
+endif # LIBTOMMATH_DEMOS
+
+endif # MATH_LIBTOMMATH

--- a/math/libtommath/Make.defs
+++ b/math/libtommath/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# apps/math/libtommath/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_MATH_LIBTOMMATH),y)
+CONFIGURED_APPS += $(APPDIR)/math/libtommath
+
+# It allows `<tommath.h>` import.
+
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/math/libtommath/libtommath}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/math/libtommath/libtommath}
+endif

--- a/math/libtommath/Makefile
+++ b/math/libtommath/Makefile
@@ -1,0 +1,112 @@
+############################################################################
+# apps/math/libtommath/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+CFLAGS += -Wno-format
+
+CSRCS = bn_cutoffs.c bn_deprecated.c bn_mp_2expt.c bn_mp_abs.c bn_mp_add.c bn_mp_add_d.c bn_mp_addmod.c \
+bn_mp_and.c bn_mp_clamp.c bn_mp_clear.c bn_mp_clear_multi.c bn_mp_cmp.c bn_mp_cmp_d.c bn_mp_cmp_mag.c \
+bn_mp_cnt_lsb.c bn_mp_complement.c bn_mp_copy.c bn_mp_count_bits.c bn_mp_decr.c bn_mp_div.c bn_mp_div_2.c \
+bn_mp_div_2d.c bn_mp_div_3.c bn_mp_div_d.c bn_mp_dr_is_modulus.c bn_mp_dr_reduce.c bn_mp_dr_setup.c \
+bn_mp_error_to_string.c bn_mp_exch.c bn_mp_expt_u32.c bn_mp_exptmod.c bn_mp_exteuclid.c bn_mp_fread.c \
+bn_mp_from_sbin.c bn_mp_from_ubin.c bn_mp_fwrite.c bn_mp_gcd.c bn_mp_get_double.c bn_mp_get_i32.c \
+bn_mp_get_i64.c bn_mp_get_l.c bn_mp_get_ll.c bn_mp_get_mag_u32.c bn_mp_get_mag_u64.c bn_mp_get_mag_ul.c \
+bn_mp_get_mag_ull.c bn_mp_grow.c bn_mp_incr.c bn_mp_init.c bn_mp_init_copy.c bn_mp_init_i32.c \
+bn_mp_init_i64.c bn_mp_init_l.c bn_mp_init_ll.c bn_mp_init_multi.c bn_mp_init_set.c bn_mp_init_size.c \
+bn_mp_init_u32.c bn_mp_init_u64.c bn_mp_init_ul.c bn_mp_init_ull.c bn_mp_invmod.c bn_mp_is_square.c \
+bn_mp_iseven.c bn_mp_isodd.c bn_mp_kronecker.c bn_mp_lcm.c bn_mp_log_u32.c bn_mp_lshd.c bn_mp_mod.c \
+bn_mp_mod_2d.c bn_mp_mod_d.c bn_mp_montgomery_calc_normalization.c bn_mp_montgomery_reduce.c \
+bn_mp_montgomery_setup.c bn_mp_mul.c bn_mp_mul_2.c bn_mp_mul_2d.c bn_mp_mul_d.c bn_mp_mulmod.c bn_mp_neg.c \
+bn_mp_or.c bn_mp_pack.c bn_mp_pack_count.c bn_mp_prime_fermat.c bn_mp_prime_frobenius_underwood.c \
+bn_mp_prime_is_prime.c bn_mp_prime_miller_rabin.c bn_mp_prime_next_prime.c \
+bn_mp_prime_rabin_miller_trials.c bn_mp_prime_rand.c bn_mp_prime_strong_lucas_selfridge.c \
+bn_mp_radix_size.c bn_mp_radix_smap.c bn_mp_rand.c bn_mp_read_radix.c bn_mp_reduce.c bn_mp_reduce_2k.c \
+bn_mp_reduce_2k_l.c bn_mp_reduce_2k_setup.c bn_mp_reduce_2k_setup_l.c bn_mp_reduce_is_2k.c \
+bn_mp_reduce_is_2k_l.c bn_mp_reduce_setup.c bn_mp_root_u32.c bn_mp_rshd.c bn_mp_sbin_size.c bn_mp_set.c \
+bn_mp_set_double.c bn_mp_set_i32.c bn_mp_set_i64.c bn_mp_set_l.c bn_mp_set_ll.c bn_mp_set_u32.c \
+bn_mp_set_u64.c bn_mp_set_ul.c bn_mp_set_ull.c bn_mp_shrink.c bn_mp_signed_rsh.c bn_mp_sqr.c \
+bn_mp_sqrmod.c bn_mp_sqrt.c bn_mp_sqrtmod_prime.c bn_mp_sub.c bn_mp_sub_d.c bn_mp_submod.c \
+bn_mp_to_radix.c bn_mp_to_sbin.c bn_mp_to_ubin.c bn_mp_ubin_size.c bn_mp_unpack.c bn_mp_xor.c bn_mp_zero.c \
+bn_prime_tab.c bn_s_mp_add.c bn_s_mp_balance_mul.c bn_s_mp_exptmod.c bn_s_mp_exptmod_fast.c \
+bn_s_mp_get_bit.c bn_s_mp_invmod_fast.c bn_s_mp_invmod_slow.c bn_s_mp_karatsuba_mul.c \
+bn_s_mp_karatsuba_sqr.c bn_s_mp_montgomery_reduce_fast.c bn_s_mp_mul_digs.c bn_s_mp_mul_digs_fast.c \
+bn_s_mp_mul_high_digs.c bn_s_mp_mul_high_digs_fast.c bn_s_mp_prime_is_divisible.c \
+bn_s_mp_rand_jenkins.c bn_s_mp_rand_platform.c bn_s_mp_reverse.c bn_s_mp_sqr.c bn_s_mp_sqr_fast.c \
+bn_s_mp_sub.c bn_s_mp_toom_mul.c bn_s_mp_toom_sqr.c
+
+VPATH += $(LIBTOMMATH_UNPACKNAME)
+
+ifneq ($(CONFIG_LIBTOMMATH_DEMOS),)
+CSRCS += shared.c
+VPATH += $(LIBTOMMATH_UNPACKNAME)/demo
+
+ifneq ($(CONFIG_LIBTOMMATH_TEST),)
+MAINSRC += test.c
+
+PROGNAME += $(CONFIG_LIBTOMMATH_TEST_PROGNAME)
+PRIORITY += $(CONFIG_LIBTOMMATH_TEST_PRIORITY)
+STACKSIZE += $(CONFIG_LIBTOMMATH_TEST_STACKSIZE)
+endif
+
+ifneq ($(CONFIG_LIBTOMMATH_MTEST_OPPONENT),)
+MAINSRC += mtest_opponent.c
+
+PROGNAME += $(CONFIG_LIBTOMMATH_MTEST_OPPONENT_PROGNAME)
+PRIORITY += $(CONFIG_LIBTOMMATH_MTEST_OPPONENT_PRIORITY)
+STACKSIZE += $(CONFIG_LIBTOMMATH_MTEST_OPPONENT_STACKSIZE)
+endif
+
+ifneq ($(CONFIG_LIBTOMMATH_TIMING),)
+MAINSRC += timing.c
+
+PROGNAME += $(CONFIG_LIBTOMMATH_TIMING_PROGNAME)
+PRIORITY += $(CONFIG_LIBTOMMATH_TIMING_PRIORITY)
+STACKSIZE += $(CONFIG_LIBTOMMATH_TIMING_STACKSIZE)
+endif
+
+endif
+# Set up build configuration and environment
+
+CONFIG_LIBTOMMATH_URL ?= "https://github.com/libtom/libtommath/archive"
+
+LIBTOMMATH_VERSION = $(patsubst "%",%,$(strip $(CONFIG_LIBTOMMATH_VERSION)))
+LIBTOMMATH_ZIP = v$(LIBTOMMATH_VERSION).zip
+
+LIBTOMMATH_UNPACKNAME = libtommath
+UNPACK ?= unzip -o
+
+$(LIBTOMMATH_ZIP):
+	@echo "Downloading: $(LIBTOMMATH_ZIP)"
+	$(Q) curl -O -L $(CONFIG_LIBTOMMATH_URL)/$(LIBTOMMATH_ZIP)
+
+$(LIBTOMMATH_UNPACKNAME): $(LIBTOMMATH_ZIP)
+	@echo "Unpacking: $(LIBTOMMATH_ZIP) -> $(LIBTOMMATH_UNPACKNAME)"
+	$(Q) $(UNPACK) $(LIBTOMMATH_ZIP)
+	$(Q) mv	libtommath-$(LIBTOMMATH_VERSION) $(LIBTOMMATH_UNPACKNAME)
+	$(Q) touch $(LIBTOMMATH_UNPACKNAME)
+
+context:: $(LIBTOMMATH_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(LIBTOMMATH_UNPACKNAME))
+	$(call DELFILE, $(LIBTOMMATH_ZIP))
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
This adds the initial support for the libtommath and libtomcrypt libraries.  These are setting the foundation for being able to run the dropbear ssh server/client on NuttX.

## Impact

## Testing

Simple crypto test
```
nsh> echo "hello world" > /tmp/pt.txt
nsh> ltcrypt aes /tmp/pt.txt /tmp/ct.bin

Enter key: nsh> hexdump /tmp/ct.bin
/tmp/ct.bin at 00000000:
0000: e3 89 05 22 d7 c1 cb 54 b5 2a b2 40 a9 c1 b6 22 ..."...T.*.@..."
0010: d9 83 ac 24 09 79 ca 47 db 3c c9 9e             ...$.y.G.<..
nsh> ltcrypt -d aes /tmp/ct.bin /dev/console

Enter key:
hello world
nsh> 
```


```
nsh> tommath_test
Digit size 64 Bit 
Size of mp_digit: 8
Size of mp_word: 16
MP_DIGIT_BIT: 60
MP_PREC: 32
SEED: 0x11a

TEST feature_detection



TEST trivial_stuff



TEST mp_get_set_i32



TEST mp_get_set_i64



TEST mp_and



TEST mp_cnt_lsb



TEST mp_complement



TEST mp_decr



TEST mp_div_3

     9984
Passed div_3 testing

TEST mp_dr_reduce

31 digit modulus.... passed

TEST mp_pack_unpack



TEST mp_fread_fwrite



TEST mp_get_u32



TEST mp_get_u64

 r = 0x7fffffffffffffff i = 62

TEST mp_get_ul

 t = 0x7fffffffffffffff i = 62

TEST mp_log_u32



TEST mp_incr



TEST mp_invmod



TEST mp_is_square

   999



TEST mp_kronecker



TEST mp_montgomery_reduce

 digit size: 1000



TEST mp_root_u32



TEST mp_or



TEST mp_prime_is_prime

Testing mp_prime_is_prime() with Arnault's pseudoprime  803...901 

Testing mp_prime_is_prime() with certified prime 2^1119 + 53

Testing (    safe-prime):       127 bits    



TEST mp_prime_next_prime



TEST mp_prime_rand

Testing (not safe-prime):       127 bits    


TEST mp_rand



TEST mp_read_radix

 '123456' a == 123456, length = 7
 '-123456' a == -123456, length = 8
 '0' a == 0, length = 2


TEST mp_read_write_ubin

mp_to_ubin_size  113
mp_to_ubin len = 113


TEST mp_read_write_sbin

mp_to_sbin_size  114
mp_to_sbin len = 114


TEST mp_reduce_2k

  128 bits(1)(2)........

TEST mp_reduce_2k_l



TEST mp_set_double



TEST mp_signed_rsh



TEST mp_sqrt

   999

TEST mp_sqrtmod_prime



TEST mp_xor



TEST s_mp_balance_mul



TEST s_mp_karatsuba_mul



TEST s_mp_karatsuba_sqr



TEST s_mp_toom_mul



TEST s_mp_toom_sqr



Tests OK/NOP/FAIL: 42/0/0
```
