### PR TITLE
canutils: libcanutils: add GPL build barrier

### DIFF
--- a/canutils/libcanutils/Kconfig
+++ b/canutils/libcanutils/Kconfig
@@ -6,7 +6,7 @@
 config CANUTILS_LIBCANUTILS
 	bool "CAN-utils support library"
 	default n
-	depends on NET_CAN
+	depends on NET_CAN && ALLOW_GPL_COMPONENTS
 	---help---
 		Enable the CAN-utils support library ported from
 		https://github.com/linux-can/can-utils


### PR DESCRIPTION
## Summary
Exclude libcanutils from build unless the license is set to
allow GPL code in the build.

NOTE
Depends on
https://github.com/apache/incubator-nuttx/pull/4352

## Impact
LICENSE

## Testing
Compiled
