### PR TITLE
fsutils/ipcfg: fix debugassert

### DIFF
--- a/fsutils/ipcfg/ipcfg_binary.c
+++ b/fsutils/ipcfg/ipcfg_binary.c
@@ -329,7 +329,7 @@ int ipcfg_read_binary_ipv6(FAR const char *path,
   int fd;
   int ret;
 
-  DEBUGASSERT(fd >= 0 && ipv6cfg != NULL);
+  DEBUGASSERT(path != NULL && ipv6cfg != NULL);
 
   /* Open the file for reading */
 


### PR DESCRIPTION
cppcheck reports the following error:

fsutils/ipcfg/ipcfg_binary.c:332:15: error: Uninitialized variable: fd [uninitvar]
  DEBUGASSERT(fd >= 0 && ipv6cfg != NULL);

Update the DEBUGASSERT() to match that of ipcfg_read_binary_ipv4(). fd is
uninitilized and doesn't need to be checked here.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

The debugassert may behave unexpectedly

## Impact

No impact

## Testing

Compile-tested only