### PR TITLE
wapi: add 5g channel map in wapi

### DIFF
--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -365,6 +365,10 @@ static int wapi_scan_event(FAR struct iw_event *event,
               {
                 info->freq = 2484;
               }
+            else if (event->u.freq.m >= 36 && event->u.freq.m <= 165)
+              {
+                info->freq = 5000 + 5 * event->u.freq.m;
+              }
           }
         else
           {


### PR DESCRIPTION
## Summary
scan result only process channel 1~14, and no process for 5g channel

## Impact
wapi scan result can only show 2g channel

## Testing
local test with brcm 43013 chip which can search 5g channel and result is pass
