### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 /symtab_apps.c
 cscope.out
 Make.dep
+# nuttx/$(TOPDIR)/Makefile.[unix|win]::$(DIRLINKS_EXTERNAL_DIRS)
+.dirlinks


### PR DESCRIPTION
## Summary
This PR: https://github.com/apache/incubator-nuttx/pull/5069 creates a file named .dirlinks.
This PR adds that file to the .gitignore

## Impact
The file is for tracking simlinks have been built, not needed for normal use.

## Testing
Verified it's not showing up locally
