### PR TITLE
apps: add variable to identify main shell

### DIFF
--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -245,7 +245,7 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
 
 int nsh_consolemain(int argc, FAR char *argv[])
 {
-  FAR struct console_stdio_s *pstate = nsh_newconsole();
+  FAR struct console_stdio_s *pstate = nsh_newconsole(true);
   FAR const char *msg;
   int ret;
 

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -130,13 +130,14 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 #  endif /* CONFIG_NSH_DISABLEBG */
         {
           int rc = 0;
+          int tc = 0;
 
-          /* Setup up to receive SIGINT if control-C entered.  The return
-           * value is ignored because this console device may not support
-           * SIGINT.
-           */
+          if (vtbl->isctty)
+            {
+              /* Setup up to receive SIGINT if control-C entered. */
 
-          ioctl(stdout->fs_fd, TIOCSCTTY, ret);
+              tc = ioctl(stdout->fs_fd, TIOCSCTTY, ret);
+            }
 
           /* Wait for the application to exit.  We did lock the scheduler
            * above, but that does not guarantee that the application did not
@@ -198,7 +199,10 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                */
             }
 
-          ioctl(stdout->fs_fd, TIOCSCTTY, -1);
+          if (vtbl->isctty && tc == 0)
+            {
+              ioctl(stdout->fs_fd, TIOCNOTTY);
+            }
         }
 #  ifndef CONFIG_NSH_DISABLEBG
       else

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -274,7 +274,7 @@ static FAR char *nsh_consolelinebuffer(FAR struct nsh_vtbl_s *vtbl)
 #ifndef CONFIG_NSH_DISABLEBG
 static FAR struct nsh_vtbl_s *nsh_consoleclone(FAR struct nsh_vtbl_s *vtbl)
 {
-  FAR struct console_stdio_s *pclone = nsh_newconsole();
+  FAR struct console_stdio_s *pclone = nsh_newconsole(vtbl->isctty);
   return &pclone->cn_vtbl;
 }
 #endif
@@ -436,7 +436,7 @@ static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl, int exitstatus)
  * Name: nsh_newconsole
  ****************************************************************************/
 
-FAR struct console_stdio_s *nsh_newconsole(void)
+FAR struct console_stdio_s *nsh_newconsole(bool isctty)
 {
   FAR struct console_stdio_s *pstate =
     (FAR struct console_stdio_s *)zalloc(sizeof(struct console_stdio_s));
@@ -454,6 +454,7 @@ FAR struct console_stdio_s *nsh_newconsole(void)
       pstate->cn_vtbl.error       = nsh_erroroutput;
       pstate->cn_vtbl.linebuffer  = nsh_consolelinebuffer;
       pstate->cn_vtbl.exit        = nsh_consoleexit;
+      pstate->cn_vtbl.isctty      = isctty;
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
       /* Set the initial option flags */

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -128,6 +128,10 @@ struct nsh_vtbl_s
   /* Parser state data */
 
   struct nsh_parser_s np;
+
+  /* Ctrl tty or not */
+
+  bool isctty;
 };
 
 /* This structure describes a console front-end that is based on stdin and
@@ -177,6 +181,6 @@ struct console_stdio_s
 
 /* Defined in nsh_console.c *************************************************/
 
-FAR struct console_stdio_s *nsh_newconsole(void);
+FAR struct console_stdio_s *nsh_newconsole(bool isctty);
 
 #endif /* __APPS_NSHLIB_NSH_CONSOLE_H */

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -66,7 +66,7 @@
 
 int nsh_consolemain(int argc, FAR char *argv[])
 {
-  FAR struct console_stdio_s *pstate = nsh_newconsole();
+  FAR struct console_stdio_s *pstate = nsh_newconsole(true);
   int ret;
 
   DEBUGASSERT(pstate != NULL);

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -155,12 +155,14 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
       if (vtbl->np.np_bg == false)
 #  endif /* CONFIG_NSH_DISABLEBG */
         {
-          /* Setup up to receive SIGINT if control-C entered.  The return
-           * value is ignored because this console device may not support
-           * SIGINT.
-           */
+          int tc = 0;
 
-          ioctl(stdout->fs_fd, TIOCSCTTY, pid);
+          if (vtbl->isctty)
+            {
+              /* Setup up to receive SIGINT if control-C entered. */
+
+              tc = ioctl(stdout->fs_fd, TIOCSCTTY, pid);
+            }
 
           /* Wait for the application to exit.  We did lock the scheduler
            * above, but that does not guarantee that the application did not
@@ -213,7 +215,10 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                */
             }
 
-          ioctl(stdout->fs_fd, TIOCSCTTY, -1);
+          if (vtbl->isctty && tc == 0)
+            {
+              ioctl(stdout->fs_fd, TIOCNOTTY);
+            }
         }
 #  ifndef CONFIG_NSH_DISABLEBG
       else

--- a/nshlib/nsh_system.c
+++ b/nshlib/nsh_system.c
@@ -57,7 +57,7 @@
 
 int nsh_system(int argc, FAR char *argv[])
 {
-  FAR struct console_stdio_s *pstate = nsh_newconsole();
+  FAR struct console_stdio_s *pstate = nsh_newconsole(false);
   int ret;
 
   DEBUGASSERT(pstate != NULL);

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -68,7 +68,7 @@ enum telnetd_state_e
 
 static int nsh_telnetmain(int argc, char *argv[])
 {
-  FAR struct console_stdio_s *pstate = nsh_newconsole();
+  FAR struct console_stdio_s *pstate = nsh_newconsole(true);
   FAR struct nsh_vtbl_s *vtbl;
   int ret;
 

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -241,7 +241,7 @@ restart:
 
 int nsh_consolemain(int argc, FAR char *argv[])
 {
-  FAR struct console_stdio_s *pstate = nsh_newconsole();
+  FAR struct console_stdio_s *pstate = nsh_newconsole(true);
   struct boardioc_usbdev_ctrl_s ctrl;
   FAR void *handle;
   int ret;


### PR DESCRIPTION

## Summary

apps: add variable to identify main shell

This should be with
https://github.com/apache/incubator-nuttx/pull/4042

Root cause:

These modify for shell ctrl + C usefulness when system() execute.

1. execute 'cu' in shell front end, uart record 'cu' pid for later killing.
2. one thread use system() to do sth anything, uart record new pid for later killing.
3. ctrl +c can't kill 'cu' thread

FIX:
add param to nsh_newconsole() to identify the main shell & system cmd shell.

## Impact

## Testing

