### PR TITLE
testing: Remove duplicate pthread_barrierattr_init calls.

### DIFF
--- a/testing/ostest/barrier.c
+++ b/testing/ostest/barrier.c
@@ -118,7 +118,7 @@ void barrier_test(void)
                                 CONFIG_TESTING_OSTEST_NBARRIER_THREADS);
   if (status != OK)
     {
-      printf("barrier_test: pthread_barrierattr_init failed, status=%d\n",
+      printf("barrier_test: pthread_barrier_init failed, status=%d\n",
              status);
     }
 

--- a/testing/ostest/barrier.c
+++ b/testing/ostest/barrier.c
@@ -107,6 +107,8 @@ void barrier_test(void)
 
   printf("barrier_test: Initializing barrier\n");
 
+  /* Create the barrier */
+
   status = pthread_barrierattr_init(&barrierattr);
   if (status != OK)
     {
@@ -121,10 +123,6 @@ void barrier_test(void)
       printf("barrier_test: pthread_barrier_init failed, status=%d\n",
              status);
     }
-
-  /* Create the barrier */
-
-  pthread_barrierattr_init(&barrierattr);
 
   /* Start CONFIG_TESTING_OSTEST_NBARRIER_THREADS thread instances */
 

--- a/testing/smp/smp_main.c
+++ b/testing/smp/smp_main.c
@@ -235,7 +235,7 @@ int main(int argc, FAR char *argv[])
                              CONFIG_TESTING_SMP_NBARRIER_THREADS);
   if (ret != OK)
     {
-      printf("  Main[0]: pthread_barrierattr_init failed, ret=%d\n",
+      printf("  Main[0]: pthread_barrier_init failed, ret=%d\n",
              ret);
 
       errcode = EXIT_FAILURE;

--- a/testing/smp/smp_main.c
+++ b/testing/smp/smp_main.c
@@ -221,6 +221,8 @@ int main(int argc, FAR char *argv[])
   show_cpu("  Main", 0);
   printf("  Main[0]: Initializing barrier\n");
 
+  /* Create the barrier */
+
   ret = pthread_barrierattr_init(&barrierattr);
   if (ret != OK)
     {
@@ -241,10 +243,6 @@ int main(int argc, FAR char *argv[])
       errcode = EXIT_FAILURE;
       goto errout_with_attr;
     }
-
-  /* Create the barrier */
-
-  pthread_barrierattr_init(&barrierattr);
 
   /* Start CONFIG_TESTING_SMP_NBARRIER_THREADS thread instances */
 


### PR DESCRIPTION
## Summary
testing: Remove duplicate pthread_barrierattr_init calls.
## Impact
SMP and ostest programs.
## Testing
esp32-devkitc:smp
esp32-devkic:ostest

