### PR TITLE
examples/foc: improve code modularity and fix typo

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -216,8 +216,13 @@ config EXAMPLES_FOC_SETPOINT_CONST
 config EXAMPLES_FOC_SETPOINT_ADC
 	bool "Use ADC to control setpoint"
 	select EXAMPLES_FOC_HAVE_ADC
+	select EXAMPLES_FOC_HAVE_SETPOINT_VAR
 
 endchoice # FOC setpoint interface
+
+config EXAMPLES_FOC_HAVE_SETPOINT_VAR
+	bool
+	default n
 
 if EXAMPLES_FOC_SETPOINT_CONST
 
@@ -227,13 +232,13 @@ config EXAMPLES_FOC_SETPOINT_CONST_VALUE
 
 endif # EXAMPLES_FOC_SETPOINT_CONST
 
-if EXAMPLES_FOC_SETPOINT_ADC
+if EXAMPLES_FOC_HAVE_SETPOINT_VAR
 
-config EXAMPLES_FOC_SETPOINT_ADC_MAX
-	int "FOC maximum setpoint from ADC [x1000]"
+config EXAMPLES_FOC_SETPOINT_MAX
+	int "FOC maximum setpoint [x1000]"
 	default 0
 
-endif # EXAMPLES_FOC_SETPOINT_ADC
+endif # EXAMPLES_FOC_HAVE_SETPOINT_VAR
 
 config EXAMPLES_FOC_TIME_DEFAULT
 	int "FOC run time default (sec)"

--- a/examples/foc/Makefile
+++ b/examples/foc/Makefile
@@ -32,7 +32,7 @@ MODULE    = $(CONFIG_EXAMPLES_FOC)
 MAINSRC = foc_main.c
 
 ASRCS =
-CSRCS = foc_device.c foc_mq.c foc_thr.c
+CSRCS = foc_device.c foc_mq.c foc_thr.c foc_intf.c
 
 ifeq ($(CONFIG_BUILTIN),y)
 CSRCS += foc_parseargs.c

--- a/examples/foc/Makefile
+++ b/examples/foc/Makefile
@@ -32,7 +32,7 @@ MODULE    = $(CONFIG_EXAMPLES_FOC)
 MAINSRC = foc_main.c
 
 ASRCS =
-CSRCS = foc_device.c foc_mq.c
+CSRCS = foc_device.c foc_mq.c foc_thr.c
 
 ifeq ($(CONFIG_BUILTIN),y)
 CSRCS += foc_parseargs.c

--- a/examples/foc/foc_adc.h
+++ b/examples/foc/foc_adc.h
@@ -31,55 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* VBUS source must be specified */
-
-#if defined(CONFIG_EXAMPLES_FOC_VBUS_CONST) &&  \
-  defined(CONFIG_EXAMPLES_FOC_VBUS_ADC)
-#  error
-#endif
-
-/* Velocity source must be specified */
-
-#if defined(CONFIG_EXAMPLES_FOC_SETPOINT_CONST) &&   \
-  defined(CONFIG_EXAMPLES_FOC_SETPOINT_ADC)
-#  error
-#endif
-
-/* VBUS ADC scale factor */
-
-#ifdef CONFIG_EXAMPLES_FOC_VBUS_ADC
-#  define VBUS_ADC_SCALE (CONFIG_EXAMPLES_FOC_ADC_VREF *    \
-                          CONFIG_EXAMPLES_FOC_VBUS_SCALE /  \
-                          CONFIG_EXAMPLES_FOC_ADC_MAX /     \
-                          1000.0f /                         \
-                          1000.0f)
-#endif
-
-/* Velocity ADC scale factor */
-
-#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_ADC
-#  define SETPOINT_ADC_SCALE (1.0f / CONFIG_EXAMPLES_FOC_ADC_MAX)
-#endif
-
-/* If constant velocity is selected, velocity value must be provided */
-
-#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
-#  define SETPOINT_ADC_SCALE   (1)
-#  if CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE == 0
-#    error
-#  endif
-#endif
-
-/* If constant VBUS is selected, VBUS value must be provided */
-
-#ifdef CONFIG_EXAMPLES_FOC_VBUS_CONST
-#  define VBUS_ADC_SCALE   (1)
-#  define VBUS_CONST_VALUE (CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE / 1000.0f)
-#  if CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE == 0
-#    error
-#  endif
-#endif
-
 /* Additional configuration if ADC support is required */
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -128,4 +128,53 @@
 #  endif
 #endif
 
+/* Setpoint source must be specified */
+
+#if !defined(CONFIG_EXAMPLES_FOC_SETPOINT_CONST) &&  \
+    !defined(CONFIG_EXAMPLES_FOC_SETPOINT_ADC)
+#  error
+#endif
+
+/* Setpoint ADC scale factor */
+
+#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_ADC
+#  define SETPOINT_ADC_SCALE (1.0f / CONFIG_EXAMPLES_FOC_ADC_MAX)
+#endif
+
+/* If constant setpoint is selected, setpoint value must be provided */
+
+#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
+#  define SETPOINT_ADC_SCALE   (1)
+#  if CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE == 0
+#    error
+#  endif
+#endif
+
+/* VBUS source must be specified */
+
+#if !defined(CONFIG_EXAMPLES_FOC_VBUS_CONST) &&  \
+    !defined(CONFIG_EXAMPLES_FOC_VBUS_ADC)
+#  error
+#endif
+
+/* VBUS ADC scale factor */
+
+#ifdef CONFIG_EXAMPLES_FOC_VBUS_ADC
+#  define VBUS_ADC_SCALE (CONFIG_EXAMPLES_FOC_ADC_VREF *    \
+                          CONFIG_EXAMPLES_FOC_VBUS_SCALE /  \
+                          CONFIG_EXAMPLES_FOC_ADC_MAX /     \
+                          1000.0f /                         \
+                          1000.0f)
+#endif
+
+/* If constant VBUS is selected, VBUS value must be provided */
+
+#ifdef CONFIG_EXAMPLES_FOC_VBUS_CONST
+#  define VBUS_ADC_SCALE   (1)
+#  define VBUS_CONST_VALUE (CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE / 1000.0f)
+#  if CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE == 0
+#    error
+#  endif
+#endif
+
 #endif /* __EXAMPLES_FOC_FOC_CFG_H */

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -123,7 +123,7 @@
 #  if CONFIG_EXAMPLES_FOC_MOTOR_POLES == 0
 #    error
 #  endif
-#  if CONFIG_EXAMPLES_FOC_MOTOR_POSMAX == 0
+#  if CONFIG_EXAMPLES_FOC_QENCO_POSMAX == 0
 #    error
 #  endif
 #endif

--- a/examples/foc/foc_intf.c
+++ b/examples/foc/foc_intf.c
@@ -1,0 +1,485 @@
+/****************************************************************************
+ * apps/examples/foc/foc_intf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/ioctl.h>
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+#  include <nuttx/input/buttons.h>
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+#  include <nuttx/analog/adc.h>
+#  include <nuttx/analog/ioctl.h>
+#endif
+
+#include "foc_thr.h"
+#include "foc_adc.h"
+#include "foc_intf.h"
+#include "foc_debug.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_EXAMPLES_FOC_HAVE_ADC) ||    \
+    defined(CONFIG_EXAMPLES_FOC_HAVE_BUTTON)
+#  define FOC_HAVE_INTF
+#endif
+
+/* Button init state */
+
+#if CONFIG_EXAMPLES_FOC_STATE_INIT == 1
+#  define STATE_BUTTON_I (0)
+#elif CONFIG_EXAMPLES_FOC_STATE_INIT == 2
+#  define STATE_BUTTON_I (2)
+#elif CONFIG_EXAMPLES_FOC_STATE_INIT == 3
+#  define STATE_BUTTON_I (1)
+#elif CONFIG_EXAMPLES_FOC_STATE_INIT == 4
+#  define STATE_BUTTON_I (3)
+#else
+#  error
+#endif
+
+/****************************************************************************
+ * Private Type Definition
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+/* Button interface data */
+
+struct foc_intf_btn_s
+{
+  int fd;
+};
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+/* ADC interface data */
+
+struct foc_intf_adc_s
+{
+  int  fd;
+  bool adc_trigger;
+};
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+/* Example state */
+
+static const int g_state_list[5] =
+{
+  FOC_EXAMPLE_STATE_FREE,
+  FOC_EXAMPLE_STATE_CW,
+  FOC_EXAMPLE_STATE_STOP,
+  FOC_EXAMPLE_STATE_CCW,
+  0
+};
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+/* Button interface data */
+
+static struct foc_intf_btn_s g_btn_intf;
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+/* ADC interface data */
+
+static struct foc_intf_adc_s g_adc_intf;
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+/****************************************************************************
+ * Name: foc_button_init
+ ****************************************************************************/
+
+static int foc_button_init(FAR struct foc_intf_btn_s *intf)
+{
+  int ret = 0;
+
+  DEBUGASSERT(intf);
+
+  /* Open button driver */
+
+  intf->fd = open(CONFIG_EXAMPLES_FOC_BUTTON_DEVPATH,
+                  (O_RDONLY | O_NONBLOCK));
+  if (intf->fd < 0)
+    {
+      PRINTF("ERROR: failed to open %s %d\n",
+             CONFIG_EXAMPLES_FOC_BUTTON_DEVPATH, errno);
+      ret = -errno;
+      goto errout;
+    }
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_button_deinit
+ ****************************************************************************/
+
+static int foc_button_deinit(FAR struct foc_intf_btn_s *intf)
+{
+  DEBUGASSERT(intf);
+
+  if (intf->fd > 0)
+    {
+      close(intf->fd);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_button_update
+ ****************************************************************************/
+
+static int foc_button_update(FAR struct foc_intf_btn_s *intf,
+                             FAR struct foc_intf_data_s *data)
+{
+  static int      state_i  = STATE_BUTTON_I;
+  btn_buttonset_t b_sample = 0;
+  int             ret      = OK;
+
+  DEBUGASSERT(intf);
+  DEBUGASSERT(data);
+
+  /* Get button state */
+
+  ret = read(intf->fd, &b_sample, sizeof(btn_buttonset_t));
+  if (ret < 0)
+    {
+      if (errno != EAGAIN)
+        {
+          PRINTF("ERROR: read button failed %d\n", errno);
+          ret = -errno;
+          goto errout;
+        }
+      else
+        {
+          ret = OK;
+        }
+    }
+
+  /* Next state */
+
+  if (b_sample & (1 << 0))
+    {
+      state_i += 1;
+
+      if (g_state_list[state_i] == 0)
+        {
+          state_i = 0;
+        }
+
+      data->state        = g_state_list[state_i];
+      data->state_update = true;
+
+      PRINTF("BUTTON STATE %" PRIu32 "\n", data->state);
+    }
+
+errout:
+  return ret;
+}
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+/****************************************************************************
+ * Name: foc_adc_init
+ ****************************************************************************/
+
+static int foc_adc_init(FAR struct foc_intf_adc_s *intf)
+{
+  int ret = OK;
+
+  DEBUGASSERT(intf);
+
+  /* Open ADC device */
+
+  intf->fd = open(CONFIG_EXAMPLES_FOC_ADC_DEVPATH, (O_RDONLY | O_NONBLOCK));
+  if (intf->fd <= 0)
+    {
+      PRINTF("ERROR: failed to open %s %d\n",
+             CONFIG_EXAMPLES_FOC_ADC_DEVPATH, errno);
+      ret = -errno;
+      goto errout;
+    }
+
+  /* Initial ADC trigger */
+
+  ret = ioctl(intf->fd, ANIOC_TRIGGER, 0);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: ANIOC_TRIGGER ioctl failed: %d\n", errno);
+      ret = -errno;
+      goto errout;
+    }
+
+  /* Make sure that conversion is done before first read form ADC device */
+
+  usleep(10000);
+
+  /* Read ADC data if the first loop cylce */
+
+  intf->adc_trigger = false;
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_adc_deinit
+ ****************************************************************************/
+
+static int foc_adc_deinit(FAR struct foc_intf_adc_s *intf)
+{
+  DEBUGASSERT(intf);
+
+  if (intf->fd > 0)
+    {
+      close(intf->fd);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_adc_update
+ ****************************************************************************/
+
+static int foc_adc_update(FAR struct foc_intf_adc_s *intf,
+                          FAR struct foc_intf_data_s *data)
+{
+  struct adc_msg_s adc_sample[ADC_SAMPLES];
+  int              ret = OK;
+
+  DEBUGASSERT(intf);
+  DEBUGASSERT(data);
+
+  if (intf->adc_trigger == true)
+    {
+      /* Issue the software trigger to start ADC conversion */
+
+      ret = ioctl(intf->fd, ANIOC_TRIGGER, 0);
+      if (ret < 0)
+        {
+          PRINTF("ERROR: ANIOC_TRIGGER ioctl failed: %d\n", errno);
+          ret = -errno;
+          goto errout;
+        }
+
+      /* No ADC trigger next cycle */
+
+      intf->adc_trigger = false;
+    }
+  else
+    {
+      /* Get ADC samples */
+
+      ret = read(intf->fd, adc_sample,
+                 (ADC_SAMPLES * sizeof(struct adc_msg_s)));
+      if (ret < 0)
+        {
+          if (errno != EAGAIN)
+            {
+              PRINTF("ERROR: adc read failed %d\n", errno);
+              ret = -errno;
+              goto errout;
+            }
+          else
+            {
+              ret = OK;
+            }
+        }
+      else
+        {
+          /* Verify we have received the configured number of samples */
+
+          if (ret != ADC_SAMPLES * sizeof(struct adc_msg_s))
+            {
+              PRINTF("ERROR: adc read invalid read %d != %d\n", ret,
+                     ADC_SAMPLES * sizeof(struct adc_msg_s));
+              ret = -EINVAL;
+              goto errout;
+            }
+
+#ifdef CONFIG_EXAMPLES_FOC_VBUS_ADC
+          /* Get raw VBUS */
+
+          data->vbus_raw = adc_sample[VBUS_ADC_SAMPLE].am_data;
+
+          data->vbus_update = true;
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_ADC
+          /* Get raw VEL */
+
+          data->sp_raw = adc_sample[SETPOINT_ADC_SAMPLE].am_data;
+
+          data->sp_update = true;
+#endif
+
+          /* ADC trigger next cycle */
+
+          intf->adc_trigger = true;
+        }
+    }
+
+errout:
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_intf_init
+ ****************************************************************************/
+
+int foc_intf_init(void)
+{
+  int ret = OK;
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+  /* Initialize ADC interface */
+
+  ret = foc_adc_init(&g_adc_intf);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: failed to initialize adc interface %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+  /* Initialize button interface */
+
+  ret = foc_button_init(&g_btn_intf);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: failed to initialize button interface %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef FOC_HAVE_INTF
+  errout:
+#endif
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_intf_deinit
+ ****************************************************************************/
+
+int foc_intf_deinit(void)
+{
+  int ret = OK;
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+  /* De-initialize adc interface */
+
+  ret = foc_adc_deinit(&g_adc_intf);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: foc_adc_deinit failed %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+  /* De-initialize button interface */
+
+  ret = foc_button_deinit(&g_btn_intf);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: foc_button_deinit failed %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef FOC_HAVE_INTF
+  errout:
+#endif
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_intf_update
+ ****************************************************************************/
+
+int foc_intf_update(FAR struct foc_intf_data_s *data)
+{
+  int ret = OK;
+
+  DEBUGASSERT(data);
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
+  /* Update button */
+
+  ret = foc_button_update(&g_btn_intf, data);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: button update failed %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ADC
+  /* Update ADC */
+
+  ret = foc_adc_update(&g_adc_intf, data);
+  if (ret < 0)
+    {
+      PRINTF("ERROR: adc update failed %d\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef FOC_HAVE_INTF
+  errout:
+#endif
+
+  return ret;
+}

--- a/examples/foc/foc_intf.h
+++ b/examples/foc/foc_intf.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * apps/examples/foc/foc_intf.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __EXAMPLES_FOC_FOC_INTF_H
+#define __EXAMPLES_FOC_FOC_INTF_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definition
+ ****************************************************************************/
+
+/* FOC control interface data */
+
+struct foc_intf_data_s
+{
+  uint32_t state;
+  uint32_t vbus_raw;
+  int32_t  sp_raw;
+  bool     vbus_update;
+  bool     state_update;
+  bool     sp_update;
+  bool     terminate;
+  bool     started;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int foc_intf_init(void);
+int foc_intf_deinit(void);
+int foc_intf_update(FAR struct foc_intf_data_s *data);
+
+#endif /* __EXAMPLES_FOC_FOC_INTF_H */

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -41,7 +41,7 @@
 
 #include "foc_mq.h"
 #include "foc_thr.h"
-#include "foc_adc.h"
+#include "foc_cfg.h"
 #include "foc_debug.h"
 #include "foc_device.h"
 #include "foc_parseargs.h"

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -28,22 +28,16 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
-#include <mqueue.h>
-#include <pthread.h>
 
 #include <sys/types.h>
-#include <sys/ioctl.h>
 #include <sys/boardctl.h>
-#include <nuttx/fs/fs.h>
 
 #include "foc_mq.h"
 #include "foc_thr.h"
 #include "foc_cfg.h"
 #include "foc_debug.h"
-#include "foc_device.h"
 #include "foc_parseargs.h"
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
@@ -82,40 +76,6 @@
 /* Enabled instnaces default state */
 
 #define INST_EN_DEAFULT (0xff)
-
-/****************************************************************************
- * Private Type Definition
- ****************************************************************************/
-
-/****************************************************************************
- * Private Function Protototypes
- ****************************************************************************/
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_BUTTON
-/* Example state */
-
-static const int g_state_list[5] =
-{
-  FOC_EXAMPLE_STATE_FREE,
-  FOC_EXAMPLE_STATE_CW,
-  FOC_EXAMPLE_STATE_STOP,
-  FOC_EXAMPLE_STATE_CCW,
-  0
-};
-#endif
-
-pthread_mutex_t g_cntr_lock;
-
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
-static int g_float_thr_cntr = 0;
-#endif
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
-static int g_fixed16_thr_cntr = 0;
-#endif
 
 /****************************************************************************
  * Private Functions
@@ -336,218 +296,6 @@ static int foc_kill_send(mqd_t mqd)
 }
 
 /****************************************************************************
- * Name: foc_control_thr
- ****************************************************************************/
-
-FAR void *foc_control_thr(FAR void *arg)
-{
-  FAR struct foc_ctrl_env_s *envp = (FAR struct foc_ctrl_env_s *) arg;
-  char                       mqname[10];
-  int                        ret  = OK;
-
-  DEBUGASSERT(envp);
-
-  /* Get controller type */
-
-  pthread_mutex_lock(&g_cntr_lock);
-
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
-  if (g_float_thr_cntr < CONFIG_EXAMPLES_FOC_FLOAT_INST)
-    {
-      envp->type = FOC_NUMBER_TYPE_FLOAT;
-    }
-  else
-#endif
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
-  if (g_fixed16_thr_cntr < CONFIG_EXAMPLES_FOC_FIXED16_INST)
-    {
-      envp->type = FOC_NUMBER_TYPE_FIXED16;
-    }
-  else
-#endif
-    {
-      /* Invalid configuration */
-
-      ASSERT(0);
-    }
-
-  pthread_mutex_unlock(&g_cntr_lock);
-
-  PRINTF("FOC device %d type = %d!\n", envp->id, envp->type);
-
-  /* Get queue name */
-
-  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, envp->id);
-
-  /* Open queue */
-
-  envp->mqd = mq_open(mqname, (O_RDONLY | O_NONBLOCK), 0666, NULL);
-  if (envp->mqd == (mqd_t)-1)
-    {
-      PRINTF("ERROR: mq_open failed errno=%d\n", errno);
-      goto errout;
-    }
-
-  /* Select control logic according to FOC device type */
-
-  switch (envp->type)
-    {
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
-      case FOC_NUMBER_TYPE_FLOAT:
-        {
-          pthread_mutex_lock(&g_cntr_lock);
-          envp->inst = g_float_thr_cntr;
-          g_float_thr_cntr += 1;
-          pthread_mutex_unlock(&g_cntr_lock);
-
-          /* Start thread */
-
-          ret = foc_float_thr(envp);
-
-          pthread_mutex_lock(&g_cntr_lock);
-          g_float_thr_cntr -= 1;
-          pthread_mutex_unlock(&g_cntr_lock);
-
-          break;
-        }
-#endif
-
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
-      case FOC_NUMBER_TYPE_FIXED16:
-        {
-          pthread_mutex_lock(&g_cntr_lock);
-          envp->inst = g_fixed16_thr_cntr;
-          g_fixed16_thr_cntr += 1;
-          pthread_mutex_unlock(&g_cntr_lock);
-
-          /* Start thread */
-
-          ret = foc_fixed16_thr(envp);
-
-          pthread_mutex_lock(&g_cntr_lock);
-          g_fixed16_thr_cntr -= 1;
-          pthread_mutex_unlock(&g_cntr_lock);
-
-          break;
-        }
-#endif
-
-      default:
-        {
-          PRINTF("ERROR: unknown FOC device type %d\n", envp->type);
-          goto errout;
-        }
-    }
-
-  if (ret < 0)
-    {
-      PRINTF("ERROR: foc control thread failed %d\n", ret);
-    }
-
-errout:
-
-  /* Close queue */
-
-  if (envp->mqd == (mqd_t)-1)
-    {
-      mq_close(envp->mqd);
-    }
-
-  PRINTFV("foc_control_thr %d exit\n", envp->id);
-
-  return NULL;
-}
-
-/****************************************************************************
- * Name: foc_threads_terminated
- ****************************************************************************/
-
-static bool foc_threads_terminated(void)
-{
-  bool ret = false;
-
-  pthread_mutex_unlock(&g_cntr_lock);
-
-  if (1
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
-      && g_float_thr_cntr <= 0
-#endif
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
-      && g_fixed16_thr_cntr <= 0
-#endif
-    )
-    {
-      ret = true;
-    }
-
-  pthread_mutex_lock(&g_cntr_lock);
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: foc_threads_init
- ****************************************************************************/
-
-static int foc_threads_init(FAR struct foc_ctrl_env_s *foc, int i,
-                            FAR mqd_t *mqd, FAR pthread_t *thread)
-{
-  char                mqname[10];
-  int                 ret = OK;
-  pthread_attr_t      attr;
-  struct mq_attr      mqattr;
-  struct sched_param  param;
-
-  DEBUGASSERT(foc);
-  DEBUGASSERT(mqd);
-  DEBUGASSERT(thread);
-
-  /* Store device id */
-
-  foc->id = i;
-
-  /* Fill in attributes for message queue */
-
-  mqattr.mq_maxmsg  = CONTROL_MQ_MAXMSG;
-  mqattr.mq_msgsize = CONTROL_MQ_MSGSIZE;
-  mqattr.mq_flags   = 0;
-
-  /* Get queue name */
-
-  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, foc->id);
-
-  /* Initialize thread recv queue */
-
-  *mqd = mq_open(mqname, (O_WRONLY | O_CREAT | O_NONBLOCK),
-                 0666, &mqattr);
-  if (*mqd < 0)
-    {
-      PRINTF("ERROR: mq_open %s failed errno=%d\n", mqname, errno);
-      goto errout;
-    }
-
-  /* Configure thread */
-
-  pthread_attr_init(&attr);
-  param.sched_priority = CONFIG_EXAMPLES_FOC_CONTROL_PRIO;
-  pthread_attr_setschedparam(&attr, &param);
-  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_FOC_CONTROL_STACKSIZE);
-
-  /* Create FOC threads */
-
-  ret = pthread_create(thread, &attr, foc_control_thr, foc);
-  if (ret != 0)
-    {
-      PRINTF("ERROR: pthread_create ctrl failed %d\n", ret);
-      ret = -ret;
-      goto errout;
-    }
-
-errout:
-  return ret;
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -627,12 +375,12 @@ int main(int argc, char *argv[])
 
   PRINTF("\nStart foc_main application!\n\n");
 
-  /* Initialize mutex */
+  /* Initialize threads */
 
-  ret = pthread_mutex_init(&g_cntr_lock, NULL);
-  if (ret != 0)
+  ret = foc_threads_init();
+  if (ret < 0)
     {
-      PRINTF("ERROR: pthread_mutex_init failed %d\n", errno);
+      PRINTF("ERROR: failed to initialize threads %d\n", ret);
       goto errout_no_mutex;
     }
 
@@ -689,10 +437,10 @@ int main(int argc, char *argv[])
         {
           /* Initialize controller thread if enabled */
 
-          ret = foc_threads_init(&foc[i], i, &mqd[i], &threads[i]);
+          ret = foc_ctrlthr_init(&foc[i], i, &mqd[i], &threads[i]);
           if (ret < 0)
             {
-              PRINTF("ERROR: foc_threads_init failed %d!\n", ret);
+              PRINTF("ERROR: foc_ctrlthr_init failed %d!\n", ret);
               goto errout;
             }
         }
@@ -1010,9 +758,7 @@ errout:
 
 errout_no_mutex:
 
-  /* Free/uninitialize data structures */
-
-  pthread_mutex_destroy(&g_cntr_lock);
+  foc_threads_deinit();
 
   PRINTF("foc_main exit\n");
 

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -29,7 +29,6 @@
 #include "foc_motor_b16.h"
 
 #include "foc_cfg.h"
-#include "foc_adc.h"
 #include "foc_debug.h"
 
 /****************************************************************************

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -29,7 +29,6 @@
 #include "foc_motor_f32.h"
 
 #include "foc_cfg.h"
-#include "foc_adc.h"
 #include "foc_debug.h"
 
 /****************************************************************************

--- a/examples/foc/foc_thr.c
+++ b/examples/foc/foc_thr.c
@@ -1,0 +1,312 @@
+/****************************************************************************
+ * apps/examples/foc/foc_thr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "foc_mq.h"
+#include "foc_thr.h"
+#include "foc_debug.h"
+
+#include "industry/foc/foc_common.h"
+
+/****************************************************************************
+ * Extern Functions Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+extern int foc_float_thr(FAR struct foc_ctrl_env_s *envp);
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+extern int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+pthread_mutex_t g_cntr_lock;
+
+#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+static int g_float_thr_cntr = 0;
+#endif
+#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+static int g_fixed16_thr_cntr = 0;
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_control_thr
+ ****************************************************************************/
+
+static FAR void *foc_control_thr(FAR void *arg)
+{
+  FAR struct foc_ctrl_env_s *envp = (FAR struct foc_ctrl_env_s *) arg;
+  char                       mqname[10];
+  int                        ret  = OK;
+
+  DEBUGASSERT(envp);
+
+  /* Get controller type */
+
+  pthread_mutex_lock(&g_cntr_lock);
+
+#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+  if (g_float_thr_cntr < CONFIG_EXAMPLES_FOC_FLOAT_INST)
+    {
+      envp->type = FOC_NUMBER_TYPE_FLOAT;
+    }
+  else
+#endif
+#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+  if (g_fixed16_thr_cntr < CONFIG_EXAMPLES_FOC_FIXED16_INST)
+    {
+      envp->type = FOC_NUMBER_TYPE_FIXED16;
+    }
+  else
+#endif
+    {
+      /* Invalid configuration */
+
+      ASSERT(0);
+    }
+
+  pthread_mutex_unlock(&g_cntr_lock);
+
+  PRINTF("FOC device %d type = %d!\n", envp->id, envp->type);
+
+  /* Get queue name */
+
+  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, envp->id);
+
+  /* Open queue */
+
+  envp->mqd = mq_open(mqname, (O_RDONLY | O_NONBLOCK), 0666, NULL);
+  if (envp->mqd == (mqd_t)-1)
+    {
+      PRINTF("ERROR: mq_open failed errno=%d\n", errno);
+      goto errout;
+    }
+
+  /* Select control logic according to FOC device type */
+
+  switch (envp->type)
+    {
+#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+      case FOC_NUMBER_TYPE_FLOAT:
+        {
+          pthread_mutex_lock(&g_cntr_lock);
+          envp->inst = g_float_thr_cntr;
+          g_float_thr_cntr += 1;
+          pthread_mutex_unlock(&g_cntr_lock);
+
+          /* Start thread */
+
+          ret = foc_float_thr(envp);
+
+          pthread_mutex_lock(&g_cntr_lock);
+          g_float_thr_cntr -= 1;
+          pthread_mutex_unlock(&g_cntr_lock);
+
+          break;
+        }
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+      case FOC_NUMBER_TYPE_FIXED16:
+        {
+          pthread_mutex_lock(&g_cntr_lock);
+          envp->inst = g_fixed16_thr_cntr;
+          g_fixed16_thr_cntr += 1;
+          pthread_mutex_unlock(&g_cntr_lock);
+
+          /* Start thread */
+
+          ret = foc_fixed16_thr(envp);
+
+          pthread_mutex_lock(&g_cntr_lock);
+          g_fixed16_thr_cntr -= 1;
+          pthread_mutex_unlock(&g_cntr_lock);
+
+          break;
+        }
+#endif
+
+      default:
+        {
+          PRINTF("ERROR: unknown FOC device type %d\n", envp->type);
+          goto errout;
+        }
+    }
+
+  if (ret < 0)
+    {
+      PRINTF("ERROR: foc control thread failed %d\n", ret);
+    }
+
+errout:
+
+  /* Close queue */
+
+  if (envp->mqd == (mqd_t)-1)
+    {
+      mq_close(envp->mqd);
+    }
+
+  PRINTFV("foc_control_thr %d exit\n", envp->id);
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_threads_init
+ ****************************************************************************/
+
+int foc_threads_init(void)
+{
+  int ret = OK;
+
+  /* Initialize mutex */
+
+  ret = pthread_mutex_init(&g_cntr_lock, NULL);
+  if (ret != 0)
+    {
+      PRINTF("ERROR: pthread_mutex_init failed %d\n", errno);
+      goto errout;
+    }
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_threads_deinit
+ ****************************************************************************/
+
+void foc_threads_deinit(void)
+{
+  /* Free/uninitialize data structures */
+
+  pthread_mutex_destroy(&g_cntr_lock);
+}
+
+/****************************************************************************
+ * Name: foc_threads_terminated
+ ****************************************************************************/
+
+bool foc_threads_terminated(void)
+{
+  bool ret = false;
+
+  pthread_mutex_unlock(&g_cntr_lock);
+
+  if (1
+#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+      && g_float_thr_cntr <= 0
+#endif
+#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+      && g_fixed16_thr_cntr <= 0
+#endif
+    )
+    {
+      ret = true;
+    }
+
+  pthread_mutex_lock(&g_cntr_lock);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_ctrlthr_init
+ ****************************************************************************/
+
+int foc_ctrlthr_init(FAR struct foc_ctrl_env_s *foc, int i, FAR mqd_t *mqd,
+                     FAR pthread_t *thread)
+{
+  char                mqname[10];
+  int                 ret = OK;
+  pthread_attr_t      attr;
+  struct mq_attr      mqattr;
+  struct sched_param  param;
+
+  DEBUGASSERT(foc);
+  DEBUGASSERT(mqd);
+  DEBUGASSERT(thread);
+
+  /* Store device id */
+
+  foc->id = i;
+
+  /* Fill in attributes for message queue */
+
+  mqattr.mq_maxmsg  = CONTROL_MQ_MAXMSG;
+  mqattr.mq_msgsize = CONTROL_MQ_MSGSIZE;
+  mqattr.mq_flags   = 0;
+
+  /* Get queue name */
+
+  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, foc->id);
+
+  /* Initialize thread recv queue */
+
+  *mqd = mq_open(mqname, (O_WRONLY | O_CREAT | O_NONBLOCK),
+                 0666, &mqattr);
+  if (*mqd < 0)
+    {
+      PRINTF("ERROR: mq_open %s failed errno=%d\n", mqname, errno);
+      goto errout;
+    }
+
+  /* Configure thread */
+
+  pthread_attr_init(&attr);
+  param.sched_priority = CONFIG_EXAMPLES_FOC_CONTROL_PRIO;
+  pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_FOC_CONTROL_STACKSIZE);
+
+  /* Create FOC threads */
+
+  ret = pthread_create(thread, &attr, foc_control_thr, foc);
+  if (ret != 0)
+    {
+      PRINTF("ERROR: pthread_create ctrl failed %d\n", ret);
+      ret = -ret;
+      goto errout;
+    }
+
+errout:
+  return ret;
+}

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -27,9 +27,10 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/motor/foc/foc.h>
-
+#include <pthread.h>
 #include <mqueue.h>
+
+#include <nuttx/motor/foc/foc.h>
 
 #include "foc_device.h"
 
@@ -122,12 +123,10 @@ struct foc_ctrl_env_s
  * Public Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
-int foc_float_thr(FAR struct foc_ctrl_env_s *envp);
-#endif
-
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
-int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp);
-#endif
+int foc_threads_init(void);
+void foc_threads_deinit(void);
+bool foc_threads_terminated(void);
+int foc_ctrlthr_init(FAR struct foc_ctrl_env_s *foc, int i, FAR mqd_t *mqd,
+                     FAR pthread_t *thread);
 
 #endif /* __EXAMPLES_FOC_FOC_THR_H */


### PR DESCRIPTION
## Summary

- examples/foc/foc_cfg.h: fix typo
- examples/foc: move setpoint and vbus configuration from foc_adc.h to foc_cfg.h
- examples/foc: move threads related logic to a separate file
- examples/foc: move adc and button interfaces logic to a separate file

## Impact
No functional changes

## Testing
b-g431b-esc1/foc_f32
