### PR TITLE
system/cu: fix setting termios with parity

### DIFF
--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -146,14 +146,16 @@ static int set_termios(int fd, int rate, enum parity_mode parity,
 
   tio = g_tio_dev;
 
+  tio.c_cflag &= ~(PARENB | PARODD | CRTSCTS);
+
   switch (parity)
     {
       case PARITY_EVEN:
-        tio.c_cflag = PARENB;
+        tio.c_cflag |= PARENB;
         break;
 
       case PARITY_ODD:
-        tio.c_cflag = PARENB | PARODD;
+        tio.c_cflag |= PARENB | PARODD;
         break;
 
       case PARITY_NONE:


### PR DESCRIPTION
Clear only the bits in `c_cflag` that will be set by cu.

Otherwise if even or odd parity is set all other bits of `c_cflag` will be cleared.
Including `CS8` default character size. And this will leads in the end to the error `EINVAL` in sanity checks on termios setting in `up_ioctl()` in stm32_serial:
https://github.com/apache/incubator-nuttx/blob/02a6966ad5de551a9f2adb0f97c21d404170c79b/arch/arm/src/stm32/stm32_serial.c#L2349-L2360


