### PR TITLE
tools/mksymtab.sh: Fix issue to generate symtab_apps.c for MSYS

### DIFF
--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -42,9 +42,9 @@ prefix=$2
 
 varlist=`find $dir -name *-thunk.S 2>/dev/null | xargs grep -h asciz | cut -f3 | sort | uniq`
 if [ -z "$varlist" ]; then
-  execlist=`find $dir -type f -perm -a=x 2>/dev/null`
+  execlist=`find $dir -type f 2>/dev/null`
   if [ ! -z "$execlist" ]; then
-    varlist=`nm $execlist | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+    varlist=`nm $execlist 2>/dev/null | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
   fi
 fi
 


### PR DESCRIPTION
## Summary
The file permission is used to get the execlist, but the file permission
cannot be changed for MSYS environment. As the result, symtab_apps.c cannot
be generated correctly. This commit removes the permission match from script.
And, just in case, add to  ignore the error messages by `nm`.

Related: https://github.com/apache/incubator-nuttx-apps/issues/858

## Impact
loadable applications by using `mksymtab.sh`.

## Testing
