### PR TITLE
crypto/mbedtls: Bump Mbed TLS to version 3.0.0

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -12,8 +12,8 @@ menuconfig CRYPTO_MBEDTLS
 if CRYPTO_MBEDTLS
 
 config MBEDTLS_VERSION
-	string "MBEDTLS Version"
-	default "2.25.0"
+	string "Mbed TLS Version"
+	default "3.0.0"
 
 menuconfig MBEDTLS_APPS
 	tristate "Mbed TLS Applications"

--- a/include/crypto/mbedtls_config.h
+++ b/include/crypto/mbedtls_config.h
@@ -42,7 +42,7 @@
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_PKCS1_V15
 #define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-#define MBEDTLS_SSL_PROTO_TLS1_1
+#define MBEDTLS_SSL_PROTO_TLS1_2
 
 /* Modules */
 #define MBEDTLS_AES_C
@@ -65,6 +65,7 @@
 #define MBEDTLS_PK_PARSE_C
 #define MBEDTLS_RSA_C
 #define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA224_C
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_SSL_CLI_C
 #define MBEDTLS_SSL_SRV_C
@@ -77,11 +78,5 @@
 #define MBEDTLS_PEM_PARSE_C
 
 #define MBEDTLS_FS_IO
-
-/****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include "mbedtls/check_config.h"
 
 #endif /* __APPS_INCLUDE_CRYPTO_MBEDTLS_CONFIG_H */


### PR DESCRIPTION
## Summary
This PR intends to bump **Mbed TLS** version to 3.0.0.

Since Mbed TLS support on NuttX is fresh, it is better to start it from the latest major revision to avoid future hurdles with API incompatibilities.

Changes to `mbedtls_config.h` were based on [this migration guide](https://github.com/ARMmbed/mbedtls/blob/development/docs/3.0-migration-guide.md).

## Impact
Should have no impact since Mbed TLS support on NuttX has been added recently.

## Testing
`esp32-devkitc:mcuboot_agent` using Mbed TLS as the crypto backend.
Also tested the builtin Mbed TLS examples `mbedbenchmark` and `mbedselftest`, worked as expected.
```bash
nsh> mbedselftest

  CALLOC(0): passed (NULL)
  CALLOC(1): passed
  CALLOC(1 again): passed (same address)

  MD5 test #1: passed
  MD5 test #2: passed
  MD5 test #3: passed
  MD5 test #4: passed
  MD5 test #5: passed
  MD5 test #6: passed
  MD5 test #7: passed

  SHA-1 test #1: passed
  SHA-1 test #2: passed
  SHA-1 test #3: passed

  SHA-224 test #1: passed
  SHA-224 test #2: passed
  SHA-224 test #3: passed
  SHA-256 test #1: passed
  SHA-256 test #2: passed
  SHA-256 test #3: passed

  DES -ECB- 56 (dec): passed
  DES -ECB- 56 (enc): passed
  DES3-ECB-112 (dec): passed
  DES3-ECB-112 (enc): passed
  DES3-ECB-168 (dec): passed
  DES3-ECB-168 (enc): passed

  DES -CBC- 56 (dec): passed
  DES -CBC- 56 (enc): passed
  DES3-CBC-112 (dec): passed
  DES3-CBC-112 (enc): passed
  DES3-CBC-168 (dec): passed
  DES3-CBC-168 (enc): passed

  AES-ECB-128 (dec): passed
  AES-ECB-128 (enc): passed
  AES-ECB-192 (dec): passed
  AES-ECB-192 (enc): passed
  AES-ECB-256 (dec): passed
  AES-ECB-256 (enc): passed

  AES-CBC-128 (dec): passed
  AES-CBC-128 (enc): passed
  AES-CBC-192 (dec): passed
  AES-CBC-192 (enc): passed
  AES-CBC-256 (dec): passed
  AES-CBC-256 (enc): passed

  Base64 encoding test: passed
  Base64 decoding test: passed

  MPI test #1 (mul_mpi): passed
  MPI test #2 (div_mpi): passed
  MPI test #3 (exp_mod): passed
  MPI test #4 (inv_mod): passed
  MPI test #5 (simple gcd): passed

  RSA key validation: passed
  PKCS#1 encryption : passed
  PKCS#1 decryption : passed
  PKCS#1 data sign  : passed
  PKCS#1 sig. verify: passed

  CTR_DRBG (PR = TRUE) : passed
  CTR_DRBG (PR = FALSE): passed

  ENTROPY test: passed

  Executed 11 test suites

  [ All tests PASS ]

nsh> 
```