### PR TITLE
system/trace:  Suppress warnings.

### DIFF
--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -292,8 +292,12 @@ static int trace_cmd_mode(int index, int argc, FAR char **argv,
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
   struct note_filter_irq_s filter_irq;
 #endif
+
+#if defined(CONFIG_SCHED_INSTRUMENTATION_SYSCALL) ||\
+    defined(CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER)
   int i;
   int count;
+#endif
 
   /* Usage: trace mode [{+|-}{o|s|a|i}...] */
 

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -85,7 +85,7 @@ struct trace_dump_task_context_s
   FAR struct trace_dump_task_context_s *next;
   pid_t pid;                              /* Task PID */
   int syscall_nest;                       /* Syscall nest level */
-  char name[CONFIG_TASK_NAME_SIZE + 1];   /* Task name (with NUL terminator) */
+  char name[CONFIG_TASK_NAME_SIZE + 1];   /* Task name (with NULL terminator) */
 };
 
 struct trace_dump_context_s


### PR DESCRIPTION
## Summary
Condition variables that are needed only when SYSCALL or IRQ instrumentation is enabled.
## Impact
trace porgram.
## Testing
ESP32 with trace enabled.
