### PR TITLE
testing/ostest: Fix the compiler warning

### DIFF
--- a/testing/ostest/aio.c
+++ b/testing/ostest/aio.c
@@ -155,7 +155,7 @@ static int check_done(void)
         {
           /* Check if the I/O has completed */
 
-          printf("  list[%d]. result = %d\n", i, aiocbp->aio_result);
+          printf("  list[%d]. result = %zd\n", i, aiocbp->aio_result);
           if (aiocbp->aio_lio_opcode == LIO_NOP)
             {
               printf("     NO operation\n");
@@ -219,7 +219,7 @@ static int remove_done(void)
         {
           /* Check if the I/O has completed */
 
-          printf("  list[%d]. result = %d\n", i, aiocbp->aio_result);
+          printf("  list[%d]. result = %zd\n", i, aiocbp->aio_result);
           if (aiocbp->aio_lio_opcode == LIO_NOP)
             {
               printf("     NO operation\n");

--- a/testing/ostest/sporadic2.c
+++ b/testing/ostest/sporadic2.c
@@ -44,7 +44,7 @@
 #define PRIO_MID      100
 #define PRIO_HIGH1    180
 #define PRIO_HIGH2    170
-#define REPL_INTERVAL 100000000L
+#define REPL_INTERVAL INT32_C(100000000)
 #define MAX_BUDGET    (REPL_INTERVAL / 2)
 #define PRIO_HI_NDX   0
 #define PRIO_LO_NDX   1


### PR DESCRIPTION
## Summary
```
aio.c: In function ‘check_done’:
aio.c:158:41: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ {aka ‘volatile long int’} [-Wformat=]
  158 |           printf("  list[%d]. result = %d\n", i, aiocbp->aio_result);
      |                                        ~^        ~~~~~~~~~~~~~~~~~~
      |                                         |              |
      |                                         int            ssize_t {aka volatile long int}
      |                                        %ld
aio.c: In function ‘remove_done’:
aio.c:222:41: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ {aka ‘volatile long int’} [-Wformat=]
  222 |           printf("  list[%d]. result = %d\n", i, aiocbp->aio_result);
      |                                        ~^        ~~~~~~~~~~~~~~~~~~
      |                                         |              |
      |                                         int            ssize_t {aka volatile long int}
      |                                        %ld

sporadic2.c: In function ‘sporadic2_test’:
sporadic2.c:313:10: warning: format ‘%i’ expects argument of type ‘int’, but argument 4 has type ‘long int’ [-Wformat=]
  313 |   printf("Sporadic 1: prio high %d, low %d, repl %" PRIi32 " ns\n",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/xiaoxiang/backup/os/nuttx/nuttx/include/stdint.h:35,
                 from /home/xiaoxiang/backup/os/nuttx/nuttx/include/sys/types.h:32,
                 from /home/xiaoxiang/backup/os/nuttx/nuttx/include/stdio.h:30,
                 from sporadic2.c:27:
/home/xiaoxiang/backup/os/nuttx/nuttx/include/arch/inttypes.h:51:24: note: format string is defined here
   51 | #  define PRIi32      "i"
sporadic2.c:315:10: warning: format ‘%i’ expects argument of type ‘int’, but argument 4 has type ‘long int’ [-Wformat=]
  315 |   printf("Sporadic 2: prio high %d, low %d, repl %" PRIi32 " ns\n",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Impact
Minor

## Testing
sim:ostest
