### PR TITLE
Fixes BAS list 'Error: Break at: end of program' error.

### DIFF
--- a/interpreters/bas/bas_program.c
+++ b/interpreters/bas/bas_program.c
@@ -731,11 +731,6 @@ struct Value *Program_list(struct Program *this, int dev, int watchIntr,
             {
               return Value_new_ERROR(value, IOERROR, FS_errmsg);
             }
-
-          if (watchIntr)
-            {
-              return Value_new_ERROR(value, BREAK);
-            }
         }
 
       String_destroy(&s);


### PR DESCRIPTION
## Summary
As a newbie, I thought trying out the BAS interpreter to be a nice first step. But when I issued a 'list' command to see the short BASIC program I wrote, I got an "Error: Break at: end of program" after printing the first line.

This seems to be a side effect of cleaning up the BAS code to conform to the NuttX coding style. In the 'Program_list()' function (bas_program.c:714), this line:

      if (watchIntr && FS_intr) return Value_new_ERROR(value,BREAK);

is changed to (removing the 'FS_intr' variable):

          if (watchIntr)
             {
               return Value_new_ERROR(value, BREAK);
             }

At runtime, 'watchIntr' evaluates to 1 by the caller ('channel == STDCHANNEL') when using 'list' at the prompt. Hence, the above 'if' always triggers and listing ends with an error after printing the first line.

In the original code, 'FS_intr' is 0 (false) as long as the user didn't interrupt the printing out the code. But since this 'FS_intr' is gone, 'if (watchIntr)' now always evaluates to 'true' while this used to be always 'false' unless the user interrupted the printing of a listing.

Since 'FS_intr' is nowhere to be seen anywhere else in the BAS code (because of the cleanup effort to conform to the NuttX coding style?) I thought it was best to completely remove this if statement instead of out commenting it.

## Impact
Using 'list' at the BAS prompt now works and doesn't return a confusing 'Error: Break at: end of program' error.

## Testing
I ran the "git diff --name-only master | egrep "\.c|\.h" | xargs echo | xargs ./tools/checkpatch.sh -f | less" command line. No warnings/errors were shown.
