### PR TITLE
apps/system: fix command history behavior

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -601,6 +601,8 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                           buf[nch++] = g_cmdhist.buf[idx][i];
                           RL_PUTC(vtbl, g_cmdhist.buf[idx][i]);
                         }
+
+                      buf[nch] = '\0';
                     }
                 }
 #endif /* CONFIG_READLINE_CMD_HISTORY */
@@ -682,7 +684,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                * buffer, don't save it again.
                */
 
-              if (strncmp(buf, g_cmdhist.buf[g_cmdhist.head], nch) != 0)
+              if (strncmp(buf, g_cmdhist.buf[g_cmdhist.head], nch + 1) != 0)
                 {
                   g_cmdhist.head = (g_cmdhist.head + 1) % RL_CMDHIST_LEN;
 


### PR DESCRIPTION
## Summary
Fixing "last command" misbehavior when one command in history is a substring of another.

## Impact
Fix the minor corner case

## Testing

