### PR TITLE
crypto/mbedtls: Fix occasional failures during Mbed TLS build

### DIFF
--- a/crypto/mbedtls/Make.defs
+++ b/crypto/mbedtls/Make.defs
@@ -29,8 +29,4 @@ CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/mbedtls/mbed
 CFLAGS += ${shell $(DEFINE) "$(CC)" MBEDTLS_CONFIG_FILE='"<crypto/mbedtls_config.h>"'}
 CXXFLAGS += ${shell $(DEFINE) "$(CC)" MBEDTLS_CONFIG_FILE='"<crypto/mbedtls_config.h>"'}
 
-ifneq ($(CONFIG_MBEDTLS_APPS),)
-CONFIGURED_APPS += $(APPDIR)/crypto/mbedtls/
-endif
-
 endif


### PR DESCRIPTION
## Summary
This PR intends to provide a fix to an occasional build failure on Mbed TLS.
Mbed TLS was being added twice to `CONFIGURED_APPS` variable, resulting in it being built more than once. If parallel build is enabled, the build could randomly fail due to unmet dependencies.

## Impact
Fix to Mbed TLS build. After patch is applied, build passes consistently.

## Testing
`esp32-devkitc` with a custom defconfig.

