### PR TITLE
Revert "webclient: Don't call the sink callback if no data is available"

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -1063,11 +1063,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
                    * received file.
                    */
 
-                  if (ws->offset == ws->datend)
-                    {
-                      /* We don't have data to give to the client yet. */
-                    }
-                  else if (ctx->sink_callback)
+                  if (ctx->sink_callback)
                     {
                       ret = ctx->sink_callback(&ws->buffer, ws->offset,
                                                ws->datend, &ws->buflen,


### PR DESCRIPTION
## Summary
This PR intends to revert commit ee1f4fdcdbbfbb02f4e9e9970b27e45a95a724e7.

After the mentioned commit an application no longer receives the HTTP header via the `sink_callback` when the amount of received bytes equals the size of the HTTP header (`ws->offset == ws->datend`).
This creates an issue for applications that requires information contained on the HTTP header (e.g., the value of `Content-Length`).
On the other hand, the same filtering from ee1f4fdcdbbfbb02f4e9e9970b27e45a95a724e7 could be performed by the application during the handling of the `sink_callback`, maintaining the same current behavior.

## Impact
Users of `webclient` application.

## Testing
Custom application.