### PR TITLE
usrsock/rpmsg/server: select eventfd by default

### DIFF
--- a/netutils/usrsock_rpmsg/Kconfig
+++ b/netutils/usrsock_rpmsg/Kconfig
@@ -7,6 +7,7 @@ config NETUTILS_USRSOCK_RPMSG
 	tristate "RPMSG usrsock"
 	default n
 	depends on NET && OPENAMP
+	select EVENT_FD if !NET_USRSOCK
 	---help---
 		Enable usrsock through rpmsg channel.
 


### PR DESCRIPTION
## Summary
Avoid build break when user forget to select EVENT_FD

## Impact
Default kconfig setting

## Testing

