### PR TITLE
system/embedlog: Fix sed command usage for macOS

### DIFF
--- a/system/embedlog/Makefile
+++ b/system/embedlog/Makefile
@@ -230,9 +230,10 @@ $(EMBEDLOG_SOURCES)/include/embedlog.h: $(EMBEDLOG_SOURCES)/include/embedlog.h.i
 	    -e "s/@ENABLE_OUT_TTY@/$(CONFIG_EMBEDLOG_ENABLE_OUT_TTY)/" \
 	    -e "s/@ENABLE_PREFIX@/$(CONFIG_EMBEDLOG_ENABLE_PREFIX)/" \
 	    -e "s/@ENABLE_OUT_CUSTOM@/$(CONFIG_EMBEDLOG_ENABLE_OUT_CUSTOM)/" \
-	    -e "s/@ENABLE_PTHREAD@/$(CONFIG_EMBEDLOG_ENABLE_PTHREAD)/" $< > $@
-	$(Q) sed -i -e "s/^#if y$$/#if 1/" \
-	    -e "s/^#if $$/#if 0/" -e "s/^#if n$$/#if 0/" $@
+	    -e "s/@ENABLE_PTHREAD@/$(CONFIG_EMBEDLOG_ENABLE_PTHREAD)/" \
+	    -e "s/^#if y$$/#if 1/" \
+	    -e "s/^#if $$/#if 0/" \
+	    -e "s/^#if n$$/#if 0/" $< > $@
 
 create_includes: $(EMBEDLOG_SOURCES)/include/embedlog.h
 	$(Q) $(CP) $< $(APPDIR)/include/system


### PR DESCRIPTION
## Summary
The `sed` command only with `-i` option has not been supported
on macOS platform, and so it causes build error on macOS.
Fix Makefile so that it passes on all platforms without using
`-i` option.

## Impact
None

## Testing
Build tested embedlog on Linux, Windows and macOS. 
