### PR TITLE
sensortest: modify errno type when api not support

### DIFF
--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -277,7 +277,7 @@ int main(int argc, FAR char *argv[])
   if (ret < 0)
     {
       ret = -errno;
-      if (ret != -ENOTTY)
+      if (ret != -ENOTSUP)
         {
           printf("Failed to set interval for sensor:%s, ret:%s\n",
                  devname, strerror(errno));
@@ -289,7 +289,7 @@ int main(int argc, FAR char *argv[])
   if (ret < 0)
     {
       ret = -errno;
-      if (ret != -ENOTTY)
+      if (ret != -ENOTSUP)
         {
           printf("Failed to batch for sensor:%s, ret:%s\n",
                  devname, strerror(errno));
@@ -301,7 +301,7 @@ int main(int argc, FAR char *argv[])
   if (ret < 0)
     {
       ret = -errno;
-      if (ret != -ENOTTY)
+      if (ret != -ENOTSUP)
         {
           printf("Failed to enable sensor:%s, ret:%s\n",
                  devname, strerror(errno));


### PR DESCRIPTION
## Summary
sensortest: modify errno type when api not support
## Impact
return correct errno when api isn't support.
## Testing
daily test
