### PR TITLE
Make readline/cle work without CONFIG_FILE_STREAM

### DIFF
--- a/include/system/cle.h
+++ b/include/system/cle.h
@@ -53,7 +53,7 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: cle
+ * Name: cle/cle_fd
  *
  * Description:
  *   EMACS-like command line editor.  This is actually more like readline
@@ -61,8 +61,13 @@ extern "C"
  *
  ****************************************************************************/
 
+int cle_fd(FAR char *line, FAR const char *prompt, uint16_t linelen,
+           int infd, int outfd);
+
+#ifdef CONFIG_FILE_STREAM
 int cle(FAR char *line, FAR const char *prompt, uint16_t linelen,
         FAR FILE *instream, FAR FILE *outstream);
+#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/system/readline.h
+++ b/include/system/readline.h
@@ -143,31 +143,41 @@ FAR const struct extmatch_vtable_s *
 #endif
 
 /****************************************************************************
- * Name: readline
+ * Name: readline_fd
  *
- *   readline() reads in at most one less than 'buflen' characters from
- *   'instream' and stores them into the buffer pointed to by 'buf'.
- *   Characters are echoed on 'outstream'.  Reading stops after an EOF or a
+ *   readline_fd() reads in at most one less than 'buflen' characters from
+ *   'infd' and stores them into the buffer pointed to by 'buf'.
+ *   Characters are echoed on 'outfd'.  Reading stops after an EOF or a
  *   newline.  If a newline is read, it is stored into the buffer.  A null
  *   terminator is stored after the last character in the buffer.
  *
- *   This version of realine assumes that we are reading and writing to
- *   a VT100 console.  This will not work well if 'instream' or 'outstream'
+ *   This version of readline_fd assumes that we are reading and writing to
+ *   a VT100 console.  This will not work well if 'infd' or 'outfd'
  *   corresponds to a raw byte steam.
  *
  *   This function is inspired by the GNU readline but is an entirely
  *   different creature.
  *
  * Input Parameters:
- *   buf       - The user allocated buffer to be filled.
- *   buflen    - the size of the buffer.
- *   instream  - The stream to read characters from
- *   outstream - The stream to each characters to.
+ *   buf    - The user allocated buffer to be filled.
+ *   buflen - the size of the buffer.
+ *   infd   - The file to read characters from
+ *   outfd  - The file to each characters to.
  *
  * Returned values:
  *   On success, the (positive) number of bytes transferred is returned.
  *   EOF is returned to indicate either an end of file condition or a
  *   failure.
+ *
+ ****************************************************************************/
+
+ssize_t readline_fd(FAR char *buf, int buflen, int infd, int outfd);
+
+/****************************************************************************
+ * Name: readline
+ *
+ *   readline() is same to readline_fd() but accept a file stream instead
+ *   of a file handle.
  *
  ****************************************************************************/
 

--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -142,8 +142,8 @@ struct cle_s
   uint16_t coloffs;         /* Left cursor offset */
   uint16_t linelen;         /* Size of the line buffer */
   uint16_t nchars;          /* Size of data in the line buffer */
-  FAR FILE *ins;            /* Input file stream */
-  FAR FILE *outs;           /* Output file stream */
+  int infd;                 /* Input file handle */
+  int outfd;                /* Output file handle */
   FAR char *line;           /* Line buffer */
   FAR const char *prompt;   /* Prompt, in case we have to re-print it */
 };
@@ -257,7 +257,6 @@ static void cle_write(FAR struct cle_s *priv, FAR const char *buffer,
                       uint16_t buflen)
 {
   ssize_t nwritten;
-  uint16_t  nremaining = buflen;
 
   /* Loop until all bytes have been successfully written (or until a
    * unrecoverable error is encountered)
@@ -267,7 +266,7 @@ static void cle_write(FAR struct cle_s *priv, FAR const char *buffer,
     {
       /* Put the next gulp */
 
-      nwritten = fwrite(buffer, sizeof(char), buflen, priv->outs);
+      nwritten = write(priv->outfd, buffer, buflen);
 
       /* Handle write errors.  write() should neve return 0. */
 
@@ -291,12 +290,11 @@ static void cle_write(FAR struct cle_s *priv, FAR const char *buffer,
 
       else
         {
-          nremaining -= nwritten;
+          buffer += nwritten;
+          buflen -= nwritten;
         }
     }
-  while (nremaining > 0);
-
-  fflush(priv->outs);
+  while (buflen > 0);
 }
 
 /****************************************************************************
@@ -333,7 +331,7 @@ static int cle_getch(FAR struct cle_s *priv)
     {
       /* Read one character from the incoming stream */
 
-      nread = fread (&buffer, sizeof(char), 1, priv->ins);
+      nread = read(priv->infd, &buffer, 1);
 
       /* Check for error or end-of-file. */
 
@@ -1135,7 +1133,7 @@ static int cle_editloop(FAR struct cle_s *priv)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: cle
+ * Name: cle/cle_fd
  *
  * Description:
  *   EMACS-like command line editor.  This is actually more like readline
@@ -1143,8 +1141,8 @@ static int cle_editloop(FAR struct cle_s *priv)
  *
  ****************************************************************************/
 
-int cle(FAR char *line, const char *prompt, uint16_t linelen,
-        FILE *instream, FILE *outstream)
+int cle_fd(FAR char *line, FAR const char *prompt, uint16_t linelen,
+           int infd, int outfd)
 {
   FAR struct cle_s priv;
   uint16_t column;
@@ -1157,8 +1155,8 @@ int cle(FAR char *line, const char *prompt, uint16_t linelen,
   priv.linelen  = linelen;
   priv.line     = line;
 
-  priv.ins      = instream;
-  priv.outs     = outstream;
+  priv.infd     = infd;
+  priv.outfd    = outfd;
 
   /* Store the prompt in case we need to re-print it */
 
@@ -1225,3 +1223,11 @@ int cle(FAR char *line, const char *prompt, uint16_t linelen,
 
   return ret;
 }
+
+#ifdef CONFIG_FILE_STREAM
+int cle(FAR char *line, FAR const char *prompt, uint16_t linelen,
+        FAR FILE *instream, FAR FILE *outstream)
+{
+  return cle_fd(line, prompt, linelen, instream->fs_fd, outstream->fs_fd);
+}
+#endif

--- a/system/readline/Makefile
+++ b/system/readline/Makefile
@@ -22,6 +22,6 @@ include $(APPDIR)/Make.defs
 
 # The Readline Library
 
-CSRCS = readline.c readline_common.c
+CSRCS = readline.c readline_fd.c readline_common.c
 
 include $(APPDIR)/Application.mk

--- a/system/readline/readline.c
+++ b/system/readline/readline.c
@@ -24,151 +24,10 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
 #include <assert.h>
 
 #include "system/readline.h"
-#include "readline.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Private Type Declarations
- ****************************************************************************/
-
-struct readline_s
-{
-  struct rl_common_s vtbl;
-  int infd;
-#ifdef CONFIG_READLINE_ECHO
-  int outfd;
-#endif
-};
-
-/****************************************************************************
- * Private Function Prototypes
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: readline_getc
- ****************************************************************************/
-
-static int readline_getc(FAR struct rl_common_s *vtbl)
-{
-  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
-  char buffer;
-  ssize_t nread;
-
-  DEBUGASSERT(priv);
-
-  /* Loop until we successfully read a character (or until an unexpected
-   * error occurs).
-   */
-
-  do
-    {
-      /* Read one character from the incoming stream */
-
-      nread = read(priv->infd, &buffer, 1);
-
-      /* Check for end-of-file. */
-
-      if (nread == 0)
-        {
-          /* Return EOF on end-of-file */
-
-          return EOF;
-        }
-
-      /* Check if an error occurred */
-
-      else if (nread < 0)
-        {
-          /* EINTR is not really an error; it simply means that a signal was
-           * received while waiting for input.
-           */
-
-          int errcode = errno;
-          if (errcode != EINTR)
-            {
-              /* Return EOF on any errors that we cannot handle */
-
-              return EOF;
-            }
-        }
-    }
-  while (nread < 1);
-
-  /* On success, return the character that was read */
-
-  return (int)buffer;
-}
-
-/****************************************************************************
- * Name: readline_putc
- ****************************************************************************/
-
-#ifdef CONFIG_READLINE_ECHO
-static void readline_putc(FAR struct rl_common_s *vtbl, int ch)
-{
-  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
-  char buffer = ch;
-  ssize_t nwritten;
-
-  DEBUGASSERT(priv);
-
-  /* Loop until we successfully write a character (or until an unexpected
-   * error occurs).
-   */
-
-  do
-    {
-      /* Write the character to the outgoing stream */
-
-      nwritten = write(priv->outfd, &buffer, 1);
-
-      /* Check for irrecoverable write errors. */
-
-      if (nwritten < 0 && errno != EINTR)
-        {
-          break;
-        }
-    }
-  while (nwritten < 1);
-}
-#endif
-
-/****************************************************************************
- * Name: readline_write
- ****************************************************************************/
-
-#ifdef CONFIG_READLINE_ECHO
-static void readline_write(FAR struct rl_common_s *vtbl,
-                           FAR const char *buffer, size_t buflen)
-{
-  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
-  DEBUGASSERT(priv && buffer && buflen > 0);
-
-  write(priv->outfd, buffer, buflen);
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -177,52 +36,20 @@ static void readline_write(FAR struct rl_common_s *vtbl,
 /****************************************************************************
  * Name: readline
  *
- *   readline() reads in at most one less than 'buflen' characters from
- *   'instream' and stores them into the buffer pointed to by 'buf'.
- *   Characters are echoed on 'outstream'.  Reading stops after an EOF or a
- *   newline.  If a newline is read, it is stored into the buffer.  A null
- *   terminator is stored after the last character in the buffer.
- *
- *   This version of realine assumes that we are reading and writing to
- *   a VT100 console.  This will not work well if 'instream' or 'outstream'
- *   corresponds to a raw byte steam.
- *
- *   This function is inspired by the GNU readline but is an entirely
- *   different creature.
- *
- * Input Parameters:
- *   buf       - The user allocated buffer to be filled.
- *   buflen    - the size of the buffer.
- *   instream  - The stream to read characters from
- *   outstream - The stream to each characters to.
- *
- * Returned values:
- *   On success, the (positive) number of bytes transferred is returned.
- *   EOF is returned to indicate either an end of file condition or a
- *   failure.
+ *   readline() is same to readline_fd() but accept a file stream instead
+ *   of a file handle.
  *
  ****************************************************************************/
 
+#ifdef CONFIG_FILE_STREAM
 ssize_t readline(FAR char *buf, int buflen, FILE *instream, FILE *outstream)
 {
-  struct readline_s vtbl;
-
   /* Sanity checks */
 
   DEBUGASSERT(instream && outstream);
 
-  /* Set up the vtbl structure */
+  /* Let readline_fd do the work */
 
-  vtbl.vtbl.rl_getc  = readline_getc;
-  vtbl.infd          = instream->fs_fd;
-
-#ifdef CONFIG_READLINE_ECHO
-  vtbl.vtbl.rl_putc  = readline_putc;
-  vtbl.vtbl.rl_write = readline_write;
-  vtbl.outfd         = outstream->fs_fd;
-#endif
-
-  /* The let the common readline logic do the work */
-
-  return readline_common(&vtbl.vtbl, buf, buflen);
+  return readline_fd(buf, buflen, instream->fs_fd, outstream->fs_fd);
 }
+#endif

--- a/system/readline/readline_fd.c
+++ b/system/readline/readline_fd.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ * apps/system/readline/readline_fd.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "system/readline.h"
+#include "readline.h"
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+struct readline_s
+{
+  struct rl_common_s vtbl;
+  int infd;
+#ifdef CONFIG_READLINE_ECHO
+  int outfd;
+#endif
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: readline_getc
+ ****************************************************************************/
+
+static int readline_getc(FAR struct rl_common_s *vtbl)
+{
+  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
+  char buffer;
+  ssize_t nread;
+
+  DEBUGASSERT(priv);
+
+  /* Loop until we successfully read a character (or until an unexpected
+   * error occurs).
+   */
+
+  do
+    {
+      /* Read one character from the incoming stream */
+
+      nread = read(priv->infd, &buffer, 1);
+
+      /* Check for end-of-file. */
+
+      if (nread == 0)
+        {
+          /* Return EOF on end-of-file */
+
+          return EOF;
+        }
+
+      /* Check if an error occurred */
+
+      else if (nread < 0)
+        {
+          /* EINTR is not really an error; it simply means that a signal was
+           * received while waiting for input.
+           */
+
+          int errcode = errno;
+          if (errcode != EINTR)
+            {
+              /* Return EOF on any errors that we cannot handle */
+
+              return EOF;
+            }
+        }
+    }
+  while (nread < 1);
+
+  /* On success, return the character that was read */
+
+  return (int)buffer;
+}
+
+/****************************************************************************
+ * Name: readline_putc
+ ****************************************************************************/
+
+#ifdef CONFIG_READLINE_ECHO
+static void readline_putc(FAR struct rl_common_s *vtbl, int ch)
+{
+  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
+  char buffer = ch;
+  ssize_t nwritten;
+
+  DEBUGASSERT(priv);
+
+  /* Loop until we successfully write a character (or until an unexpected
+   * error occurs).
+   */
+
+  do
+    {
+      /* Write the character to the outgoing stream */
+
+      nwritten = write(priv->outfd, &buffer, 1);
+
+      /* Check for irrecoverable write errors. */
+
+      if (nwritten < 0 && errno != EINTR)
+        {
+          break;
+        }
+    }
+  while (nwritten < 1);
+}
+#endif
+
+/****************************************************************************
+ * Name: readline_write
+ ****************************************************************************/
+
+#ifdef CONFIG_READLINE_ECHO
+static void readline_write(FAR struct rl_common_s *vtbl,
+                           FAR const char *buffer, size_t buflen)
+{
+  FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
+  DEBUGASSERT(priv && buffer && buflen > 0);
+
+  write(priv->outfd, buffer, buflen);
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: readline_fd
+ *
+ *   readline_fd() reads in at most one less than 'buflen' characters from
+ *   'infd' and stores them into the buffer pointed to by 'buf'.
+ *   Characters are echoed on 'outfd'.  Reading stops after an EOF or a
+ *   newline.  If a newline is read, it is stored into the buffer.  A null
+ *   terminator is stored after the last character in the buffer.
+ *
+ *   This version of readline_fd assumes that we are reading and writing to
+ *   a VT100 console.  This will not work well if 'infd' or 'outfd'
+ *   corresponds to a raw byte steam.
+ *
+ *   This function is inspired by the GNU readline but is an entirely
+ *   different creature.
+ *
+ * Input Parameters:
+ *   buf    - The user allocated buffer to be filled.
+ *   buflen - the size of the buffer.
+ *   infd   - The file to read characters from
+ *   outfd  - The file to each characters to.
+ *
+ * Returned values:
+ *   On success, the (positive) number of bytes transferred is returned.
+ *   EOF is returned to indicate either an end of file condition or a
+ *   failure.
+ *
+ ****************************************************************************/
+
+ssize_t readline_fd(FAR char *buf, int buflen, int infd, int outfd)
+{
+  struct readline_s vtbl;
+
+  /* Set up the vtbl structure */
+
+  vtbl.vtbl.rl_getc  = readline_getc;
+  vtbl.infd          = infd;
+
+#ifdef CONFIG_READLINE_ECHO
+  vtbl.vtbl.rl_putc  = readline_putc;
+  vtbl.vtbl.rl_write = readline_write;
+  vtbl.outfd         = outfd;
+#endif
+
+  /* The let the common readline logic do the work */
+
+  return readline_common(&vtbl.vtbl, buf, buflen);
+}


### PR DESCRIPTION
## Summary

- system/readline: Make it work without CONFIG_FILE_STREAM 
- system/cle: Make it work without CONFIG_FILE_STREAM

## Impact
stdio version work as before, fd version will be used in the upcoming nsh optimization patch

## Testing
Pass CI and ostest
