### PR TITLE
netutils/webclient: fix the fd leak during connect(2) fail

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -903,8 +903,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
       if (ret < 0)
         {
           nerr("ERROR: connect failed: %d\n", errno);
-          free(ws);
-          return ret;
+          goto errout_with_errno;
         }
 
       /* Send the request */


### PR DESCRIPTION
## Summary
Minor change in the fail path

## Impact
Fix the resource leak in webclient

## Testing
run webclient
