### PR TITLE
Correct nsh library Kconfig

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -627,12 +627,14 @@ endmenu
 if MMCSD
 
 config NSH_MMCSDMINOR
-	int "MMC/SD minor number"
+	int "MMC/SD minor device number"
 	default 0
 	---help---
-		If board-specific NSH start-up logic needs to mount an MMC/SD device, then the
-		setting should be provided to identify the MMC/SD minor device number (i.e., the N ini
-		/dev/mmcsdN).  Default 0
+		If the architecture supports an MMC/SD slot and if the NSH
+		architecture specific logic is present, this option will provide
+		the MMC/SD minor number, i.e., the MMC/SD block driver will
+		be registered as /dev/mmcsdN where N is the minor number.
+		Default is zero.
 
 config NSH_MMCSDSLOTNO
 	int "MMC/SD slot number"
@@ -762,16 +764,6 @@ config NSH_DISABLE_LOOPS
 
 endif # !NSH_DISABLESCRIPT
 
-config NSH_MMCSDMINOR
-	int "MMC/SD minor device number"
-	default 0
-	---help---
-		If the architecture supports an MMC/SD slot and if the NSH
-		architecture specific logic is present, this option will provide
-		the MMC/SD minor number, i.e., the MMC/SD block driver will
-		be registered as /dev/mmcsdN where N is the minor number.
-		Default is zero.
-
 config NSH_ROMFSETC
 	bool "Support ROMFS start-up script"
 	default n
@@ -786,7 +778,7 @@ if NSH_ROMFSETC
 config NSH_CROMFSETC
 	bool "Support CROMFS (compressed) start-up script"
 	default n
-	depends on NSH_ROMFSETC && FS_CROMFS
+	depends on FS_CROMFS
 	---help---
 		Mount a CROMFS filesystem at /etc and provide a compressed startup
 		script at /etc/init.d/rcS.

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -11,7 +11,6 @@ config NSH_LIBRARY
 	default n
 	select NETUTILS_NETLIB if NET
 	select LIBC_NETDB if NET
-	select READLINE_HAVE_EXTMATCH
 	select BOARDCTL if (!NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT) || NSH_ARCHINIT || NSH_ROMFSETC
 	select BOARDCTL_MKRD if !NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT
 	select BOARDCTL_ROMDISK if NSH_ROMFSETC
@@ -80,6 +79,7 @@ choice
 config NSH_READLINE
 	bool "Minimal readline()"
 	select SYSTEM_READLINE
+	select READLINE_HAVE_EXTMATCH
 	---help---
 		Selects the minimal implementation of readline().  This minimal
 		implementation provides on backspace for command line editing.

--- a/system/readline/Kconfig
+++ b/system/readline/Kconfig
@@ -3,10 +3,6 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config READLINE_HAVE_EXTMATCH
-	bool
-	default n
-
 menuconfig SYSTEM_READLINE
 	bool "readline() Support"
 	default n
@@ -14,6 +10,10 @@ menuconfig SYSTEM_READLINE
 		Enable support for the readline() function.
 
 if SYSTEM_READLINE
+
+config READLINE_HAVE_EXTMATCH
+	bool
+	default n
 
 config READLINE_ECHO
 	bool "Echo character input"


### PR DESCRIPTION
## Summary

- system/readline: Move READLINE_HAVE_EXTMATCH inside SYSTEM_READLINE section
- nsh: Remove the duplicated NSH_MMCSDMINOR

## Impact
No real change

## Testing
Pass CI
