### PR TITLE
ci: Bump github/super-linter version to V4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 🧹 YAML Lint
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_YAML: true
           FILTER_REGEX_INCLUDE: .*\.github/.*


### PR DESCRIPTION
## Summary
This PR intends to bump the version of the `github/super-linter` action.

## Impact
This is an attempt to fix a recent issue with the Lint job.
![image](https://user-images.githubusercontent.com/38959758/146970901-a447849d-74b9-403d-bf2d-1f8e9736e279.png)

## Testing
CI build pass.
