### PR TITLE
timer_gpout example: use /dev/gpio0 and rename to timer_gpio

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1716,43 +1716,46 @@ Example configuration:
 - `CONFIG_EXAMPLES_TIMER_PROGNAME` – This is the name of the program that will
   be used when the NSH ELF program is installed. Default: `timer`.
 
-## `timer_gpout`
+## `timer_gpio`
 
-This example uses the timer interrupt to periodically
-change the state of a digital output.
-The digital output may be a relay, a led or anything else.
-This example can be very useful to validate timer drivers
-by using a logic analyzer connected to the digital output.
-This example, mainly differs from the timer example because it
-waits on a sigwaitinfo() instead of using a signal handler.
-This approach ensures a deterministic wake-up time when
-the signal occurs.
+This example uses the timer interrupt to periodically change the state of a
+digital output. The digital output may be a relay, a led or anything else.
+This example can be very useful to validate timer drivers by using a logic
+analyzer connected to the digital output. This example mainly differs from
+the timer example because it waits on a sigwaitinfo() instead of using a
+signal handler. This approach ensures a deterministic wake-up time when the
+signal occurs.
 
 Dependencies:
 
 - `CONFIG_TIMER` – The timer driver must be selected.
 - `CONFIG_DEV_GPIO` – The GPIO driver must be selected.
 
-Note: You should also select one timer instance and have gpout
-proper configured in your board logic.
+Note: You should also select one timer instance and have the gpio driver
+properly configured in your board logic.
 
 Example configuration:
 
-- `EXAMPLES_TIMER_GPOUT_TIM_DEVNAME` – This is the name of the timer device that will be used.
-   Default: `/dev/timer0`.
-- `EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME` – This is the name of the gpout device that will be used.
+- `EXAMPLES_TIMER_GPIO_TIM_DEVNAME` – This is the name of the timer device
+    that will be used.
+  Default: `/dev/timer0`.
+- `EXAMPLES_TIMER_GPIO_GPIO_DEVNAME` – This is the name of the gpio device
+    that will be used.
   Default: `/dev/gpio0`.
-- `EXAMPLES_TIMER_GPOUT_INTERVAL` – This is the timer interval in microseconds.
+- `EXAMPLES_TIMER_GPIO_INTERVAL` – This is the timer interval in
+    microseconds.
   Default: `1000000`.
-- `EXAMPLES_TIMER_GPOUT_SIGNO` – This is the signal number that is used to notify that a timer
-		interrupt occurred.
+- `EXAMPLES_TIMER_GPIO_SIGNO` – This is the signal number that is used to
+    notify that a timer interrupt occurred.
   Default: `17`.
-- `EXAMPLES_TIMER_GPOUT_STACKSIZE` – This is the stack size allocated when the timer task runs.
+- `EXAMPLES_TIMER_GPIO_STACKSIZE` – This is the stack size allocated when the
+    timer task runs.
   Default: `2048`.
-- `EXAMPLES_TIMER_GPOUT_PRIORITY` – This is the priority of the timer task.
+- `EXAMPLES_TIMER_GPIO_PRIORITY` – This is the priority of the timer task.
   Default: `255`.
-- `EXAMPLES_TIMER_GPOUT_PROGNAME` – This is the name of the program that will be used from the nsh.
-  Default: `timer_gpout`.
+- `EXAMPLES_TIMER_GPIO_PROGNAME` – This is the name of the program that will
+    be used from the nsh.
+  Default: `timer_gpio`.
 
 ## `touchscreen` Touchscreen Events
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1740,8 +1740,8 @@ Example configuration:
 
 - `EXAMPLES_TIMER_GPOUT_TIM_DEVNAME` – This is the name of the timer device that will be used.
    Default: `/dev/timer0`.
-- `EXAMPLES_TIMER_GPOUT_GPOUT_DEVNAME` – This is the name of the gpout device that will be used.
-  Default: `/dev/gpout0`.
+- `EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME` – This is the name of the gpout device that will be used.
+  Default: `/dev/gpio0`.
 - `EXAMPLES_TIMER_GPOUT_INTERVAL` – This is the timer interval in microseconds.
   Default: `1000000`.
 - `EXAMPLES_TIMER_GPOUT_SIGNO` – This is the signal number that is used to notify that a timer

--- a/examples/timer_gpio/Kconfig
+++ b/examples/timer_gpio/Kconfig
@@ -3,64 +3,62 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config EXAMPLES_TIMER_GPOUT
-	tristate "Timer GPOUT example"
+config EXAMPLES_TIMER_GPIO
+	tristate "Timer GPIO example"
 	default n
 	depends on TIMER && DEV_GPIO
 	---help---
-		Enable the timer-gpout example.
-		This example uses the timer interrupt to periodically
-		change the state of a digital output.
-		The digital output may be a relay, a led or anything else.
-		This example can be very useful to validate timer drivers
-		by using a logic analyzer connected to the digital output.
-		This example, differs from the timer example because it
-		waits on a sigwaitinfo() instead of using a signal handler.
-		This approach ensures a deterministic wake-up time when
-		the signal occurs. 
+		Enable the timer-gpio example. This example uses the timer interrupt
+		to periodically change the state of a digital output. The digital
+		output may be a relay, a led or anything else. This example can be
+		very useful to validate timer drivers by using a logic analyzer
+		connected to the digital output. This example differs from the timer
+		example because it waits on a sigwaitinfo() instead of using a signal
+		handler. This approach ensures a deterministic wake-up time when the
+		signal occurs. 
 
-if EXAMPLES_TIMER_GPOUT
+if EXAMPLES_TIMER_GPIO
 
-config EXAMPLES_TIMER_GPOUT_TIM_DEVNAME
+config EXAMPLES_TIMER_GPIO_TIM_DEVNAME
 	string "Timer device name"
 	default "/dev/timer0"
 	---help---
 		This is the name of the timer device that will be used.
 
-config EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME
-	string "GPOUT device name"
+config EXAMPLES_TIMER_GPIO_GPIO_DEVNAME
+	string "GPIO device name"
 	default "/dev/gpio0"
 	---help---
 		This is the name of the gpio device that will be used.
 
-config EXAMPLES_TIMER_GPOUT_INTERVAL
+config EXAMPLES_TIMER_GPIO_INTERVAL
 	int "Timer interval (microseconds)"
 	default 1000000
 	---help---
 		This is the timer interval in microseconds.
 
-config EXAMPLES_TIMER_GPOUT_SIGNO
+config EXAMPLES_TIMER_GPIO_SIGNO
 	int "Notification signal number"
 	default 17
 	---help---
 		This is the signal number that is used to notify that a timer
 		interrupt occurred.
 
-config EXAMPLES_TIMER_GPOUT_STACKSIZE
+config EXAMPLES_TIMER_GPIO_STACKSIZE
 	int "Timer stack size"
 	default DEFAULT_TASK_STACKSIZE
 	---help---
 		This is the stack size allocated when the timer task runs.
 
-config EXAMPLES_TIMER_GPOUT_PRIORITY
+config EXAMPLES_TIMER_GPIO_PRIORITY
 	int "Timer task priority"
 	default 255
 	---help---
 		This is the priority of the timer task.
 
-config EXAMPLES_TIMER_GPOUT_PROGNAME
-	string "Timer GPOUT program name"
-	default "timer_gpout"
+config EXAMPLES_TIMER_GPIO_PROGNAME
+	string "Timer GPIO program name"
+	default "timer_gpio"
 	---help---
 		This is the name of the program that will be used from the nsh.
 

--- a/examples/timer_gpio/Make.defs
+++ b/examples/timer_gpio/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/timer_gpout/Makefile
+# apps/examples/timer_gpio/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,17 +18,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-# Timer built-in application info
-
-PROGNAME  = $(CONFIG_EXAMPLES_TIMER_GPOUT_PROGNAME)
-PRIORITY  = $(CONFIG_EXAMPLES_TIMER_GPOUT_PRIORITY)
-STACKSIZE = $(CONFIG_EXAMPLES_TIMER_GPOUT_STACKSIZE)
-MODULE    = $(CONFIG_EXAMPLES_TIMER_GPOUT)
-
-# Timer example
-
-MAINSRC = timer_gpout_main.c
-
-include $(APPDIR)/Application.mk
+ifeq ($(CONFIG_EXAMPLES_TIMER_GPIO),y)
+CONFIGURED_APPS += $(APPDIR)/examples/timer_gpio
+endif

--- a/examples/timer_gpio/Makefile
+++ b/examples/timer_gpio/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/timer_gpout/Make.defs
+# apps/examples/timer_gpio/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +18,17 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_TIMER_GPOUT),y)
-CONFIGURED_APPS += $(APPDIR)/examples/timer_gpout
-endif
+include $(APPDIR)/Make.defs
+
+# Timer built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_TIMER_GPIO_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_TIMER_GPIO_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_TIMER_GPIO_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_TIMER_GPIO)
+
+# Timer example
+
+MAINSRC = timer_gpio_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/timer_gpio/timer_gpio_main.c
+++ b/examples/timer_gpio/timer_gpio_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/timer_gpout/timer_gpout_main.c
+ * apps/examples/timer_gpio/timer_gpio_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -50,7 +50,7 @@
 
 static char g_devtim[DEVNAME_SIZE];
 static char g_devgpio[DEVNAME_SIZE];
-static bool g_timer_gpout_daemon_started = false;
+static bool g_timer_gpio_daemon_started = false;
 
 /****************************************************************************
  * Private Functions
@@ -90,7 +90,7 @@ static void timer_status(int fd)
 }
 
 /****************************************************************************
- * Name: timer_gpout_daemon
+ * Name: timer_gpio_daemon
  *
  * Description:
  *   Deamon that will be active waiting on a signal to change the digital
@@ -98,7 +98,7 @@ static void timer_status(int fd)
  *
  ****************************************************************************/
 
-static int timer_gpout_daemon(int argc, char *argv[])
+static int timer_gpio_daemon(int argc, char *argv[])
 {
   struct timer_notify_s notify;
   sigset_t set;
@@ -110,8 +110,8 @@ static int timer_gpout_daemon(int argc, char *argv[])
 
   /* Indicate that the deamon is running */
 
-  g_timer_gpout_daemon_started = true;
-  printf("timer_gpout_daemon: timer_gpout_daemon started\n");
+  g_timer_gpio_daemon_started = true;
+  printf("timer_gpio_daemon: timer_gpio_daemon started\n");
 
   /* Open the timer device */
 
@@ -121,7 +121,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   if (fd_timer < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_daemon: Failed to open %s: %d\n",
+      printf("timer_gpio_daemon: Failed to open %s: %d\n",
               g_devtim, errcode);
       return EXIT_FAILURE;
     }
@@ -134,7 +134,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   if (fd_gpio < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_daemon: Failed to open %s: %d\n",
+      printf("timer_gpio_daemon: Failed to open %s: %d\n",
               g_devgpio, errcode);
       close(fd_timer);
       return EXIT_FAILURE;
@@ -147,14 +147,14 @@ static int timer_gpout_daemon(int argc, char *argv[])
   /* Set the timer interval */
 
   printf("Set timer interval to %lu\n",
-         (unsigned long)CONFIG_EXAMPLES_TIMER_GPOUT_INTERVAL);
+         (unsigned long)CONFIG_EXAMPLES_TIMER_GPIO_INTERVAL);
 
   ret = ioctl(fd_timer, TCIOC_SETTIMEOUT,
-              CONFIG_EXAMPLES_TIMER_GPOUT_INTERVAL);
+              CONFIG_EXAMPLES_TIMER_GPIO_INTERVAL);
   if (ret < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_daemon: Failed to set the timer interval: %d\n",
+      printf("timer_gpio_daemon: Failed to set the timer interval: %d\n",
              errcode);
       goto errout;
     }
@@ -166,7 +166,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   /* Configure the signal set for this task */
 
   sigemptyset(&set);
-  sigaddset(&set, CONFIG_EXAMPLES_TIMER_GPOUT_SIGNO);
+  sigaddset(&set, CONFIG_EXAMPLES_TIMER_GPIO_SIGNO);
 
   /* Configure the timer notifier to receive a signal when timeout occurs.
    * Inform the PID of the process that will be notified by the internal
@@ -178,7 +178,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
 
   notify.pid   = getpid();
   notify.event.sigev_notify = SIGEV_SIGNAL;
-  notify.event.sigev_signo  = CONFIG_EXAMPLES_TIMER_GPOUT_SIGNO;
+  notify.event.sigev_signo  = CONFIG_EXAMPLES_TIMER_GPIO_SIGNO;
   notify.event.sigev_value.sival_ptr = NULL;
 
   ret = ioctl(fd_timer, TCIOC_NOTIFICATION,
@@ -186,7 +186,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   if (ret < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_daemon: Failed to set the timer handler: %d\n",
+      printf("timer_gpio_daemon: Failed to set the timer handler: %d\n",
              errcode);
       goto errout;
     }
@@ -199,7 +199,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   if (ret < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_daemon: Failed to start the timer: %d\n", errcode);
+      printf("timer_gpio_daemon: Failed to start the timer: %d\n", errcode);
       goto errout;
     }
 
@@ -209,7 +209,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
       if (ret < 0)
         {
           int errcode = errno;
-          printf("timer_gpout_daemon: ERROR: sigwaitinfo() failed: %d\n",
+          printf("timer_gpio_daemon: ERROR: sigwaitinfo() failed: %d\n",
                  errcode);
           goto errout;
         }
@@ -224,7 +224,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
       if (ret < 0)
         {
           int errcode = errno;
-          printf("timer_gpout_daemon: Failed to write value"
+          printf("timer_gpio_daemon: Failed to write value"
                  " %u from %s: %d\n",
                 (unsigned int)state, g_devgpio, errcode);
           goto errout;
@@ -234,9 +234,9 @@ static int timer_gpout_daemon(int argc, char *argv[])
 errout:
   close(fd_timer);
   close(fd_gpio);
-  g_timer_gpout_daemon_started = false;
+  g_timer_gpio_daemon_started = false;
 
-  printf("timer_gpout_daemon: Terminating!\n");
+  printf("timer_gpio_daemon: Terminating!\n");
   return EXIT_FAILURE;
 }
 
@@ -245,7 +245,7 @@ errout:
  ****************************************************************************/
 
 /****************************************************************************
- * timer_gpout main
+ * timer_gpio main
  ****************************************************************************/
 
 int main(int argc, FAR char *argv[])
@@ -253,9 +253,9 @@ int main(int argc, FAR char *argv[])
   int ret;
   int opt;
 
-  if (g_timer_gpout_daemon_started)
+  if (g_timer_gpio_daemon_started)
     {
-      printf("timer_gpout_main: timer_gpout daemon already running\n");
+      printf("timer_gpio_main: timer_gpio daemon already running\n");
       return EXIT_SUCCESS;
     }
 
@@ -263,8 +263,8 @@ int main(int argc, FAR char *argv[])
 
   /* Use the ones configured on menuconfig */
 
-  strcpy(g_devtim, CONFIG_EXAMPLES_TIMER_GPOUT_TIM_DEVNAME);
-  strcpy(g_devgpio, CONFIG_EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME);
+  strcpy(g_devtim, CONFIG_EXAMPLES_TIMER_GPIO_TIM_DEVNAME);
+  strcpy(g_devgpio, CONFIG_EXAMPLES_TIMER_GPIO_GPIO_DEVNAME);
 
   /* Or the ones passed as arguments */
 
@@ -282,22 +282,22 @@ int main(int argc, FAR char *argv[])
             fprintf(stderr, "ERROR: Option needs a value\n");
             exit(EXIT_FAILURE);
         default: /* '?' */
-            fprintf(stderr, "Usage: %s [-d /dev/timerx] [-d /dev/gpiox]\n",
+            fprintf(stderr, "Usage: %s [-t /dev/timer0] [-g /dev/gpio0]\n",
                     argv[0]);
             exit(EXIT_FAILURE);
       }
     }
 
-  printf("timer_gpout_main: Starting the timer_gpout daemon\n");
-  ret = task_create("timer_gpout_daemon",
-                    CONFIG_EXAMPLES_TIMER_GPOUT_PRIORITY,
-                    CONFIG_EXAMPLES_TIMER_GPOUT_STACKSIZE,
-                    timer_gpout_daemon,
+  printf("timer_gpio_main: Starting the timer_gpio daemon\n");
+  ret = task_create("timer_gpio_daemon",
+                    CONFIG_EXAMPLES_TIMER_GPIO_PRIORITY,
+                    CONFIG_EXAMPLES_TIMER_GPIO_STACKSIZE,
+                    timer_gpio_daemon,
                     NULL);
   if (ret < 0)
     {
       int errcode = errno;
-      printf("timer_gpout_main: Failed to start timer_gpout_daemon: %d\n",
+      printf("timer_gpio_main: Failed to start timer_gpio_daemon: %d\n",
              errcode);
       return EXIT_FAILURE;
     }

--- a/examples/timer_gpout/Kconfig
+++ b/examples/timer_gpout/Kconfig
@@ -27,11 +27,11 @@ config EXAMPLES_TIMER_GPOUT_TIM_DEVNAME
 	---help---
 		This is the name of the timer device that will be used.
 
-config EXAMPLES_TIMER_GPOUT_GPOUT_DEVNAME
+config EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME
 	string "GPOUT device name"
-	default "/dev/gpout0"
+	default "/dev/gpio0"
 	---help---
-		This is the name of the gpout device that will be used.
+		This is the name of the gpio device that will be used.
 
 config EXAMPLES_TIMER_GPOUT_INTERVAL
 	int "Timer interval (microseconds)"

--- a/examples/timer_gpout/timer_gpout_main.c
+++ b/examples/timer_gpout/timer_gpout_main.c
@@ -38,7 +38,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define DEVNAME_SIZE 16
+#define DEVNAME_SIZE 32
 
 /****************************************************************************
  * Private Types
@@ -49,7 +49,7 @@
  ****************************************************************************/
 
 static char g_devtim[DEVNAME_SIZE];
-static char g_devgpout[DEVNAME_SIZE];
+static char g_devgpio[DEVNAME_SIZE];
 static bool g_timer_gpout_daemon_started = false;
 
 /****************************************************************************
@@ -104,7 +104,7 @@ static int timer_gpout_daemon(int argc, char *argv[])
   sigset_t set;
   struct siginfo value;
   int fd_timer;
-  int fd_gpout;
+  int fd_gpio;
   int ret;
   bool state = false;
 
@@ -128,14 +128,14 @@ static int timer_gpout_daemon(int argc, char *argv[])
 
   /* Open the GPIO driver */
 
-  printf("Open %s\n", g_devgpout);
+  printf("Open %s\n", g_devgpio);
 
-  fd_gpout = open(g_devgpout, O_RDWR);
-  if (fd_gpout < 0)
+  fd_gpio = open(g_devgpio, O_RDWR);
+  if (fd_gpio < 0)
     {
       int errcode = errno;
       printf("timer_gpout_daemon: Failed to open %s: %d\n",
-              g_devgpout, errcode);
+              g_devgpio, errcode);
       close(fd_timer);
       return EXIT_FAILURE;
     }
@@ -214,26 +214,26 @@ static int timer_gpout_daemon(int argc, char *argv[])
           goto errout;
         }
 
-      /* Change the gpout state */
+      /* Change the gpio state */
 
       state = !state;
 
       /* Write the pin value */
 
-      ret = ioctl(fd_gpout, GPIOC_WRITE, (unsigned long)state);
+      ret = ioctl(fd_gpio, GPIOC_WRITE, (unsigned long)state);
       if (ret < 0)
         {
           int errcode = errno;
           printf("timer_gpout_daemon: Failed to write value"
                  " %u from %s: %d\n",
-                (unsigned int)state, g_devgpout, errcode);
+                (unsigned int)state, g_devgpio, errcode);
           goto errout;
         }
     }
 
 errout:
   close(fd_timer);
-  close(fd_gpout);
+  close(fd_gpio);
   g_timer_gpout_daemon_started = false;
 
   printf("timer_gpout_daemon: Terminating!\n");
@@ -264,7 +264,7 @@ int main(int argc, FAR char *argv[])
   /* Use the ones configured on menuconfig */
 
   strcpy(g_devtim, CONFIG_EXAMPLES_TIMER_GPOUT_TIM_DEVNAME);
-  strcpy(g_devgpout, CONFIG_EXAMPLES_TIMER_GPOUT_GPOUT_DEVNAME);
+  strcpy(g_devgpio, CONFIG_EXAMPLES_TIMER_GPOUT_GPIO_DEVNAME);
 
   /* Or the ones passed as arguments */
 
@@ -276,13 +276,13 @@ int main(int argc, FAR char *argv[])
             strcpy(g_devtim, optarg);
             break;
         case 'g':
-            strcpy(g_devgpout, optarg);
+            strcpy(g_devgpio, optarg);
             break;
         case ':':
             fprintf(stderr, "ERROR: Option needs a value\n");
             exit(EXIT_FAILURE);
         default: /* '?' */
-            fprintf(stderr, "Usage: %s [-d /dev/timerx] [-d /dev/gpoutx]\n",
+            fprintf(stderr, "Usage: %s [-d /dev/timerx] [-d /dev/gpiox]\n",
                     argv[0]);
             exit(EXIT_FAILURE);
       }


### PR DESCRIPTION
## Summary
https://github.com/apache/incubator-nuttx/pull/4774 changes the naming of GPIO devices. Instead of separate gpout, gpin and gpint devices they are all named /dev/gpioN now. The timer_gpout example seems to be the only application that has explicit references to /dev/gpout0, so I have made changes so that it now uses /dev/gpio0 instead.

I have also renamed the application itself from timer_gpout to timer_gpio, which seems more appropriate now that there is no explicit gpout devices anymore.

## Impact
See https://github.com/apache/incubator-nuttx/pull/4774 - everybody and everything that was using /dev/gpoutN devices now needs to use /dev/gpioN. With this PR this will already be fixed for the timer_gpio application, which seems to be the only app to directly use a /dev/gpout device.

## Testing
I don't have access to a board/arch that implements both the timer and gpio drivers, so I was not able to test this on real hardware. However, the application builds without issues for a STM32F4Discovery board with timer and gpio drivers enabled.

