### PR TITLE
Revert "Follow up task_spawn change from kernel side"

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -168,10 +168,9 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
     {
       /* Start the built-in */
 
-      pid = task_spawn(builtin->name, builtin->main, &file_actions,
+      ret = task_spawn(&pid, builtin->name, builtin->main, &file_actions,
                        &attr, (argv) ? &argv[1] : (FAR char * const *)NULL,
                        (FAR char * const *)NULL);
-      ret = pid < 0 ? -pid : 0;
     }
 
   if (ret != 0)

--- a/system/popen/popen.c
+++ b/system/popen/popen.c
@@ -253,12 +253,8 @@ FILE *popen(FAR const char *command, FAR const char *mode)
   errcode = posix_spawn(&container->shell, argv[0], &file_actions,
                         &attr, argv, (FAR char * const *)NULL);
 #else
-  container->shell = task_spawn("popen", nsh_system, &file_actions,
-                                &attr, argv + 1, (FAR char * const *)NULL);
-  if (container->shell < 0)
-    {
-      errcode = -container->shell;
-    }
+  errcode = task_spawn(&container->shell, "popen", nsh_system, &file_actions,
+                       &attr, argv, (FAR char * const *)NULL);
 #endif
 
   if (errcode != 0)

--- a/system/system/system.c
+++ b/system/system/system.c
@@ -137,12 +137,8 @@ int system(FAR const char *cmd)
   errcode = posix_spawn(&pid, argv[0],  NULL, &attr,
                         argv, (FAR char * const *)NULL);
 #else
-  pid = task_spawn("system", nsh_system, NULL, &attr,
-                   argv + 1, (FAR char * const *)NULL);
-  if (pid < 0)
-    {
-      errcode = -pid;
-    }
+  errcode = task_spawn(&pid, "system", nsh_system, NULL, &attr,
+                       argv, (FAR char * const *)NULL);
 #endif
 
   /* Release the attributes and check for an error from the spawn operation */


### PR DESCRIPTION
## Summary
since the prototype of task_spawn restore to the origin
This reverts commit 58293abb8e896bb04f3a76bf8b48206debe68f26.
Depends on https://github.com/apache/incubator-nuttx/pull/4027

## Impact
Avoid API compatibility issue

## Testing

