### PR TITLE
wireless/bluetooth/nimble: make stacksize configurable

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -7,7 +7,11 @@ config NIMBLE
     host-layer stack.
 
 if NIMBLE
-  config NIMBLE_REF
+config NIMBLE_STACKSIZE
+	int "nimble stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+config NIMBLE_REF
   string "Version"
   default "cd8ab38c3da91b71dd428979153a408f38d3b02e"
   ---help---

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -21,7 +21,7 @@
 include $(APPDIR)/Make.defs
 
 PRIORITY  = 255
-STACKSIZE = 16384
+STACKSIZE = $(CONFIG_NIMBLE_STACKSIZE)
 
 NIMBLE_UNPACKDIR = mynewt-nimble
 NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/$(NIMBLE_UNPACKDIR)


### PR DESCRIPTION
## Summary
wireless/bluetooth/nimble: make stacksize configurable

After this change, nimble works again on nrf52832:

```
NuttShell (NSH) NuttX-10.2.0
nsh> 
nsh> 
nsh> 
nsh> nimble &
nimble [5:255]
port init
hci init
gap init
gatt init
ans init
ias init
lls init
tps init
hci_sock task init
ble_host task init
nsh> hci sock task
host task
advertise

nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 001000 Idle Task
    1     1 224 RR       Kthread --- Waiting  Semaphore 00000000 002016 hpwork 0x20000d24
    2     2 100 RR       Kthread --- Ready              00000000 002016 lpwork 0x20000d30
    3     3 100 RR       Task    --- Running            00000000 002032 init
    4     4 100 RR       Kthread --- Waiting  MQ empty  00000000 002024 BT HCI Tx
    5     5 255 RR       Task    --- Waiting  Signal    00000000 002032 nimble
    7     5   1 RR       pthread --- Waiting  Semaphore 00000000 002048 pt-0x12fdd 0
    8     5   1 RR       pthread --- Waiting  MQ empty  00000000 002048 pt-0x12ff5 0
nsh> free
                   total       used       free    largest  nused  nfree
        Umem:      32400      26048       6352       5776     77      5
```




## Impact

## Testing
nrf52840-dk and nrf52832-dk
