### PR TITLE
webclient: Add a way to specify timeout

### DIFF
--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -195,6 +195,13 @@ struct webclient_context
    *   headers          - An array of pointers to the extra headers.
    *   nheaders         - The number of elements in the "headers" array.
    *   bodylen          - The size of the request body.
+   *   timeout_sec      - The timeout in second.
+   *                      This is not meant to cover the entire transaction.
+   *                      Instead, this is meant to be an inactive timer.
+   *                      That is, if no progress is made during the
+   *                      specified amount of time, the operation will fail.
+   *                      The default is CONFIG_WEBCLIENT_TIMEOUT, which is
+   *                      10 seconds by default.
    */
 
   FAR const char *method;
@@ -205,6 +212,7 @@ struct webclient_context
   FAR const char * FAR const *headers;
   unsigned int nheaders;
   size_t bodylen;
+  unsigned int timeout_sec;
 
   /* other parameters
    *

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -815,7 +815,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
 
           snprintf(port_str, sizeof(port_str), "%u", ws->port);
           ret = tls_ops->connect(tls_ctx, ws->hostname, port_str,
-                                 CONFIG_WEBCLIENT_TIMEOUT, &conn.tls_conn);
+                                 ctx->timeout_sec, &conn.tls_conn);
         }
       else
         {
@@ -879,7 +879,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
 
           /* Set send and receive timeout values */
 
-          tv.tv_sec  = CONFIG_WEBCLIENT_TIMEOUT;
+          tv.tv_sec  = ctx->timeout_sec;
           tv.tv_usec = 0;
 
           setsockopt(conn.sockfd, SOL_SOCKET, SO_RCVTIMEO,
@@ -1277,6 +1277,7 @@ void webclient_set_defaults(FAR struct webclient_context *ctx)
 {
   memset(ctx, 0, sizeof(*ctx));
   ctx->method = "GET";
+  ctx->timeout_sec = CONFIG_WEBCLIENT_TIMEOUT;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
webclient: Add a way to specify timeout

## Impact
webclient

## Testing
a fork of this was tested with my local app, using a crafted-to-be-slow http server.
