### PR TITLE
fix: fb: set overlay to 0

### DIFF
--- a/examples/fb/fb_main.c
+++ b/examples/fb/fb_main.c
@@ -346,6 +346,9 @@ int main(int argc, FAR char *argv[])
       return EXIT_FAILURE;
     }
 
+  /* Get the first overlay information */
+
+  state.oinfo.overlay = 0;
   ret = ioctl(state.fd, FBIOGET_OVERLAYINFO,
                         (unsigned long)((uintptr_t)&state.oinfo));
   if (ret < 0)


### PR DESCRIPTION

## Summary
When CONFIG_FB_OVERLAY=y, need set overlay=0,
otherwise the lcd driver doesn't know which
layer to get.
## Impact
None
## Testing
It has been verified on my own development board.
