### PR TITLE
examples: Fix printf format warnings

### DIFF
--- a/examples/bmi160/sixaxis_main.c
+++ b/examples/bmi160/sixaxis_main.c
@@ -38,6 +38,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <inttypes.h>
 #include <fcntl.h>
 #include <stdio.h>
 
@@ -86,7 +87,7 @@ int main(int argc, FAR char *argv[])
 
       if (prev != data.sensor_time)
         {
-          printf("[%d] %d, %d, %d / %d, %d, %d\n",
+          printf("[%" PRIu32 "] %d, %d, %d / %d, %d, %d\n",
                  data.sensor_time,
                  data.gyro.x, data.gyro.y, data.gyro.z,
                  data.accel.x, data.accel.y, data.accel.z);

--- a/examples/charger/charger_main.c
+++ b/examples/charger/charger_main.c
@@ -244,8 +244,8 @@ int main(int argc, FAR char *argv[])
     }
 
   gettimeofday(&tv, NULL);
-  printf("%d.%06d: %d mV, %d mA\n",
-         tv.tv_sec, tv.tv_usec, voltage, current);
+  printf("%ju.%06ld: %d mV, %d mA\n",
+         (uintmax_t)tv.tv_sec, tv.tv_usec, voltage, current);
 
   close(fd);
 

--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -378,7 +379,8 @@ static inline int
   crc = crc32(g_entryimage, entry->len);
   if (crc != entry->crc)
     {
-      printf("ERROR: Bad CRC: %u vs %u\n", crc, entry->crc);
+      printf("ERROR: Bad CRC: %" PRIu32 " vs %" PRIu32 "\n",
+             crc, entry->crc);
       printf("  Entry id:   %04X\n", entry->id);
       printf("  Entry size: %d\n", entry->len);
       return ERROR;


### PR DESCRIPTION
## Summary
Fix printf format warnings by -Wformat.

## Impact
None

## Testing
Run examples/bmi160, examples/charger and examples/configdata.
