### PR TITLE
chat: Replace _info with ninfo to avoid polluting the nsh

### DIFF
--- a/netutils/chat/chat.c
+++ b/netutils/chat/chat.c
@@ -157,14 +157,14 @@ static int chat_tokenise(FAR struct chat *priv,
 
     tok_pos = 0;
 
-    _info("%s (%d)\n", tok->string, tok->no_termin);
+    ninfo("%s (%d)\n", tok->string, tok->no_termin);
     return 0;
   }
 
   /* Tokenizer start */
 
   DEBUGASSERT(script != NULL);
-  _info("%s\n", script);
+  ninfo("%s\n", script);
 
   while (!ret && *cursor != '\0')
     {
@@ -282,7 +282,7 @@ static int chat_tokenise(FAR struct chat *priv,
       ret = tok_on_delimiter();
     }
 
-  _info("result %d\n", ret);
+  ninfo("result %d\n", ret);
   return ret;
 }
 
@@ -300,7 +300,7 @@ static int chat_internalise(FAR struct chat *priv,
   while (tok && !ret)
     {
       DEBUGASSERT(tok->string);
-      _info("(%c) %s\n", rhs ? 'R' : 'L', tok->string);
+      ninfo("(%c) %s\n", rhs ? 'R' : 'L', tok->string);
 
       if (!rhs)
         {
@@ -410,7 +410,7 @@ static int chat_internalise(FAR struct chat *priv,
       ret = -ENODATA;
     }
 
-  _info("result %d, rhs %d\n", ret, rhs);
+  ninfo("result %d, rhs %d\n", ret, rhs);
   return ret;
 }
 
@@ -430,7 +430,7 @@ static void chat_tokens_free(FAR struct chat_token *first_tok)
       first_tok = next_tok;
     }
 
-  _info("tokens freed\n");
+  ninfo("tokens freed\n");
 }
 
 /* Main parsing function. */
@@ -467,14 +467,14 @@ static int chat_readb(FAR struct chat *priv, FAR char *c, int timeout_ms)
   ret = poll(&fds, 1, timeout_ms);
   if (ret <= 0)
     {
-      _info("poll timed out\n");
+      ninfo("poll timed out\n");
       return -ETIMEDOUT;
     }
 
   ret = read(priv->ctl.fd, c, 1);
   if (ret != 1)
     {
-      _info("read failed\n");
+      ninfo("read failed\n");
       return -EPERM;
     }
 
@@ -483,7 +483,7 @@ static int chat_readb(FAR struct chat *priv, FAR char *c, int timeout_ms)
       fputc(*c, stderr);
     }
 
-  _info("read \'%c\' (0x%02X)\n", *c, *c);
+  ninfo("read \'%c\' (0x%02X)\n", *c, *c);
   return 0;
 }
 
@@ -491,9 +491,9 @@ static void chat_flush(FAR struct chat *priv)
 {
   char c;
 
-  _info("starting\n");
+  ninfo("starting\n");
   while (chat_readb(priv, (FAR char *) &c, 0) == 0);
-  _info("done\n");
+  ninfo("done\n");
 }
 
 static int chat_expect(FAR struct chat *priv, FAR const char *s)
@@ -545,7 +545,7 @@ static int chat_expect(FAR struct chat *priv, FAR const char *s)
         }
     }
 
-  _info("result %d\n", ret);
+  ninfo("result %d\n", ret);
   return ret;
 }
 
@@ -557,7 +557,7 @@ static int chat_send(FAR struct chat *priv, FAR const char *s)
   /* 'write' returns the number of successfully written characters */
 
   ret = write(priv->ctl.fd, s, len);
-  _info("wrote %d out of %d bytes of \'%s\'\n", ret, len, s);
+  ninfo("wrote %d out of %d bytes of \'%s\'\n", ret, len, s);
   if (ret > 0)
     {
       /* Just SUCCESS */
@@ -574,7 +574,7 @@ static int chat_line_run(FAR struct chat *priv,
   int ret = 0;
   int numarg;
 
-  _info("type %d, rhs %s\n", line->type, line->rhs);
+  ninfo("type %d, rhs %s\n", line->type, line->rhs);
 
   switch (line->type)
     {
@@ -623,11 +623,11 @@ static int chat_line_run(FAR struct chat *priv,
           numarg = atoi(line->rhs);
           if (numarg < 0)
             {
-              _info("invalid timeout string %s\n", line->rhs);
+              ninfo("invalid timeout string %s\n", line->rhs);
             }
           else
             {
-              _info("timeout is %d s\n", numarg);
+              ninfo("timeout is %d s\n", numarg);
               priv->ctl.timeout = numarg;
             }
 
@@ -685,7 +685,7 @@ static int chat_script_run(FAR struct chat *priv)
     }
 
 #ifdef CONFIG_DEBUG_INFO
-  _info("Script result %d, exited on line %d\n", ret, line_num);
+  ninfo("Script result %d, exited on line %d\n", ret, line_num);
 #endif
   return ret;
 }


### PR DESCRIPTION
## Summary
Replace _info with ninfo to avoid polluting the nsh
## Impact
Avoid verbose message in the terminal
## Testing
Building
