### PR TITLE
fsutils/mkfatfs: Allow for configurable buffer alignment

### DIFF
--- a/fsutils/mkfatfs/Kconfig
+++ b/fsutils/mkfatfs/Kconfig
@@ -10,3 +10,12 @@ config FSUTILS_MKFATFS
 	select BCH
 	---help---
 		Enables support for the mkfatfs utility
+
+config MKFATFS_BUFFER_ALIGMENT
+	int "Buffer alignment"
+	default 0
+	depends on FSUTILS_MKFATFS
+	---help---
+		Enables alignment of the buffers used by the mkfatfs application
+		to N bytes. This may be needed for systems with cache or buffer
+		alignment constraints.

--- a/fsutils/mkfatfs/mkfatfs.c
+++ b/fsutils/mkfatfs/mkfatfs.c
@@ -39,6 +39,17 @@
 #include "mkfatfs.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_MKFATFS_BUFFER_ALIGMENT) && \
+            CONFIG_MKFATFS_BUFFER_ALIGMENT > 0
+#  define fat_buffer_alloc(s) memalign(CONFIG_MKFATFS_BUFFER_ALIGMENT, (s))
+#else
+#  define fat_buffer_alloc(s) malloc((s))
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -337,9 +348,11 @@ int mkfatfs(FAR const char *pathname, FAR struct fat_format_s *fmt)
       goto errout_with_driver;
     }
 
-  /* Allocate a buffer that will be working sector memory */
+  /* Allocate a buffer that will be working sector memory
+   * Lets align it as needed
+   */
 
-  var.fv_sect = (FAR uint8_t *)malloc(var.fv_sectorsize);
+  var.fv_sect = (FAR uint8_t *)fat_buffer_alloc(var.fv_sectorsize);
   if (!var.fv_sect)
     {
       ferr("ERROR: Failed to allocate working buffers\n");


### PR DESCRIPTION
## Summary

Enables alignment of the buffers used by the mkfatfs application
to N bytes. 

This may be needed for systems with cache or buffer alignment constraints.

## Impact

None behind Kconfig
 
## Testing

px4_fmuv5