### PR TITLE
Fix few typos in builtin/ and sotest_main example.

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -45,7 +45,7 @@
  * Input Parameter:
  *   filename  - Name of the linked-in binary to be started.
  *   argv      - Argument list
- *   redirfile - If output if redirected, this parameter will be non-NULL
+ *   redirfile - If output is redirected, this parameter will be non-NULL
  *               and will provide the full path to the file.
  *   oflags    - If output is redirected, this parameter will provide the
  *               open flags to use.  This will support file replacement
@@ -53,7 +53,7 @@
  *
  * Returned Value:
  *   This is an end-user function, so it follows the normal convention:
- *   Returns the PID of the exec'ed module.  On failure, it.returns
+ *   Returns the PID of the exec'ed module.  On failure, it returns
  *   -1 (ERROR) and sets errno appropriately.
  *
  ****************************************************************************/

--- a/examples/elf/tests/hello/hello.c
+++ b/examples/elf/tests/hello/hello.c
@@ -42,14 +42,14 @@ int main(int argc, char **argv)
   /* Print arguments */
 
   printf("argc\t= %d\n", argc);
-  printf("argv\t= 0x%p\n", argv);
+  printf("argv\t= %p\n", argv);
 
   for (i = 0; i < argc; i++)
     {
       printf("argv[%d]\t= ", i);
       if (argv[i])
         {
-          printf("(0x%p) \"%s\"\n", argv[i], argv[i]);
+          printf("(%p) \"%s\"\n", argv[i], argv[i]);
         }
       else
         {
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
         }
     }
 
-  printf("argv[%d]\t= 0x%p\n", argc, argv[argc]);
+  printf("argv[%d]\t= %p\n", argc, argv[argc]);
   printf("Goodbye, world!\n");
   return 0;
 }

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -159,11 +159,9 @@ int main(int argc, FAR char *argv[])
 
 #if CONFIG_MODLIB_MAXDEPEND > 0
   /* Install the first test shared library.  The first shared library only
-   * verifies that symbols exported be one shared library can be used to
+   * verifies that symbols exported by one shared library can be used to
    * resolve undefined symbols in a second shared library.
    */
-
-  /* Install the second test shared library  */
 
   handle1 = dlopen(BINDIR "/modprint", RTLD_NOW | RTLD_LOCAL);
   if (handle1 == NULL)
@@ -261,7 +259,7 @@ int main(int argc, FAR char *argv[])
   ret = dlclose(handle2);
   if (ret < 0)
     {
-      fprintf(stderr, "ERROR: rmmod(handle2) failed: %d\n", ret);
+      fprintf(stderr, "ERROR: dlclose(handle2) failed: %d\n", ret);
       exit(EXIT_FAILURE);
     }
 
@@ -271,7 +269,7 @@ int main(int argc, FAR char *argv[])
   ret = dlclose(handle1);
   if (ret < 0)
     {
-      fprintf(stderr, "ERROR: rmmod(handle1) failed: %d\n", ret);
+      fprintf(stderr, "ERROR: dlclose(handle1) failed: %d\n", ret);
       exit(EXIT_FAILURE);
     }
 #endif


### PR DESCRIPTION
## Summary
1. Fix few typos in builtin/ and sotest_main example.
2. Drop the 0x when printing pointers in elf/hello
## Impact
No functional change.
## Testing
esp32c3-devkit:elf esp32c3-devkit:sotest
