### PR TITLE
system/nxlooper: Fix the following compiler warning

### DIFF
--- a/include/system/nxlooper.h
+++ b/include/system/nxlooper.h
@@ -162,6 +162,33 @@ int nxlooper_setdevice(FAR struct nxlooper_s *plooper,
                        FAR const char *device);
 
 /****************************************************************************
+ * Name: nxlooper_loopraw
+ *
+ *   nxlooper_loopraw() tries to record and then play the raw data using the
+ *   Audio system.  If a device is specified, it will try to use that
+ *   device.
+ *
+ * Input Parameters:
+ *   plooper    Pointer to the initialized Looper context
+ *   nchannels  channel num
+ *   bpsampe    bit width
+ *   samprate   sample rate
+ *   chmap      channel map
+ *
+ * Returned Value:
+ *   OK         File is being looped
+ *   -EBUSY     The media device is busy
+ *   -ENOSYS    The media file is an unsupported type
+ *   -ENODEV    No audio device suitable
+ *   -ENOENT    The media file was not found
+ *
+ ****************************************************************************/
+
+int nxlooper_loopraw(FAR struct nxlooper_s *plooper,
+                     uint8_t nchannels, uint8_t bpsamp,
+                     uint32_t samprate, uint8_t chmap);
+
+/****************************************************************************
  * Name: nxlooper_stop
  *
  *   Stops current loopback.

--- a/system/nxlooper/nxlooper.c
+++ b/system/nxlooper/nxlooper.c
@@ -122,8 +122,6 @@ static int nxlooper_opendevice(FAR struct nxlooper_s *plooper)
       FAR struct dirent *pdevice;
       FAR DIR *dirp;
       char path[64];
-      uint8_t supported = true;
-      uint8_t x;
 
       /* Search for a device in the audio device directory */
 
@@ -479,7 +477,7 @@ static void *nxlooper_loopthread(pthread_addr_t pvarg)
 
       /* Validate a message was received */
 
-      audinfo("message received size %d id%d\n", size, msg.msg_id);
+      audinfo("message received size %zd id%d\n", size, msg.msg_id);
       if (size != sizeof(msg))
         {
           /* Interrupted by a signal? What to do? */


### PR DESCRIPTION
## Summary
```
nxlooper.c: In function 'nxlooper_opendevice':
Error: nxlooper.c:126:15: error: unused variable 'x' [-Werror=unused-variable]
  126 |       uint8_t x;
      |               ^
Error: nxlooper.c:125:15: error: unused variable 'supported' [-Werror=unused-variable]
  125 |       uint8_t supported = true;
      |               ^~~~~~~~~
In file included from nxlooper.c:40:
nxlooper.c: In function 'nxlooper_loopthread':
Error: nxlooper.c:482:15: error: format '%d' expects argument of type 'int', but argument 3 has type 'ssize_t' {aka 'long int'} [-Werror=format=]
  482 |       audinfo("message received size %d id%d\n", size, msg.msg_id);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                                  |
      |                                                  ssize_t {aka long int}
nxlooper.c:482:39: note: format string is defined here
  482 |       audinfo("message received size %d id%d\n", size, msg.msg_id);
      |                                      ~^
      |                                       |
      |                                       int
      |                                      %ld
cc1: all warnings being treated as errors
make[3]: *** [/github/workspace/sources/apps/Application.mk:133: nxlooper.c.github.workspace.sources.apps.system.nxlooper.o] Error 1
nxlooper_main.c: In function 'nxlooper_cmd_loopback':
Error: nxlooper_main.c:209:9: error: implicit declaration of function 'nxlooper_loopraw'; did you mean 'nxlooper_stop'? [-Werror=implicit-function-declaration]
  209 |   ret = nxlooper_loopraw(plooper, channels, bpsamp,
      |         ^~~~~~~~~~~~~~~~
      |         nxlooper_stop
```

## Impact
Make https://github.com/apache/incubator-nuttx/pull/4108 pass CI

## Testing

