### PR TITLE
system/termcurses: Add terminate operation into the termcurses_ops_s interface

### DIFF
--- a/include/system/termcurses.h
+++ b/include/system/termcurses.h
@@ -110,6 +110,10 @@ struct termcurses_ops_s
   /* Check for cached keycode value */
 
   CODE bool (*checkkey)(FAR struct termcurses_s *dev);
+
+  /* Terminate  */
+
+  CODE int (*terminate)(FAR struct termcurses_s *dev);
 };
 
 struct termcurses_dev_s
@@ -157,7 +161,7 @@ extern "C"
  ****************************************************************************/
 
 int termcurses_initterm(FAR const char *term_type, int in_fd, int out_fd,
-                        FAR struct termcurses_s **dev);
+                        FAR struct termcurses_s **term);
 
 /****************************************************************************
  * Name: termcurses_deinitterm
@@ -168,7 +172,7 @@ int termcurses_initterm(FAR const char *term_type, int in_fd, int out_fd,
  *
  ****************************************************************************/
 
-int termcurses_deinitterm(FAR struct termcurses_s *dev);
+int termcurses_deinitterm(FAR struct termcurses_s *term);
 
 /****************************************************************************
  * Name: termcurses_moveyx

--- a/system/termcurses/tcurses_vt100.c
+++ b/system/termcurses/tcurses_vt100.c
@@ -93,6 +93,7 @@ static int tcurses_vt100_setattributes(FAR struct termcurses_s *dev,
 static int tcurses_vt100_getkeycode(FAR struct termcurses_s *dev,
               FAR int *specialkey, FAR int *keymodifers);
 static bool tcurses_vt100_checkkey(FAR struct termcurses_s *dev);
+static int tcurses_vt100_terminate(FAR struct termcurses_s *dev);
 
 /************************************************************************************
  * Private Data
@@ -107,7 +108,8 @@ static const struct termcurses_ops_s g_vt100_ops =
   tcurses_vt100_setcolors,
   tcurses_vt100_setattributes,
   tcurses_vt100_getkeycode,
-  tcurses_vt100_checkkey
+  tcurses_vt100_checkkey,
+  tcurses_vt100_terminate
 };
 
 /* VT100 terminal codes */
@@ -128,6 +130,10 @@ static const char *g_setblink       = ";5";
 static const char *g_setnoblink     = ";25";
 static const char *g_setunderline   = ";4";
 static const char *g_setnounderline = ";24";
+
+/* Set default background and foreground colors. */
+
+static const char *g_setdefcolors   = "\x1b[39;m\x1b[49;m";
 
 struct keycodes_s
 {
@@ -1478,4 +1484,29 @@ FAR struct termcurses_s *tcurses_vt100_initialize(int in_fd, int out_fd)
   priv->keycount = 0;
 
   return (FAR struct termcurses_s *) priv;
+}
+
+/************************************************************************************
+ * Name: tcurses_vt100_terminate
+ *
+ * Description:
+ *   Terminates a specific instance of the VT100 TermCurses handler.
+ *
+ ************************************************************************************/
+
+static int tcurses_vt100_terminate(FAR struct termcurses_s *dev)
+{
+  FAR struct tcurses_vt100_s *priv;
+  int  fd;
+
+  priv = (FAR struct tcurses_vt100_s *) dev;
+  fd   = priv->out_fd;
+
+  /* Set default foreground and background colors.
+   * (Ignore the return result.)
+   */
+
+  write(fd, g_setdefcolors, strlen(g_setdefcolors));
+
+  return OK;
 }


### PR DESCRIPTION
## Summary
system/termcurses: Add terminate operation into the termcurses_ops_s interface
    
The existing implementation of the termcurses_deinitterm calls termcurses_setcolors with some hard-coded values, leading to different terminal emulators' behavior. Instead, a reset call needs to be made to the implementation to roll back changes.
    
A new operation (terminate) has been added to the termcurses_ops interface to achieve this functionality.
    
The vt100's terminate implementation ensures that default foreground and background colors are applied portably across different terminals emulators.

## Impact
Please see the attached screen recordings to see how different terminal emulators behave without fix:
![minicom](https://user-images.githubusercontent.com/2810183/130338226-d2287fa3-d4d9-4a2d-84ae-66f48c0f2685.gif)
![picocom](https://user-images.githubusercontent.com/2810183/130338227-96fb6020-158f-472d-88e6-abf04e1ffa07.gif)

## Test
The changes have been tested on minicom, picocom, and gtkterm. All worked well with these changes.