### PR TITLE
examples: Ignore the default action if app call sigwait

### DIFF
--- a/examples/oneshot/oneshot_main.c
+++ b/examples/oneshot/oneshot_main.c
@@ -187,6 +187,10 @@ int main(int argc, FAR char *argv[])
 
   signal(CONFIG_EXAMPLES_ONESHOT_SIGNO, SIG_IGN);
 
+  /* Ignore the default signal action */
+
+  signal(CONFIG_EXAMPLES_ONESHOT_SIGNO, SIG_IGN);
+
   /* Loop waiting until the full delay expires */
 
   while (usecs > 0)


### PR DESCRIPTION
## Summary
Because the configured signo may have the default action(e.g. SIGPIPE),
and then will generate the bad side effect before the caller wakeup.

## Impact
Avoid the default action kill the program

## Testing

