### PR TITLE
testing: getprime: Fix to wait for all the threads to finish

### DIFF
--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -147,9 +147,12 @@ static void get_prime_in_parallel(int n)
       ASSERT(status == OK);
     }
 
-  /* Wait for finishing the last thread */
+  /* Wait for all the threads to finish */
 
-  pthread_join(thread[n - 1], &result);
+  for (i = 0; i < n; i++)
+    {
+      pthread_join(thread[i], &result);
+    }
 
   printf("Done\n");
 }


### PR DESCRIPTION
## Summary

- I noticed that sometimes getprime causes ASSERT in tls_getset.c
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with spresense:wifi_smp
