### PR TITLE
netutils/ftpc: ftpc_connect: Fixed invalid socket close.

### DIFF
--- a/netutils/ftpc/ftpc_connect.c
+++ b/netutils/ftpc/ftpc_connect.c
@@ -73,6 +73,10 @@ SESSION ftpc_connect(FAR union ftpc_sockaddr_u *server)
   session->conntimeo   = CONFIG_FTP_DEFTIMEO * CLOCKS_PER_SEC;
   session->pid         = getpid();
 
+  session->cmd.sd       = -1;
+  session->data.sd      = -1;
+  session->dacceptor.sd = -1;
+
   /* Use the default port if the user specified port number zero */
 
 #ifdef CONFIG_NET_IPv6


### PR DESCRIPTION
## Summary

I fixed a problem where ftpc would close stdin (0).

ftpc_connect()
  zero fill SESSION structure (cmd, data, dacceptor socket is zero)
  and connect cmd socket.
ftpc_login()
  execute login sequence on cmd socket.
ftpc_getfile() / ftpc_putfile()
  connect data socket (PASV).
  transfer data on data socket.
  close socket. (descriptor set to -1)
ftpc_quit()
  close all socket.
    close cmd socket (OK).
    close data socket (-1, so it'll be EBADF, it's OK).
    close dacceptor socket (zero is stdin, stdin will be closed).

By setting the socket descriptor to -1 initially, stdin will not be closed.

## Impact

## Testing

I tested my local app, on Spresense.