### PR TITLE
canutils: Fix error: unknown type name 'fd_set'

### DIFF
--- a/canutils/candump/candump.c
+++ b/canutils/candump/candump.c
@@ -54,7 +54,7 @@
 #include <time.h>
 #include <errno.h>
 
-#include <sys/time.h>
+#include <sys/select.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
## Summary
Replace sys/time.h with sys/select.h.
Please ignore nxstyle warning since canutils keep the original coding style to help merging.

## Impact

## Testing

