### PR TITLE
examples/qencoder: fix nxstyle warning and errors

### DIFF
--- a/examples/qencoder/qe_main.c
+++ b/examples/qencoder/qe_main.c
@@ -242,7 +242,7 @@ int main(int argc, FAR char *argv[])
     {
       printf("qe_main: open %s failed: %d\n", g_qeexample.devpath, errno);
       exitval = EXIT_FAILURE;
-      goto errout_with_dev;
+      goto errout;
     }
 
   /* Reset the count if so requested */


### PR DESCRIPTION
## Summary
FIx compile error discovered in automatic control to [NuttX PR 3929](https://github.com/apache/incubator-nuttx/pull/3929) (unused label).
