### PR TITLE
mcuboot/Kconfig: update hash commit to include fix for referenciation error in memset call

### DIFF
--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -14,7 +14,7 @@ if BOOT_MCUBOOT
 
 config MCUBOOT_VERSION
 	string "MCUboot version"
-	default "fca1aa4764eef4da008aeaf7e570184281aa79fa"
+	default "5e762643778454ca9a1f872e3dfdef6490204f96"
 
 config MCUBOOT_ENABLE_LOGGING
 	bool "Enable MCUboot logging"


### PR DESCRIPTION
## Summary
MCUboot contain important fix in port for nuttx: https://github.com/mcu-tools/mcuboot/pull/1213

## Impact
MCUboot loader and MCUboot compatible applications

## Testing
- Pass CI
- MCUboot loader works on custom SAME70 based board
