### PR TITLE
boot/mcuboot: Deactivate warnings to enable build of MCUboot library

### DIFF
--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -14,7 +14,7 @@ if BOOT_MCUBOOT
 
 config MCUBOOT_VERSION
 	string "MCUboot version"
-	default "01184bd0361c4128c6382aa9c640b02e7f1422f6"
+	default "fca1aa4764eef4da008aeaf7e570184281aa79fa"
 
 config MCUBOOT_ENABLE_LOGGING
 	bool "Enable MCUboot logging"

--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -50,6 +50,8 @@ PRIORITY  = SCHED_PRIORITY_DEFAULT
 STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
 endif
 
+CFLAGS += -Wno-undef
+
 CSRCS := mcuboot/boot/bootutil/src/boot_record.c \
          mcuboot/boot/bootutil/src/bootutil_misc.c \
          mcuboot/boot/bootutil/src/bootutil_public.c \


### PR DESCRIPTION
## Summary
This PR intends to deactivate some of the warnings emitted by the compiler when building the MCUboot library.

## Impact
CI build from https://github.com/apache/incubator-nuttx/pull/4324 was complaining due to `-Werror`.

## Testing
CI build pass.
