### PR TITLE
wireless: gs2200m: Fix error handling in sendto_request()

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -815,7 +815,7 @@ static int sendto_request(int fd, FAR struct gs2200m_s *priv,
 
       if (0 != nret)
         {
-          ret = -EINVAL;
+          ret = -errno;
           goto prepare;
         }
 


### PR DESCRIPTION
## Summary

- This commit returns -errno to the caller

## Impact

- gs2200m only

## Testing

- Tested with spresense:wifi_smp
- NOTE: need to update the gs2200m driver in NuttX

