### PR TITLE
graphics/pdcurs34: Fix compile error

### DIFF
--- a/graphics/pdcurs34/nuttx/pdcdisp.c
+++ b/graphics/pdcurs34/nuttx/pdcdisp.c
@@ -838,7 +838,7 @@ static void PDC_transform_line_term(FAR SCREEN *s, int lineno, int x,
 
   /* Move to the specified line / col */
 
-  PDC_gotoyx_term(sp, lineno, x);
+  PDC_gotoyx_term(s, lineno, x);
 
   /* Loop through all characters to be displayed */
 

--- a/graphics/pdcurs34/nuttx/pdcscrn.c
+++ b/graphics/pdcurs34/nuttx/pdcscrn.c
@@ -207,7 +207,9 @@ static int PDC_scr_open_term(int argc, char **argv)
     {
       /* Free the memory ... can't open input */
 
+#ifdef CONFIG_PDCURSES_MULTITHREAD
       PDC_ctx_free();
+#endif
       free(termscreen);
     }
 #endif


### PR DESCRIPTION
## Summary
Fix a compile error when CONFIG_SYSTEM_TERMCURSES=y.
Fix a compile warning when CONFIG_PDCURSES_MULTITHREAD=n.

## Impact
None

## Testing
Run example/pdcurses.
