### PR TITLE
nsh: fix compile break about closing CONFIG_NSH_DISABLESCRIPT

### DIFF
--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -77,7 +77,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
   usbtrace_enable(TRACE_BITSET);
 #endif
 
-#ifdef CONFIG_NSH_ROMFSETC
+#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
   /* Execute the start-up script */
 
   nsh_initscript(&pstate->cn_vtbl);


### PR DESCRIPTION

## Summary
nsh: fix compile break for closing CONFIG_NSH_DISABLESCRIPT
## Impact
N/A
## Testing
compile
