### PR TITLE
apps warning: add ether_h because  Wimplicit-function-declaration

### DIFF
--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <netinet/ether.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/stat.h>


### PR DESCRIPTION
## Summary
Please ignore the nxstyle warning:
apps/wireless/wapi/src/util.c:431:6: error: Mixed case identifier found

## Impact
Minor change

## Testing

