### PR TITLE
apps: remove space befone newline in logs

### DIFF
--- a/canutils/libobd2/obd_decodepid.c
+++ b/canutils/libobd2/obd_decodepid.c
@@ -111,7 +111,7 @@ FAR char *obd_decode_pid(FAR struct obd_dev_s *dev, uint8_t pid)
       case OBD_PID_THROTTLE_POSITION:
         snprintf(g_data, MAXDATA, "%d", (100 * dev->data[3])/255);
 #ifdef CONFIG_DEBUG_INFO
-        printf("Throttle position = %d\% \n", (100 * dev->data[3])/255);
+        printf("Throttle position = %d\%\n", (100 * dev->data[3])/255);
 #endif
         break;
     }

--- a/examples/adxl372_test/adxl372_test_main.c
+++ b/examples/adxl372_test/adxl372_test_main.c
@@ -443,7 +443,7 @@ int main(int argc, FAR char *argv[])
 
   if (is_interactive)
     {
-      printf("LSM330 diagnostic started in interactive mode... \n");
+      printf("LSM330 diagnostic started in interactive mode...\n");
       ch = 0;
       while (ch != 'x')
         {

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -82,12 +82,12 @@ static void foc_help(void)
   PRINTF("  [-h] shows this message and exits\n");
   PRINTF("  [-m] operation mode\n");
   PRINTF("       1 - IDLE mode\n");
-  PRINTF("       2 - voltage mode \n");
-  PRINTF("       3 - current mode \n");
+  PRINTF("       2 - voltage mode\n");
+  PRINTF("       3 - current mode\n");
   PRINTF("  [-c] controller mode\n");
-  PRINTF("       1 - torqe control \n");
-  PRINTF("       2 - velocity control \n");
-  PRINTF("       3 - position control \n");
+  PRINTF("       1 - torqe control\n");
+  PRINTF("       2 - velocity control\n");
+  PRINTF("       3 - position control\n");
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
   PRINTF("  [-r] torque [x1000]\n");
 #endif

--- a/examples/lsm330spi_test/lsm330spi_test_main.c
+++ b/examples/lsm330spi_test/lsm330spi_test_main.c
@@ -689,7 +689,7 @@ int main(int argc, FAR char *argv[])
 
   if (is_interactive)
     {
-      printf("LSM330 diagnostic started in interactive mode... \n");
+      printf("LSM330 diagnostic started in interactive mode...\n");
       ch = 0;
       while (ch != 'x')
         {

--- a/examples/modbusmaster/mbmaster_main.c
+++ b/examples/modbusmaster/mbmaster_main.c
@@ -222,7 +222,7 @@ static FAR void *mbmaster_pollthread(FAR void *pvarg)
 
 static void mbmaster_showstatistics(void)
 {
-  printf("Modbus master statistics: \n");
+  printf("Modbus master statistics:\n");
   printf("Requests count:  %d\n", g_mbmaster.statistics.reqcount);
   printf("Responses count: %d\n", g_mbmaster.statistics.rspcount);
   printf("Errors count:    %d\n", g_mbmaster.statistics.errcount);

--- a/examples/nettest/nettest_client.c
+++ b/examples/nettest/nettest_client.c
@@ -144,7 +144,7 @@ void nettest_client(void)
         }
       else if (nbytessent != SENDSIZE)
         {
-          printf("client: Bad send length=%d: %d of \n",
+          printf("client: Bad send length=%d: of %d\n",
                   nbytessent, SENDSIZE);
           goto errout_with_socket;
         }

--- a/examples/powerled/powerled_main.c
+++ b/examples/powerled/powerled_main.c
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
                                  (unsigned long)powerled_mode);
                       if (ret < 0)
                         {
-                          printf("failed to set powerled mode %d \n", ret);
+                          printf("failed to set powerled mode %d\n", ret);
                         }
 
                       config = false;
@@ -525,7 +525,7 @@ int main(int argc, char *argv[])
                              (unsigned long)&powerled_params);
                   if (ret < 0)
                     {
-                      printf("failed to set params %d \n", ret);
+                      printf("failed to set params %d\n", ret);
                     }
 
                   /* Start Powerled */
@@ -573,7 +573,7 @@ int main(int argc, char *argv[])
                                  (unsigned long)powerled_mode);
                       if (ret < 0)
                         {
-                          printf("failed to set powerled mode %d \n", ret);
+                          printf("failed to set powerled mode %d\n", ret);
                         }
 
                       printf("Brightness is %.2f\n",
@@ -591,7 +591,7 @@ int main(int argc, char *argv[])
                              (unsigned long)&powerled_params);
                   if (ret < 0)
                     {
-                      printf("failed to set params %d \n", ret);
+                      printf("failed to set params %d\n", ret);
                     }
 
                   /* Start Powerled */
@@ -638,7 +638,7 @@ int main(int argc, char *argv[])
                              (unsigned long)powerled_mode);
                   if (ret < 0)
                     {
-                      printf("failed to set powerled mode %d \n", ret);
+                      printf("failed to set powerled mode %d\n", ret);
                     }
 
                   powerled_params.brightness = args->brightness;
@@ -651,7 +651,7 @@ int main(int argc, char *argv[])
                              (unsigned long)&powerled_params);
                   if (ret < 0)
                     {
-                      printf("failed to set params %d \n", ret);
+                      printf("failed to set params %d\n", ret);
                     }
 
                   /* Start Powerled */
@@ -684,7 +684,7 @@ int main(int argc, char *argv[])
                              (unsigned long)powerled_mode);
                   if (ret < 0)
                     {
-                      printf("failed to set powerled mode %d \n", ret);
+                      printf("failed to set powerled mode %d\n", ret);
                     }
 
                   powerled_params.brightness = args->brightness;
@@ -697,7 +697,7 @@ int main(int argc, char *argv[])
                              (unsigned long)&powerled_params);
                   if (ret < 0)
                     {
-                      printf("failed to set params %d \n", ret);
+                      printf("failed to set params %d\n", ret);
                     }
 
                   /* Start Powerled */
@@ -726,7 +726,7 @@ int main(int argc, char *argv[])
       ret = ioctl(fd, PWRIOC_GET_STATE, (unsigned long)&powerled_state);
       if (ret < 0)
         {
-          printf("Failed to get state %d \n", ret);
+          printf("Failed to get state %d\n", ret);
         }
 
       /* Terminate if fault state */

--- a/examples/smps/smps_main.c
+++ b/examples/smps/smps_main.c
@@ -573,7 +573,7 @@ int main(int argc, char *argv[])
       ret = ioctl(fd, PWRIOC_GET_STATE, (unsigned long)&smps_state);
       if (ret < 0)
         {
-          printf("Failed to get state %d \n", ret);
+          printf("Failed to get state %d\n", ret);
         }
 
       /* Terminate if fault state */

--- a/examples/tcpblaster/tcpblaster_client.c
+++ b/examples/tcpblaster/tcpblaster_client.c
@@ -184,7 +184,7 @@ void tcpblaster_client(void)
         }
       else if (nbytessent != SENDSIZE)
         {
-          printf("client: Bad send length=%d: %d of \n",
+          printf("client: Bad send length=%d: of %d\n",
                   nbytessent, SENDSIZE);
           goto errout_with_socket;
         }

--- a/examples/wget/wget_main.c
+++ b/examples/wget/wget_main.c
@@ -164,7 +164,7 @@ int main(int argc, FAR char *argv[])
                   S_IRWXU | S_IRWXG | S_IRWXO);
       if (g_fd < 0)
         {
-          printf("cannot create file %s \n", argv[argc - 2]);
+          printf("cannot create file %s\n", argv[argc - 2]);
         }
     }
   else if (argc == 2)

--- a/examples/wgetjson/wgetjson_main.c
+++ b/examples/wgetjson/wgetjson_main.c
@@ -213,38 +213,38 @@ static int wgetjson_json_item_callback(const char *name, int type,
 
   if (!strcmp(name, "name"))
     {
-      printf("name:\t\t\t%s \n", item->valuestring);
+      printf("name:\t\t\t%s\n", item->valuestring);
 
       /* todo something.... */
     }
   else if (strcmp(name, "format/type") == 0)
     {
-      printf("format/type:\t\t%s \n", item->valuestring);
+      printf("format/type:\t\t%s\n", item->valuestring);
 
       /* todo something.... */
     }
   else if (!strcmp(name, "format/width"))
     {
-      printf("format/width:\t\t%d \n", item->valueint);
+      printf("format/width:\t\t%d\n", item->valueint);
 
       /* todo something.... */
     }
   else if (!strcmp(name, "format/height"))
     {
-      printf("format/height:\t\t%d \n", item->valueint);
+      printf("format/height:\t\t%d\n", item->valueint);
 
       /* todo something.... */
     }
   else if (!strcmp(name, "format/interlace"))
     {
-      printf("format/interlace:\t%s \n",
+      printf("format/interlace:\t%s\n",
              (item->valueint) ? "true" : "false");
 
       /* todo something.... */
     }
   else if (!strcmp(name, "format/frame rate"))
     {
-      printf("format/frame rate:\t%d \n", item->valueint);
+      printf("format/frame rate:\t%d\n", item->valueint);
 
       /* todo something.... */
     }

--- a/graphics/nxwm/src/ccalibration.cxx
+++ b/graphics/nxwm/src/ccalibration.cxx
@@ -1305,7 +1305,7 @@ IApplication *CCalibrationFactory::create(void)
 
   if (!window->open())
     {
-      gerr("ERROR: Failed to open CFullScreenWindow \n");
+      gerr("ERROR: Failed to open CFullScreenWindow\n");
       delete window;
       return (IApplication *)0;
     }

--- a/graphics/nxwm/src/nxwm_main.cxx
+++ b/graphics/nxwm/src/nxwm_main.cxx
@@ -217,7 +217,7 @@ static bool createStartWindow(void)
 
   if (!window->open())
     {
-      printf("createStartWindow: ERROR: Failed to open CApplicationWindow \n");
+      printf("createStartWindow: ERROR: Failed to open CApplicationWindow\n");
       delete window;
       return false;
     }

--- a/graphics/pdcurs34/pdcurses/pdc_addchstr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_addchstr.c
@@ -233,7 +233,7 @@ int mvwaddchstr(WINDOW *win, int y, int x, const chtype *ch)
 
 int mvwaddchnstr(WINDOW *win, int y, int x, const chtype *ch, int n)
 {
-  PDC_LOG(("mvwaddchnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvwaddchnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (wmove(win, y, x) == ERR)
     {
@@ -322,7 +322,7 @@ int mvwadd_wchstr(WINDOW *win, int y, int x, const cchar_t *wch)
 
 int mvwadd_wchnstr(WINDOW *win, int y, int x, const cchar_t *wch, int n)
 {
-  PDC_LOG(("mvwadd_wchnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvwadd_wchnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (wmove(win, y, x) == ERR)
     {

--- a/graphics/pdcurs34/pdcurses/pdc_addstr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_addstr.c
@@ -102,7 +102,7 @@ int waddnstr(WINDOW *win, const char *str, int n)
 {
   int i = 0;
 
-  PDC_LOG(("waddnstr() - called: string=\"%s\" n %d \n", str, n));
+  PDC_LOG(("waddnstr() - called: string=\"%s\" n %d\n", str, n));
 
   if (!win || !str)
     {
@@ -148,7 +148,7 @@ int addnstr(const char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("addnstr() - called: string=\"%s\" n %d \n", str, n));
+  PDC_LOG(("addnstr() - called: string=\"%s\" n %d\n", str, n));
 
   return waddnstr(stdscr, str, n);
 }
@@ -180,7 +180,7 @@ int mvaddnstr(int y, int x, const char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("mvaddnstr() - called: y %d x %d string=\"%s\" n %d \n",
+  PDC_LOG(("mvaddnstr() - called: y %d x %d string=\"%s\" n %d\n",
            y, x, str, n));
 
   if (move(y, x) == ERR)
@@ -205,7 +205,7 @@ int mvwaddstr(WINDOW *win, int y, int x, const char *str)
 
 int mvwaddnstr(WINDOW *win, int y, int x, const char *str, int n)
 {
-  PDC_LOG(("mvwaddnstr() - called: y %d x %d string=\"%s\" n %d \n",
+  PDC_LOG(("mvwaddnstr() - called: y %d x %d string=\"%s\" n %d\n",
            y, x, str, n));
 
   if (wmove(win, y, x) == ERR)

--- a/graphics/pdcurs34/pdcurses/pdc_inchstr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_inchstr.c
@@ -196,7 +196,7 @@ int mvinchnstr(int y, int x, chtype *ch, int n)
 
 int mvwinchnstr(WINDOW *win, int y, int x, chtype *ch, int n)
 {
-  PDC_LOG(("mvwinchnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvwinchnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (wmove(win, y, x) == ERR)
     {
@@ -282,7 +282,7 @@ int mvin_wchnstr(int y, int x, cchar_t *wch, int n)
 
 int mvwin_wchnstr(WINDOW *win, int y, int x, cchar_t *wch, int n)
 {
-  PDC_LOG(("mvwinchnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvwinchnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (wmove(win, y, x) == ERR)
     {

--- a/graphics/pdcurs34/pdcurses/pdc_insstr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_insstr.c
@@ -114,7 +114,7 @@ int winsnstr(WINDOW *win, const char *str, int n)
 #endif
   int len;
 
-  PDC_LOG(("winsnstr() - called: string=\"%s\" n %d \n", str, n));
+  PDC_LOG(("winsnstr() - called: string=\"%s\" n %d\n", str, n));
 
   if (!win || !str)
     {
@@ -219,7 +219,7 @@ int insnstr(const char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("insnstr() - called: string=\"%s\" n %d \n", str, n));
+  PDC_LOG(("insnstr() - called: string=\"%s\" n %d\n", str, n));
 
   return winsnstr(stdscr, str, n);
 }
@@ -229,7 +229,7 @@ int mvinsnstr(int y, int x, const char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("mvinsnstr() - called: y %d x %d string=\"%s\" n %d \n",
+  PDC_LOG(("mvinsnstr() - called: y %d x %d string=\"%s\" n %d\n",
            y, x, str, n));
 
   if (move(y, x) == ERR)
@@ -242,7 +242,7 @@ int mvinsnstr(int y, int x, const char *str, int n)
 
 int mvwinsnstr(WINDOW *win, int y, int x, const char *str, int n)
 {
-  PDC_LOG(("mvwinsnstr() - called: y %d x %d string=\"%s\" n %d \n",
+  PDC_LOG(("mvwinsnstr() - called: y %d x %d string=\"%s\" n %d\n",
            y, x, str, n));
 
   if (wmove(win, y, x) == ERR)

--- a/graphics/pdcurs34/pdcurses/pdc_instr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_instr.c
@@ -121,7 +121,7 @@ int winnstr(WINDOW *win, char *str, int n)
   chtype *src;
   int i;
 
-  PDC_LOG(("winnstr() - called: n %d \n", n));
+  PDC_LOG(("winnstr() - called: n %d\n", n));
 
   if (!win || !str)
     {
@@ -157,7 +157,7 @@ int instr(char *str)
 
 int winstr(WINDOW *win, char *str)
 {
-  PDC_LOG(("winstr() - called: \n"));
+  PDC_LOG(("winstr() - called:\n"));
 
   return (ERR == winnstr(win, str, win->_maxx)) ? ERR : OK;
 }
@@ -167,7 +167,7 @@ int mvinstr(int y, int x, char *str)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("mvinstr() - called: y %d x %d \n", y, x));
+  PDC_LOG(("mvinstr() - called: y %d x %d\n", y, x));
 
   if (move(y, x) == ERR)
     {
@@ -179,7 +179,7 @@ int mvinstr(int y, int x, char *str)
 
 int mvwinstr(WINDOW *win, int y, int x, char *str)
 {
-  PDC_LOG(("mvwinstr() - called: y %d x %d \n", y, x));
+  PDC_LOG(("mvwinstr() - called: y %d x %d\n", y, x));
 
   if (wmove(win, y, x) == ERR)
     {
@@ -194,7 +194,7 @@ int innstr(char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("innstr() - called: n %d \n", n));
+  PDC_LOG(("innstr() - called: n %d\n", n));
 
   return winnstr(stdscr, str, n);
 }
@@ -204,7 +204,7 @@ int mvinnstr(int y, int x, char *str, int n)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #endif
-  PDC_LOG(("mvinnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvinnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (move(y, x) == ERR)
     {
@@ -216,7 +216,7 @@ int mvinnstr(int y, int x, char *str, int n)
 
 int mvwinnstr(WINDOW *win, int y, int x, char *str, int n)
 {
-  PDC_LOG(("mvwinnstr() - called: y %d x %d n %d \n", y, x, n));
+  PDC_LOG(("mvwinnstr() - called: y %d x %d n %d\n", y, x, n));
 
   if (wmove(win, y, x) == ERR)
     {
@@ -232,7 +232,7 @@ int winnwstr(WINDOW *win, wchar_t *wstr, int n)
   chtype *src;
   int i;
 
-  PDC_LOG(("winnstr() - called: n %d \n", n));
+  PDC_LOG(("winnstr() - called: n %d\n", n));
 
   if (!win || !wstr)
     {

--- a/interpreters/minibasic/script.c
+++ b/interpreters/minibasic/script.c
@@ -62,7 +62,7 @@ static FAR char *script =
   "10 REM Test Script\n"
   "20 REM Tests the Interpreter\n"
   "30 REM By Malcolm Mclean\n"
-  "35 PRINT \"HERE\" \n"
+  "35 PRINT \"HERE\"\n"
   "40 PRINT INSTR(\"FRED\", \"ED\", 4)\n"
   "50 PRINT VALLEN(\"12a\"), VALLEN(\"xyz\")\n"
   "60 LET x = SQRT(3.0) * SQRT(3.0)\n"

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -482,7 +482,7 @@ static inline int lesp_read_ipd(int sockfd, int len)
 
   sock = get_sock(sockfd);
 
-  ninfo("Read %d bytes for socket %d \n", len, sockfd);
+  ninfo("Read %d bytes for socket %d\n", len, sockfd);
 
   if (sock == NULL)
     {
@@ -558,7 +558,7 @@ static inline int lesp_read_ipd(int sockfd, int len)
 
           if (sock->sem)
             {
-              ninfo("post %p \n", sock->sem);
+              ninfo("post %p\n", sock->sem);
               sem_post(sock->sem);
             }
         }
@@ -707,7 +707,7 @@ static int lesp_read(int timeout_ms)
     }
   while ((ret <= 0) && (g_lesp_state.and == lesp_eNONE));
 
-  ninfo("lesp_read %d=>%s and and = %d \n", ret, g_lesp_state.bufans,
+  ninfo("lesp_read %d=>%s and and = %d\n", ret, g_lesp_state.bufans,
         g_lesp_state.and);
 
   return ret;
@@ -1262,7 +1262,7 @@ static void *lesp_worker(void *args)
 
   UNUSED(args);
 
-  ninfo("worker Started \n");
+  ninfo("worker Started\n");
 
   while (worker->running)
     {

--- a/netutils/iperf/iperf_main.c
+++ b/netutils/iperf/iperf_main.c
@@ -153,7 +153,7 @@ int main(int argc, FAR char *argv[])
   netlib_get_ipv4addr(DEVNAME, &addr);
   if (addr.s_addr == 0)
     {
-      printf("ERROR: access IP is 0x00 \n");
+      printf("ERROR: access IP is 0x00\n");
       return -1;
     }
 
@@ -230,7 +230,7 @@ int main(int argc, FAR char *argv[])
   printf("\n mode=%s-%s "
          "sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
          "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d, "
-         "interval=%" PRId32 ", time=%" PRId32 " \n",
+         "interval=%" PRId32 ", time=%" PRId32 "\n",
          cfg.flag & IPERF_FLAG_TCP ?"tcp":"udp",
          cfg.flag & IPERF_FLAG_SERVER ?"server":"client",
          cfg.sip & 0xff, (cfg.sip >> 8) & 0xff, (cfg.sip >> 16) & 0xff,

--- a/netutils/pppd/ipcp.c
+++ b/netutils/pppd/ipcp.c
@@ -211,7 +211,7 @@ void ipcp_rx(FAR struct ppp_context_s *ctx, FAR uint8_t * buffer,
 
               /* Write the reject frame */
 
-              DEBUG1(("Writing NAK frame \n"));
+              DEBUG1(("Writing NAK frame\n"));
               ahdlc_tx(IPCP, buffer, (uint16_t)(tptr - buffer));
               DEBUG1(("- End NAK Write frame\n"));
             }
@@ -233,12 +233,12 @@ void ipcp_rx(FAR struct ppp_context_s *ctx, FAR uint8_t * buffer,
 
           /* ppp_flags |= tflag; */
 
-          DEBUG1(("SET- stuff -- are we up? c=%d dif=%d \n",
+          DEBUG1(("SET- stuff -- are we up? c=%d dif=%d\n",
                   count, (uint16_t)(bptr - buffer)));
 
           /* Write the ACK frame */
 
-          DEBUG1(("Writing ACK frame \n"));
+          DEBUG1(("Writing ACK frame\n"));
 
           /* Send packet ahdlc_txz(procol,header,data,headerlen,datalen); */
 
@@ -308,7 +308,7 @@ void ipcp_rx(FAR struct ppp_context_s *ctx, FAR uint8_t * buffer,
 
       /* ppp_ipcp_state &= ~IPCP_RX_UP; */
 
-      DEBUG1(("were up! \n"));
+      DEBUG1(("were up!\n"));
       printip(ctx->local_ip);
 #ifdef IPCP_GET_PRI_DNS
       printip(ctx->pri_dns_addr);

--- a/netutils/pppd/lcp.c
+++ b/netutils/pppd/lcp.c
@@ -280,7 +280,7 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
 
               /* Write the reject frame */
 
-              DEBUG1(("\nWriting NAK frame \n"));
+              DEBUG1(("\nWriting NAK frame\n"));
 
               /* Send packet ahdlc_txz(procol,header,data,headerlen,datalen); */
 
@@ -301,13 +301,13 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
               /* Set stuff */
 
               /* ppp_flags |= tflag;
-               * DEBUG2("SET- stuff -- are we up? c=%d dif=%d \n", count,
+               * DEBUG2("SET- stuff -- are we up? c=%d dif=%d\n", count,
                * (uint16_t)(bptr-buffer));
                */
 
               /* Write the ACK frame */
 
-              DEBUG2(("Writing ACK frame \n"));
+              DEBUG2(("Writing ACK frame\n"));
 
               /* Send packet ahdlc_txz(procol,header,data,headerlen,datalen); */
 
@@ -357,7 +357,7 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
 
       /* Write the reject frame */
 
-      DEBUG1(("Writing TERM_ACK frame \n"));
+      DEBUG1(("Writing TERM_ACK frame\n"));
 
       /* Send packet ahdlc_txz(procol,header,data,headerlen,datalen); */
 
@@ -386,7 +386,7 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
 
           /* Write the echo reply frame */
 
-          DEBUG1(("\nWriting ECHO-REPLY frame \n"));
+          DEBUG1(("\nWriting ECHO-REPLY frame\n"));
 
           /* Send packet ahdlc_txz(procol,header,data,headerlen,datalen); */
 
@@ -469,7 +469,7 @@ void lcp_echo_request(struct ppp_context_s *ctx)
            * Send packet ahdlc_txz(procol,header,data,headerlen,datalen);
            */
 
-          DEBUG1(("\nWriting ECHO-REQUEST frame \n"));
+          DEBUG1(("\nWriting ECHO-REQUEST frame\n"));
           ahdlc_tx(ctx, LCP, 0, buffer, 0, t);
           DEBUG1(("- end ECHO-REQUEST Write frame\n"));
         }

--- a/netutils/pppd/pap.c
+++ b/netutils/pppd/pap.c
@@ -102,7 +102,7 @@ void pap_rx(struct ppp_context_s *ctx, FAR uint8_t * buffer, uint16_t count)
       bptr += 3;
       len = *bptr++;
       *(bptr + len) = 0;
-      DEBUG1((" %s \n", bptr));
+      DEBUG1((" %s\n", bptr));
       ctx->pap_state |= PAP_TX_UP;
       break;
 
@@ -115,7 +115,7 @@ void pap_rx(struct ppp_context_s *ctx, FAR uint8_t * buffer, uint16_t count)
       bptr += 3;
       len = *bptr++;
       *(bptr + len) = 0;
-      DEBUG1((" %s \n", bptr));
+      DEBUG1((" %s\n", bptr));
       break;
     }
 }

--- a/netutils/pppd/ppp.c
+++ b/netutils/pppd/ppp.c
@@ -429,7 +429,7 @@ uint16_t scan_packet(FAR struct ppp_context_s *ctx, uint16_t protocol,
 
       DEBUG1(("Writing Reject frame --\n"));
       ahdlc_tx(ctx, protocol, buffer, 0, (uint16_t)(tptr - buffer), 0);
-      DEBUG1(("\nEnd writing reject \n"));
+      DEBUG1(("\nEnd writing reject\n"));
     }
 
   return bad;

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -169,7 +169,7 @@ static int _open_with_http(const char *fullurl)
 
   if (OK != n)
     {
-      printf("netlib_parsehttpurl() returned %d \n", n);
+      printf("netlib_parsehttpurl() returned %d\n", n);
       return n;
     }
 
@@ -1856,7 +1856,7 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
     {
       /* Hmmm, it's some unknown / unsupported type */
 
-      auderr("ERROR: Unsupported format: %d \n", filefmt);
+      auderr("ERROR: Unsupported format: %d\n", filefmt);
       ret = -ENOSYS;
       goto err_out_nodev;
     }

--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -131,17 +131,17 @@ static void get_prime_in_parallel(int n)
   status = pthread_attr_setschedpolicy(&attr, SCHED_RR);
   ASSERT(status == OK);
 
-  printf("Set thread policy to SCHED_RR \n");
+  printf("Set thread policy to SCHED_RR\n");
 #else
   status = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
   ASSERT(status == OK);
 
-  printf("Set thread policy to SCHED_FIFO \n");
+  printf("Set thread policy to SCHED_FIFO\n");
 #endif
 
   for (i = 0; i < n; i++)
     {
-      printf("Start thread #%d \n", i);
+      printf("Start thread #%d\n", i);
       status = pthread_create(&thread[i], &attr,
                               thread_func, (FAR void *)&i);
       ASSERT(status == OK);
@@ -189,6 +189,6 @@ int main(int argc, FAR char *argv[])
   elapsed -= (((uint64_t)ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec);
   elapsed /= NSEC_PER_MSEC; /* msec */
 
-  printf("%s took %" PRIu64 " msec \n", argv[0], elapsed);
+  printf("%s took %" PRIu64 " msec\n", argv[0], elapsed);
   return 0;
 }

--- a/testing/smart_test/smart_test.c
+++ b/testing/smart_test/smart_test.c
@@ -540,7 +540,7 @@ static void smart_usage(void)
   fprintf(stderr, "          "
     "length records are written and then overwritten with new data.\n");
   fprintf(stderr, "          "
-    "Uses the -r, -e and -t options to specify the parameters of the \n");
+    "Uses the -r, -e and -t options to specify the parameters of the\n");
   fprintf(stderr, "          "
     "record geometry and update operation.  The COUNT parameter sets\n");
   fprintf(stderr, "          "

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -448,7 +448,7 @@ static int socket_request(int fd, FAR struct gs2200m_s *priv,
   int16_t usockid;
   int ret;
 
-  gs2200m_printf("%s: start type=%d \n",
+  gs2200m_printf("%s: start type=%d\n",
                  __func__, req->type);
 
   /* Check domain requested */
@@ -487,7 +487,7 @@ static int socket_request(int fd, FAR struct gs2200m_s *priv,
                        USRSOCK_EVENT_SENDTO_READY);
     }
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return OK;
 }
 
@@ -505,7 +505,7 @@ static int close_request(int fd, FAR struct gs2200m_s *priv,
   char cid;
   int ret = 0;
 
-  gs2200m_printf("%s: start \n", __func__);
+  gs2200m_printf("%s: start\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -540,7 +540,7 @@ errout:
 
   ret = gs2200m_socket_free(priv, req->usockid);
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
 
   return OK;
 }
@@ -565,7 +565,7 @@ static int connect_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: start \n", __func__);
+  gs2200m_printf("%s: start\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -683,7 +683,7 @@ prepare:
       return wlen;
     }
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return OK;
 }
 
@@ -707,7 +707,7 @@ static int sendto_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: start (buflen=%d) \n",
+  gs2200m_printf("%s: start (buflen=%d)\n",
                  __func__, req->buflen);
 
   /* Check if this socket exists. */
@@ -852,7 +852,7 @@ prepare:
       return wlen;
     }
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
 
   return OK;
 }
@@ -873,7 +873,7 @@ static int recvfrom_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: start (req->max_buflen=%d) \n",
+  gs2200m_printf("%s: start (req->max_buflen=%d)\n",
                  __func__, req->max_buflen);
 
   memset(&rmsg, 0, sizeof(rmsg));
@@ -921,7 +921,7 @@ static int recvfrom_request(int fd, FAR struct gs2200m_s *priv,
 
   if (!rmsg.is_tcp)
     {
-      gs2200m_printf("%s: from (%s:%d) \n",
+      gs2200m_printf("%s: from (%s:%d)\n",
                      __func__,
                      inet_ntoa(rmsg.addr.sin_addr),
                      ntohs(rmsg.addr.sin_port));
@@ -986,7 +986,7 @@ prepare:
 
 err_out:
 
-  gs2200m_printf("%s: *** end ret=%d \n", __func__, ret);
+  gs2200m_printf("%s: *** end ret=%d\n", __func__, ret);
 
   if (rmsg.buf)
     {
@@ -1014,7 +1014,7 @@ static int bind_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1077,7 +1077,7 @@ prepare:
       return ret;
     }
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return OK;
 }
 
@@ -1096,7 +1096,7 @@ static int listen_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1118,7 +1118,7 @@ static int listen_request(int fd, FAR struct gs2200m_s *priv,
       return ret;
     }
 
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return ret;
 }
 
@@ -1140,7 +1140,7 @@ static int accept_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1234,7 +1234,7 @@ prepare:
     }
 
 err_out:
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return ret;
 }
 
@@ -1255,7 +1255,7 @@ static int setsockopt_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1315,7 +1315,7 @@ prepare:
 
   ret = _send_ack_common(fd, req->head.xid, &resp);
 
-  gs2200m_printf("%s: end (ret=%d) \n", __func__, ret);
+  gs2200m_printf("%s: end (ret=%d)\n", __func__, ret);
   return ret;
 }
 
@@ -1346,7 +1346,7 @@ static int getsockname_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1412,7 +1412,7 @@ prepare:
     }
 
 err_out:
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return ret;
 }
 
@@ -1431,7 +1431,7 @@ static int getpeername_request(int fd, FAR struct gs2200m_s *priv,
   DEBUGASSERT(priv);
   DEBUGASSERT(req);
 
-  gs2200m_printf("%s: called **** \n", __func__);
+  gs2200m_printf("%s: called ****\n", __func__);
 
   /* Check if this socket exists. */
 
@@ -1496,7 +1496,7 @@ prepare:
     }
 
 err_out:
-  gs2200m_printf("%s: end \n", __func__);
+  gs2200m_printf("%s: end\n", __func__);
   return ret;
 }
 
@@ -1631,7 +1631,7 @@ static int gs2200m_loop(FAR struct gs2200m_s *priv)
 
       if (fds[1].revents & POLLIN)
         {
-          gs2200m_printf("=== %s: event from /dev/gs2200m \n",
+          gs2200m_printf("=== %s: event from /dev/gs2200m\n",
                          __func__);
 
           /* retrieve cid from gs2200m driver */
@@ -1646,7 +1646,7 @@ static int gs2200m_loop(FAR struct gs2200m_s *priv)
 
           if (NULL == usock)
             {
-              gs2200m_printf("=== %s: cid=%c not found (ignored) \n",
+              gs2200m_printf("=== %s: cid=%c not found (ignored)\n",
                              __func__, cid);
             }
           else
@@ -1677,10 +1677,10 @@ static void _show_usage(FAR char *cmd)
           "Usage: %s [-a [ch]] ssid passphrase(key) \n\n", cmd);
   fprintf(stderr,
           "AP mode : specify -a option (optionally with channel) with ssid\n"
-          "          and 8 to 63 ascii passphrase for WPA2-PSK \n"
-          "          or 10 hex digits key for WEP \n");
+          "          and 8 to 63 ascii passphrase for WPA2-PSK\n"
+          "          or 10 hex digits key for WEP\n");
   fprintf(stderr,
-          "STA mode: specify ssid and passphrase for WPA/WPA2 PSK \n");
+          "STA mode: specify ssid and passphrase for WPA/WPA2 PSK\n");
 }
 
 /****************************************************************************
@@ -1695,7 +1695,7 @@ int main(int argc, FAR char *argv[])
 
   if (_daemon)
     {
-      fprintf(stderr, "%s is already running! \n", argv[0]);
+      fprintf(stderr, "%s is already running!\n", argv[0]);
       return -1;
     }
 

--- a/wireless/ieee802154/i8sak/i8sak_get.c
+++ b/wireless/ieee802154/i8sak/i8sak_get.c
@@ -90,7 +90,7 @@ void i8sak_get_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
             fprintf(stderr, "Gets various parameters and attributes\n"
                     "Usage: %s [-h] parameter\n"
                     "    -h = this help menu\n"
-                    " \n"
+                    "\n"
                     "Parameters:\n"
                     "    chan = RF channel\n"
                     "    panid = PAN Identifier\n"

--- a/wireless/ieee802154/i8sak/i8sak_scan.c
+++ b/wireless/ieee802154/i8sak/i8sak_scan.c
@@ -236,7 +236,7 @@ static void scan_eventcb(FAR struct ieee802154_primitive_s *primitive,
         break;
     }
 
-  printf("Scan results: \n");
+  printf("Scan results:\n");
 
   if (scan->type == IEEE802154_SCANTYPE_ACTIVE ||
       scan->type == IEEE802154_SCANTYPE_PASSIVE)

--- a/wireless/ieee802154/i8sak/i8sak_set.c
+++ b/wireless/ieee802154/i8sak/i8sak_set.c
@@ -90,7 +90,7 @@ void i8sak_set_cmd(FAR struct i8sak_s *i8sak, int argc, FAR char *argv[])
             fprintf(stderr, "Sets various parameters and attributes\n"
                     "Usage: %s [-h] parameter\n"
                     "    -h = this help menu\n"
-                    " \n"
+                    "\n"
                     "Parameters:\n"
                     "    chan 0-255 = RF channel (only some channels valid per radio)\n"
                     "    panid xx:xx = PAN Identifier\n"

--- a/wireless/ieee802154/i8sak/i8sak_sniffer.c
+++ b/wireless/ieee802154/i8sak/i8sak_sniffer.c
@@ -248,7 +248,7 @@ pthread_addr_t i8sak_sniffer_thread(pthread_addr_t arg)
               printf("%02X", frame.payload[i]);
             }
 
-          printf(" \n");
+          printf("\n");
           fflush(stdout);
         }
 #ifdef CONFIG_NET_6LOWPAN
@@ -266,7 +266,7 @@ pthread_addr_t i8sak_sniffer_thread(pthread_addr_t arg)
               printf("%02X", buf[i]);
             }
 
-          printf(" \n");
+          printf("\n");
           fflush(stdout);
         }
 #endif


### PR DESCRIPTION
## Summary
Many log messages contain spaces right before the newline. Those spaces does not give useful visual experience and can be removed to save some memory

## Impact
No functional changes

## Testing
Pass CI
