### PR TITLE
Rename LIB_ to LIBC_ for all libc Kconfig 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -544,7 +544,7 @@ This is a simple test to `debug/verify` the USB host HID keyboard class driver.
   These special keys include such things as up/down arrows, home and end keys,
   etc. If this not defined, only 7-bit printable and control ASCII characters
   will be provided to the user. Requires `CONFIG_HIDKBD_ENCODED` and
-  `CONFIG_LIB_KBDCODEC`.
+  `CONFIG_LIBC_KBDCODEC`.
 
 ## `igmp` Trivial IGMP
 

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -117,7 +117,7 @@ static const char delimiter[] =
   "**************************************"
   "**************************************";
 
-#ifndef CONFIG_LIB_ENVPATH
+#ifndef CONFIG_LIBC_ENVPATH
 static char fullpath[128];
 #endif
 
@@ -315,7 +315,7 @@ int main(int argc, FAR char *argv[])
 
   mm_update(&g_mmstep, "after mount");
 
-#if defined(CONFIG_LIB_ENVPATH) && defined(MOUNTPT)
+#if defined(CONFIG_LIBC_ENVPATH) && defined(MOUNTPT)
   /* Does the system support the PATH variable?
    * If YES, then set the PATH variable to the ROMFS mountpoint.
    */
@@ -341,7 +341,7 @@ int main(int argc, FAR char *argv[])
        * search the PATH variable to find the executable.
        */
 
-#ifdef CONFIG_LIB_ENVPATH
+#ifdef CONFIG_LIBC_ENVPATH
       filename = dirlist[i];
 #else
       snprintf(fullpath, 128, "%s/%s", MOUNTPT, dirlist[i]);

--- a/examples/hidkbd/Kconfig
+++ b/examples/hidkbd/Kconfig
@@ -35,7 +35,7 @@ config EXAMPLES_HIDKBD_DEVNAME
 config EXAMPLES_HIDKBD_ENCODED
 	bool "Encode Special Keys"
 	default y
-	depends on HIDKBD_ENCODED && LIB_KBDCODEC
+	depends on HIDKBD_ENCODED && LIBC_KBDCODEC
 	---help---
 		Decode special key press events in the user buffer.  In this case,
 		the example coded will use the interfaces defined in

--- a/examples/hidkbd/hidkbd_main.c
+++ b/examples/hidkbd/hidkbd_main.c
@@ -53,7 +53,7 @@
 #  define CONFIG_EXAMPLES_HIDKBD_DEVNAME "/dev/kbda"
 #endif
 
-#if !defined(CONFIG_HIDKBD_ENCODED) || !defined(CONFIG_LIB_KBDCODEC)
+#if !defined(CONFIG_HIDKBD_ENCODED) || !defined(CONFIG_LIBC_KBDCODEC)
 #  undef CONFIG_EXAMPLES_HIDKBD_ENCODED
 #endif
 

--- a/examples/nxflat/nxflat_main.c
+++ b/examples/nxflat/nxflat_main.c
@@ -96,7 +96,7 @@ static const char delimiter[] =
   "**************************************"
   "**************************************";
 
-#ifndef CONFIG_LIB_ENVPATH
+#ifndef CONFIG_LIBC_ENVPATH
 static char fullpath[128];
 #endif
 
@@ -168,7 +168,7 @@ int main(int argc, FAR char *argv[])
              ROMFSDEV, MOUNTPT, errno);
     }
 
-#if defined(CONFIG_LIB_ENVPATH) && !defined(CONFIG_PATH_INITIAL)
+#if defined(CONFIG_LIBC_ENVPATH) && !defined(CONFIG_PATH_INITIAL)
   /* Does the system support the PATH variable?  Has the PATH variable
    * already been set?  If YES and NO, then set the PATH variable to
    * the ROMFS mountpoint.
@@ -195,7 +195,7 @@ int main(int argc, FAR char *argv[])
        * search the PATH variable to find the executable.
        */
 
-#ifdef CONFIG_LIB_ENVPATH
+#ifdef CONFIG_LIBC_ENVPATH
       filename = dirlist[i];
 #else
       snprintf(fullpath, 128, "%s/%s", MOUNTPT, dirlist[i]);

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -256,7 +256,7 @@ int main(int argc, FAR char *argv[])
    * the ROMFS mountpoint.
    */
 
-#if defined(CONFIG_LIB_ENVPATH) && !defined(CONFIG_PATH_INITIAL)
+#if defined(CONFIG_LIBC_ENVPATH) && !defined(CONFIG_PATH_INITIAL)
   setenv("PATH", MOUNTPT, 1);
 #endif
 
@@ -302,7 +302,7 @@ int main(int argc, FAR char *argv[])
    * search the PATH variable to find the executable.
    */
 
-#ifdef CONFIG_LIB_ENVPATH
+#ifdef CONFIG_LIBC_ENVPATH
   filepath = g_hello_argv[0];
 #else
   snprintf(fullpath, 128, "%s/%s", MOUNTPT, g_hello_argv[0]);
@@ -401,7 +401,7 @@ int main(int argc, FAR char *argv[])
    * search the PATH variable to find the executable.
    */
 
-#ifdef CONFIG_LIB_ENVPATH
+#ifdef CONFIG_LIBC_ENVPATH
   filepath = g_redirect_argv[0];
 #else
   snprintf(fullpath, 128, "%s/%s", MOUNTPT, g_redirect_argv[0]);

--- a/examples/sendmail/sendmail_main.c
+++ b/examples/sendmail/sendmail_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/sendmail/sendmail_maini.c
+ * apps/examples/sendmail/sendmail_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -148,7 +148,7 @@ int main(int argc, FAR char *argv[])
   handle = smtp_open();
   if (handle)
     {
-      smtp_configure(handle, CONFIG_LIB_HOSTNAME, &addr.s_addr, &port);
+      smtp_configure(handle, CONFIG_LIBC_HOSTNAME, &addr.s_addr, &port);
       smtp_send(handle, g_recipient, NULL, g_sender, g_subject,
                 g_msg_body, strlen(g_msg_body));
       smtp_close(handle);

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -404,7 +404,7 @@ All of the startup-behavior is contained in `rcS.template`. The role of
   - `cd -` sets the current working directory to the previous working directory
        (`$OLDPWD`). Equivalent to `cd $OLDPWD`.
   - `cd` or `cd ~` set the current working directory to the _home_ directory.
-       The _home_ directory can be configured by setting `CONFIG_LIB_HOMEDIR` in
+       The _home_ directory can be configured by setting `CONFIG_LIBC_HOMEDIR` in
        the configuration file. The default _home_ directory is `/`.
   - `cd ..` sets the current working directory to the parent directory.
 

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -462,8 +462,8 @@
 
 /* Make sure that the home directory is defined */
 
-#ifndef CONFIG_LIB_HOMEDIR
-# define CONFIG_LIB_HOMEDIR "/"
+#ifndef CONFIG_LIBC_HOMEDIR
+# define CONFIG_LIBC_HOMEDIR "/"
 #endif
 
 #undef NSH_HAVE_VARS

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -44,7 +44,7 @@ static const char g_pwd[]    = "PWD";
 #ifndef CONFIG_NSH_DISABLE_CD
 static const char g_oldpwd[] = "OLDPWD";
 #endif
-static const char g_home[]   = CONFIG_LIB_HOMEDIR;
+static const char g_home[]   = CONFIG_LIBC_HOMEDIR;
 #endif
 
 /****************************************************************************

--- a/system/hex2bin/Kconfig
+++ b/system/hex2bin/Kconfig
@@ -6,7 +6,7 @@
 menuconfig SYSTEM_HEX2BIN
 	tristate "Intel HEX to binary conversion"
 	default n
-	select LIB_HEX2BIN
+	select LIBC_HEX2BIN
 	---help---
 		Enable support for a logic to convert Intel HEX format to binary.
 


### PR DESCRIPTION
## Summary
follow other libc component naming convention

## Impact
Follow up the kernel change: apache/incubator-nuttx#4267

## Testing
Pass CI.
