### PR TITLE
examples/dhtxx: added configuration option for dhtxx sensor devpath

### DIFF
--- a/examples/dhtxx/Kconfig
+++ b/examples/dhtxx/Kconfig
@@ -18,6 +18,12 @@ config EXAMPLES_DHTXX_PROGNAME
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
 
+config EXAMPLES_DHTXX_DEVPATH
+	string "Device path"
+	default "/dev/hum0"
+	---help---
+		The device path
+
 config EXAMPLES_DHTXX_PRIORITY
 	int "Dhtxx task priority"
 	default 100

--- a/examples/dhtxx/dhtxx_main.c
+++ b/examples/dhtxx/dhtxx_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * examples/dhtxx/dhtxx_main.c
+ * apps/examples/dhtxx/dhtxx_main.c
  *
  *   Copyright (C) 2018 Abdelatif GUETTOUCHE. All rights reserved.
  *   Author: Abdelatif GUETTOUCHE <abdelatif.guettouche@gmail.com>
@@ -61,7 +61,7 @@ int main(int argc, FAR char *argv[])
 
   printf("Dhtxx app is running.\n");
 
-  fd = open("/dev/dht0", O_RDWR);
+  fd = open(CONFIG_EXAMPLES_DHTXX_DEVPATH, O_RDWR);
 
   for (i = 0; i < 20; i++)
     {


### PR DESCRIPTION
## Summary
DHTXX sensor example was using predefined devpath which was also different from the one registered in common stm32 board section. This change allows to define the devpath in configuration.

## Testing
Tested on Nucleo F446RE with DHT11 sensor.
