### PR TITLE
examples/wgetjson: fix json buffer concatenation

### DIFF
--- a/examples/wgetjson/wgetjson_main.c
+++ b/examples/wgetjson/wgetjson_main.c
@@ -148,7 +148,7 @@ static int wgetjson_callback(FAR char **buffer, int offset, int datend,
       if (new_json_buff)
         {
           g_json_buff = new_json_buff;
-          memcpy(&g_json_buff[g_json_bufflen - 1], &((*buffer)[offset]),
+          memcpy(&g_json_buff[g_json_bufflen], &((*buffer)[offset]),
                  len);
           g_json_buff[g_json_bufflen + len] = 0;
           g_json_bufflen += org;


### PR DESCRIPTION
## Summary
during a concatenation, the last byte was being lost
## Impact

## Testing
get a big json
