### PR TITLE
Rename CONFIG_LIB_BOARDCTL to CONFIG_BOARDCTL

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -925,7 +925,7 @@ are not as expected:
 CONFIG_DISABLE_MQUEUE=n
 CONFIG_DISABLE_PTHREAD=n
 CONFIG_NX_BLOCKING=y
-CONFIG_LIB_BOARDCTL=y
+CONFIG_BOARDCTL=y
 ```
 
 ## `nxterm` Display NuttShell (NSH) as NX Console

--- a/examples/adc/Kconfig
+++ b/examples/adc/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_ADC
 	tristate "ADC example"
 	default n
-	depends on ADC && LIB_BOARDCTL
+	depends on ADC && BOARDCTL
 	---help---
 		Enable the ADC example
 

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -50,7 +50,7 @@
  * board_late_initialize() during bootupif CONFIG_BOARD_LATE_INITIALIZE
  * or 2).
  * via a call to boardctl() if the interface is enabled
- * (CONFIG_LIB_BOARDCTL=y).
+ * (CONFIG_BOARDCTL=y).
  * If this task is running as an NSH built-in application, then that
  * initialization has probably already been performed otherwise we do it
  * here.
@@ -58,7 +58,7 @@
 
 #undef NEED_BOARDINIT
 
-#if defined(CONFIG_LIB_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
+#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
 #  define NEED_BOARDINIT 1
 #endif
 

--- a/examples/module/Kconfig
+++ b/examples/module/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_MODULE
 	tristate "Module Example"
 	default n
-	depends on MODULE && LIB_BOARDCTL
+	depends on MODULE && BOARDCTL
 	select BOARDCTL_OS_SYMTAB
 	---help---
 		Enable the module example

--- a/examples/mount/Kconfig
+++ b/examples/mount/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_MOUNT
 	tristate "File system mount example"
 	default n
-	select LIB_BOARDCTL if !EXAMPLES_MOUNT_BLOCKDEVICE
+	select BOARDCTL if !EXAMPLES_MOUNT_BLOCKDEVICE
 	select BOARDCTL_MKRD if !EXAMPLES_MOUNT_BLOCKDEVICE
 	---help---
 		Enable the file system mount example

--- a/examples/nx/Kconfig
+++ b/examples/nx/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_NX
 	tristate "NX graphics example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Enable the NX graphics example
 

--- a/examples/nxdemo/Kconfig
+++ b/examples/nxdemo/Kconfig
@@ -53,7 +53,7 @@ endif
 config EXAMPLES_NXDEMO_EXTERNINIT
 	bool "External Device Initialization"
 	default n
-	depends on LIB_BOARDCTL
+	depends on BOARDCTL
 	select BOARDCTL_GRAPHICS
 	---help---
 		The driver for the graphics device on this platform requires some
@@ -67,7 +67,7 @@ config EXAMPLES_NXDEMO_EXTERNINIT
 		FAR struct fb_vtable_s *board_graphics_setup(unsigned int devno);
 		#endif
 
-		and must also define: CONFIG_LIB_BOARDCTL=y and
+		and must also define: CONFIG_BOARDCTL=y and
 		CONFIG_BOARDCTL_GRAPHICS=y so that the boardctl() interface
 		will be available in order to access this function.
 

--- a/examples/nxhello/Kconfig
+++ b/examples/nxhello/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_NXHELLO
 	tristate "NX graphics \"Hello, World!\" example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Enable the NX graphics \"Hello, World!\" example
 

--- a/examples/nximage/Kconfig
+++ b/examples/nximage/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_NXIMAGE
 	tristate "NX graphics image example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Enable the X graphics image example
 

--- a/examples/nxlines/Kconfig
+++ b/examples/nxlines/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_NXLINES
 	tristate "NX graphics lines example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Enable the X graphics lines example
 

--- a/examples/nxterm/Kconfig
+++ b/examples/nxterm/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_NXTERM
 	tristate "NxTerm example"
 	default n
 	depends on NXTERM
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Enable the NxTerm example
 

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -69,8 +69,8 @@
 #  error "You must not disable loadable modules via CONFIG_BINFMT_DISABLE in your configuration file"
 #endif
 
-#ifndef CONFIG_LIB_BOARDCTL
-#  error "This configuration requires CONFIG_LIB_BOARDCTL"
+#ifndef CONFIG_BOARDCTL
+#  error "This configuration requires CONFIG_BOARDCTL"
 #endif
 
 #ifndef CONFIG_BOARDCTL_APP_SYMTAB

--- a/examples/pwfb/Kconfig
+++ b/examples/pwfb/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_PWFB
 	tristate "NX Per-Window Framebuffer Text Example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	select NX_RAMBACKED
 	---help---
 		Enable the NX per-window framebuffer example

--- a/examples/pwlines/Kconfig
+++ b/examples/pwlines/Kconfig
@@ -7,7 +7,7 @@ config EXAMPLES_PWLINES
 	tristate "NX Per-Window Framebuffer Graphics Example"
 	default n
 	depends on NX
-	select LIB_BOARDCTL
+	select BOARDCTL
 	select NX_RAMBACKED
 	---help---
 		Enable the NX per-window framebuffer example

--- a/examples/usbserial/Kconfig
+++ b/examples/usbserial/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_USBSERIAL
 	tristate "USB serial test example"
 	default n
-	depends on LIB_BOARDCTL
+	depends on BOARDCTL
 	select BOARDCTL_USBDEVCTRL
 	---help---
 		Enable the USB serial test example

--- a/graphics/nxwm/src/nxwm_main.cxx
+++ b/graphics/nxwm/src/nxwm_main.cxx
@@ -498,12 +498,12 @@ static bool createMediaPlayer(void)
 
 int main(int argc, char *argv[])
 {
-#if defined(CONFIG_LIB_BOARDCTL) && !defined(CONFIG_BOARD_LATE_INITIALIZE)
+#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_BOARD_LATE_INITIALIZE)
   // Should we perform board-specific initialization?  There are two ways
   // that board initialization can occur:  1) automatically via
   // board_late_initialize() during bootup if CONFIG_BOARD_LATE_INITIALIZE, or
   // 2) here via a call to boardctl() if the interface is enabled
-  // (CONFIG_LIB_BOARDCTL=y).
+  // (CONFIG_BOARDCTL=y).
 
   boardctl(BOARDIOC_INIT, 0);
 #endif

--- a/graphics/twm4nx/Kconfig
+++ b/graphics/twm4nx/Kconfig
@@ -45,7 +45,7 @@ config TWM4NX_REVMINOR
 config TWM4NX_ARCHINIT
 	bool "Have architecture-specific initialization"
 	default n
-	select LIB_BOARDCTL
+	select BOARDCTL
 	depends on !NSH_ARCHINIT
 	---help---
 		Set if your board provides architecture specific initialization

--- a/graphics/twm4nx/src/twm4nx_main.cxx
+++ b/graphics/twm4nx/src/twm4nx_main.cxx
@@ -112,13 +112,13 @@ int main(int argc, FAR char *argv[])
 
   int ret;
 
-#if defined(CONFIG_TWM4NX_ARCHINIT) && defined(CONFIG_LIB_BOARDCTL) && \
+#if defined(CONFIG_TWM4NX_ARCHINIT) && defined(CONFIG_BOARDCTL) && \
    !defined(CONFIG_BOARD_LATE_INITIALIZE)
   // Should we perform board-specific initialization?  There are two ways
   // that board initialization can occur:  1) automatically via
   // board_late_initialize() during bootup if CONFIG_BOARD_LATE_INITIALIZE, or
   // 2) here via a call to boardctl() if the interface is enabled
-  // (CONFIG_LIB_BOARDCTL=y).  board_early_initialize() is also possibility,
+  // (CONFIG_BOARDCTL=y).  board_early_initialize() is also possibility,
   // although less likely.
 
   ret = boardctl(BOARDIOC_INIT, 0);

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -12,7 +12,7 @@ config NSH_LIBRARY
 	select NETUTILS_NETLIB if NET
 	select LIBC_NETDB if NET
 	select READLINE_HAVE_EXTMATCH
-	select LIB_BOARDCTL if (!NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT) || NSH_ARCHINIT || NSH_ROMFSETC
+	select BOARDCTL if (!NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT) || NSH_ARCHINIT || NSH_ROMFSETC
 	select BOARDCTL_MKRD if !NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT
 	select BOARDCTL_ROMDISK if NSH_ROMFSETC
 	---help---
@@ -916,7 +916,7 @@ config NSH_CONSOLE
 config NSH_USBCONSOLE
 	bool "Use a USB serial console"
 	default n
-	depends on LIB_BOARDCTL && NSH_CONSOLE && USBDEV && (CDCACM || PL2303)
+	depends on BOARDCTL && NSH_CONSOLE && USBDEV && (CDCACM || PL2303)
 	select BOARDCTL_USBDEVCTRL
 	---help---
 		If defined, then the an arbitrary USB serial device may be used
@@ -1103,7 +1103,7 @@ endmenu # USB Device Trace Support
 config NSH_ARCHINIT
 	bool "Have architecture-specific initialization"
 	default n
-	select LIB_BOARDCTL
+	select BOARDCTL
 	---help---
 		Set if your board provides architecture specific initialization
 		via the board-interface function boardctl().  The boardctl()

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -835,14 +835,14 @@ int nsh_loginscript(FAR struct nsh_vtbl_s *vtbl);
 
 /* Architecture-specific initialization depends on boardctl(BOARDIOC_INIT) */
 
-#if defined(CONFIG_NSH_ARCHINIT) && !defined(CONFIG_LIB_BOARDCTL)
-#  warning CONFIG_NSH_ARCHINIT is set, but CONFIG_LIB_BOARDCTL is not
+#if defined(CONFIG_NSH_ARCHINIT) && !defined(CONFIG_BOARDCTL)
+#  warning CONFIG_NSH_ARCHINIT is set, but CONFIG_BOARDCTL is not
 #  undef CONFIG_NSH_ARCHINIT
 #endif
 
 /* The mkrd command depends on boardctl(BOARDIOC_MKRD) */
 
-#if !defined(CONFIG_LIB_BOARDCTL) || !defined(CONFIG_BOARDCTL_MKRD)
+#if !defined(CONFIG_BOARDCTL) || !defined(CONFIG_BOARDCTL_MKRD)
 #  undef CONFIG_NSH_DISABLE_MKRD
 #  define CONFIG_NSH_DISABLE_MKRD 1
 #endif

--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -142,7 +142,7 @@ config ADBD_FILE_SYMLINK
 
 config ADBD_BOARD_INIT
 	bool "Board initialization"
-	depends on LIB_BOARDCTL
+	depends on BOARDCTL
 	default n
 	---help---
 		Setup board before running adb daemon.

--- a/system/cdcacm/Kconfig
+++ b/system/cdcacm/Kconfig
@@ -6,7 +6,7 @@
 menuconfig SYSTEM_CDCACM
 	tristate "USB CDC/ACM Device Commands"
 	default n
-	depends on LIB_BOARDCTL && CDCACM
+	depends on BOARDCTL && CDCACM
 	select BOARDCTL_USBDEVCTRL
 	---help---
 		Enable the USB CDC/ACM class controls.  These controls include:

--- a/system/composite/Kconfig
+++ b/system/composite/Kconfig
@@ -6,7 +6,7 @@
 menuconfig SYSTEM_COMPOSITE
 	tristate "USB Composite Device Commands"
 	default n
-	depends on LIB_BOARDCTL && USBDEV_COMPOSITE && BUILD_FLAT
+	depends on BOARDCTL && USBDEV_COMPOSITE && BUILD_FLAT
 	select BOARDCTL_USBDEVCTRL
 	---help---
 		Enable the USB composite class controls.  These controls include:

--- a/system/nsh/Kconfig
+++ b/system/nsh/Kconfig
@@ -24,7 +24,7 @@ config SYSTEM_NSH_STACKSIZE
 config SYSTEM_NSH_SYMTAB
 	bool "Register symbol table"
 	default n
-	depends on LIBC_EXECFUNCS && LIB_BOARDCTL && !EXECFUNCS_HAVE_SYMTAB
+	depends on LIBC_EXECFUNCS && BOARDCTL && !EXECFUNCS_HAVE_SYMTAB
 	select BOARDCTL_APP_SYMTAB
 	---help---
 		Enable logic to automatically register an application symbol table

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -51,7 +51,7 @@
  * support.
  */
 
-#if !defined(CONFIG_LIB_BOARDCTL) || !defined(CONFIG_BOARDCTL_APP_SYMTAB)
+#if !defined(CONFIG_BOARDCTL) || !defined(CONFIG_BOARDCTL_APP_SYMTAB)
 #  undef CONFIG_SYSTEM_NSH_SYMTAB
 #endif
 

--- a/system/usbmsc/Kconfig
+++ b/system/usbmsc/Kconfig
@@ -6,7 +6,7 @@
 menuconfig SYSTEM_USBMSC
 	tristate "USB Mass Storage Device Commands"
 	default n
-	depends on LIB_BOARDCTL && USBMSC && BUILD_FLAT
+	depends on BOARDCTL && USBMSC && BUILD_FLAT
 	select BOARDCTL_USBDEVCTRL
 	---help---
 		Enable the USB mass storage class controls.  These controls include:

--- a/system/usbmsc/README.md
+++ b/system/usbmsc/README.md
@@ -21,7 +21,7 @@ Configuration options:
   commands if this option is selected: `msconn` will connect the USB mass
   storage device; `msdis` will disconnect the USB storage device.
 
-- `CONFIG_LIB_BOARDCTL` – Enables the `boardctl()` interfaces.
+- `CONFIG_BOARDCTL` – Enables the `boardctl()` interfaces.
 
 - `CONFIG_BOARDCTL_USBDEVCTRL` – Enables the `BOARDIOC_USBDEV_CONTROL`
   `boardctl()` command.


### PR DESCRIPTION
## Summary
since boardctl isn't a libc feature

## Impact
Follow up the kernel change: https://github.com/apache/incubator-nuttx/pull/4266

## Testing
Pass CI

