### PR TITLE
testing/sensortest: Fix printf format warning

### DIFF
--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -166,8 +166,8 @@ static void print_gps(const char *buffer, const char *name)
 {
   struct sensor_event_gps *event = (struct sensor_event_gps *)buffer;
 
-  printf("%s: timestamp: %llu time_utc: %llu latitude: %f longitude: %f "
-         "altitude: %f altitude_ellipsoid: %f eph: %f epv: %f "
+  printf("%s: timestamp:%" PRIu64 " time_utc: %" PRIu64 " latitude: %f "
+         "longitude: %f altitude: %f altitude_ellipsoid: %f eph: %f epv: %f "
          "hdop: %f vdop: %f ground_speed: %f course: %f satellites_used:"
          " %u\n", name, event->timestamp, event->time_utc, event->latitude,
          event->longitude, event->altitude, event->altitude_ellipsoid,
@@ -180,7 +180,7 @@ static void print_gps_satellite(FAR const char *buffer, FAR const char *name)
   FAR struct sensor_event_gps_satellite *event =
         (struct sensor_event_gps_satellite *)buffer;
 
-  printf("%s: timestamp: %llu count: %u satellites: %u", name,
+  printf("%s: timestamp: %" PRIu64 " count: %u satellites: %u", name,
          event->timestamp, event->count, event->satellites);
 }
 


### PR DESCRIPTION
## Summary
```
sensortest.c: In function 'print_gps':
Error: sensortest.c:169:29: error: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  169 |   printf("%s: timestamp: %llu time_utc: %llu latitude: %f longitude: %f "
      |                          ~~~^
      |                             |
      |                             long long unsigned int
      |                          %lu
......
  172 |          " %u\n", name, event->timestamp, event->time_utc, event->latitude,
      |                         ~~~~~~~~~~~~~~~~
      |                              |
      |                              uint64_t {aka long unsigned int}
Error: sensortest.c:169:44: error: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  169 |   printf("%s: timestamp: %llu time_utc: %llu latitude: %f longitude: %f "
      |                                         ~~~^
      |                                            |
      |                                            long long unsigned int
      |                                         %lu
......
  172 |          " %u\n", name, event->timestamp, event->time_utc, event->latitude,
      |                                           ~~~~~~~~~~~~~~~
      |                                                |
      |                                                uint64_t {aka long unsigned int}
sensortest.c: In function 'print_gps_satellite':
Error: sensortest.c:183:29: error: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  183 |   printf("%s: timestamp: %llu count: %u satellites: %u", name,
      |                          ~~~^
      |                             |
      |                             long long unsigned int
      |                          %lu
  184 |          event->timestamp, event->count, event->satellites);
      |          ~~~~~~~~~~~~~~~~
      |               |
      |               uint64_t {aka long unsigned int}
```

## Impact
Fix the warning by PR https://github.com/apache/incubator-nuttx-apps/pull/893

## Testing
Pass CI
