### PR TITLE
netlib: Change the type of url_s:port to uint16_t

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -221,7 +221,7 @@ struct url_s
 #endif
   FAR char *host;
   int       hostlen;
-  int       port;
+  uint16_t  port;
   FAR char *path;
   int       pathlen;
 #if 0 /* not yet */

--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  apps/include/netutils/netlib.h
+ * apps/include/netutils/netlib.h
  * Various non-standard APIs to support netutils.  All non-standard and
  * intended only for internal use.
  *


### PR DESCRIPTION
## Summary

uint16_t is what's used in netlib and webclient in most of places.
There is a static analizer complaining on the type mismatch.
(It's actually harmless as far as I understand though.)

## Impact

strictly speaking, this is an api change.

## Testing

compile tested