### PR TITLE
netutils/webclient: Notify HTTP header data via dedicated callback

### DIFF
--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -47,6 +47,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
+#include <stdbool.h>
 #include <sys/types.h>
 
 /****************************************************************************
@@ -103,7 +105,7 @@
 typedef void (*wget_callback_t)(FAR char **buffer, int offset,
                                 int datend, FAR int *buflen, FAR void *arg);
 
-/* webclient_sink_callback_t: callback to consume data
+/* webclient_sink_callback_t: callback to consume body data
  *
  * Same as wget_callback_t, but allowed to fail.
  *
@@ -118,6 +120,20 @@ typedef void (*wget_callback_t)(FAR char **buffer, int offset,
 typedef CODE int (*webclient_sink_callback_t)(FAR char **buffer, int offset,
                                               int datend, FAR int *buflen,
                                               FAR void *arg);
+
+/* webclient_header_callback_t: callback to consume header data
+ *
+ * Input Parameters:
+ *   line        - A NULL-terminated string containing a header line.
+ *   truncated   - Flag for indicating whether the received header line is
+ *                 truncated for exceeding the CONFIG_WEBCLIENT_MAXHTTPLINE
+ *                 length limit.
+ *   arg         - User argument passed to callback.
+ */
+
+typedef CODE int (*webclient_header_callback_t)(FAR const char *line,
+                                                bool truncated,
+                                                FAR void *arg);
 
 /* webclient_body_callback_t: a callback to provide request body
  *
@@ -239,6 +255,8 @@ struct webclient_context
   wget_callback_t callback;
   webclient_sink_callback_t sink_callback;
   FAR void *sink_callback_arg;
+  webclient_header_callback_t header_callback;
+  FAR void *header_callback_arg;
   webclient_body_callback_t body_callback;
   FAR void *body_callback_arg;
   FAR const struct webclient_tls_ops *tls_ops;

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -519,7 +519,8 @@ static int parseurl(FAR const char *url, FAR struct wget_s *ws)
  * Name: wget_parseheaders
  ****************************************************************************/
 
-static inline int wget_parseheaders(struct wget_s *ws)
+static inline int wget_parseheaders(struct webclient_context *ctx,
+                                    struct wget_s *ws)
 {
   int offset;
   int ndx;
@@ -559,6 +560,7 @@ static inline int wget_parseheaders(struct wget_s *ws)
               ninfo("Got HTTP header line%s: %.*s\n",
                     got_nl ? "" : " (truncated)",
                     ndx - 1, &ws->line[0]);
+
               if (ws->line[0] == ISO_CR)
                 {
                   /* This was the last header line (i.e., and empty "\r\n"),
@@ -595,6 +597,16 @@ static inline int wget_parseheaders(struct wget_s *ws)
 
                   nerr("ERROR: invalid header\n");
                   return -EPROTO;
+                }
+
+              if (ctx->header_callback)
+                {
+                  ret = ctx->header_callback(&ws->line[0], !got_nl,
+                                             ctx->header_callback_arg);
+                  if (ret != 0)
+                    {
+                      goto exit;
+                    }
                 }
 
               /* Check for specific HTTP header fields. */
@@ -1046,7 +1058,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
 
           if (ws->state == WEBCLIENT_STATE_HEADERS)
             {
-              ret = wget_parseheaders(ws);
+              ret = wget_parseheaders(ctx, ws);
               if (ret < 0)
                 {
                   goto errout_with_errno;


### PR DESCRIPTION
## Summary
This PR intends to add a new API for notifying the application of received HTTP header data.

The application shall register a callback function for receiving the HTTP header data line-by-line.

These changes were implemented after joint discussion on https://github.com/apache/incubator-nuttx-apps/pull/809#issuecomment-884600636 with @yamt.

## Impact
New API to `webclient` library, should bring no impact to users if not explicitly used.

## Testing
Custom application.
