### PR TITLE
testing/ostest: Include nuttx/arch.h explicitly

### DIFF
--- a/testing/ostest/tls.c
+++ b/testing/ostest/tls.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
 #include "ostest.h"


### PR DESCRIPTION
## Summary
Required by https://github.com/apache/incubator-nuttx/pull/4913

## Impact
No real change

## Testing
Pass CI and ostest
