### PR TITLE
mcuboot/Kconfig: update hash commit to include fix for compilation warnings

### DIFF
--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -14,7 +14,7 @@ if BOOT_MCUBOOT
 
 config MCUBOOT_VERSION
 	string "MCUboot version"
-	default "5e762643778454ca9a1f872e3dfdef6490204f96"
+	default "7c890f4b075aed73e4c825ccf875b2fb9ebf2ded"
 
 config MCUBOOT_ENABLE_LOGGING
 	bool "Enable MCUboot logging"


### PR DESCRIPTION
## Summary
MCUboot contain important fix in port for nuttx: https://github.com/mcu-tools/mcuboot/pull/1222
It is needed in order to unblock https://github.com/apache/incubator-nuttx/pull/4880

## Impact
MCUboot loader and MCUboot compatible applications

## Testing

- Pass CI
- MCUboot loader works on custom SAME70 based board

