### PR TITLE
SLCAN: Fix incorrect format identifier in print function

### DIFF
--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -258,20 +258,20 @@ int main(int argc, char *argv[])
               if (nbytes == CAN_MTU)
                 {
                   reccount++;
-                  debug_print("R%d, Id:0x%X\n", reccount, frame.can_id);
+                  debug_print("R%d, Id:0x%lX\n", reccount, frame.can_id);
                   if (frame.can_id & CAN_EFF_FLAG)
                     {
                       /* 29 bit address */
 
                       frame.can_id = frame.can_id & ~CAN_EFF_FLAG;
-                      sprintf(sbuf, "T%08X%d", frame.can_id, frame.len);
+                      sprintf(sbuf, "T%08lX%d", frame.can_id, frame.len);
                       sbp = &sbuf[10];
                     }
                   else
                     {
                       /* 11 bit address */
 
-                      sprintf(sbuf, "t%03X%d", frame.can_id, frame.len);
+                      sprintf(sbuf, "t%03lX%d", frame.can_id, frame.len);
                       sbp = &sbuf[5];
                     }
 


### PR DESCRIPTION
## Summary

Fixes an incorrect format identifier in print functions in the SLCAN code. The variable is of type unsigned long, but the identifier corresponds to a standard unsigned type (hexadecimal): %X needs to be changed to %lX to prevent a compiler warning.

## Impact

This prevents a warning that for example causes this PR to fail the checks: https://github.com/apache/incubator-nuttx/pull/4560

## Testing

Builds without warnings/errors now.
