### PR TITLE
Add a system tool to get/set hostname

### DIFF
--- a/system/hostname/Kconfig
+++ b/system/hostname/Kconfig
@@ -1,0 +1,13 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_HOSTNAME
+	tristate "'hostname' command"
+	default n
+	---help---
+		Enable the hostname tool
+
+if SYSTEM_HOSTNAME
+endif

--- a/system/hostname/Make.defs
+++ b/system/hostname/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/hostname/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_HOSTNAME),)
+CONFIGURED_APPS += $(APPDIR)/system/hostname
+endif

--- a/system/hostname/Makefile
+++ b/system/hostname/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/system/hostname/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# HOSTNAME tool built-in application info
+
+PROGNAME = hostname
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_HOSTNAME)
+
+# HOSTNAME tool
+
+MAINSRC = hostname_main.c
+
+include $(APPDIR)/Application.mk

--- a/system/hostname/hostname_main.c
+++ b/system/hostname/hostname_main.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * apps/system/hostname/hostname_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <unistd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int ret;
+  char hostname[HOST_NAME_MAX + 1];
+
+  if (argc > 1)
+    {
+      ret = sethostname(argv[1], strlen(argv[1]));
+      if (ret != 0)
+        {
+          printf("sethostname() returned %d\n", ret);
+          return EXIT_FAILURE;
+        }
+    }
+  else
+    {
+      ret = gethostname(hostname, HOST_NAME_MAX);
+      if (ret != 0)
+        {
+          printf("gethostname() returned %d\n", ret);
+          return EXIT_FAILURE;
+        }
+
+      printf("%s\n", hostname);
+    }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
Add a tool to get/set hostname

## Impact
Userspace can now get and set the system hostname

## Testing
Tested by setting hostname, and getting it back. Checked that the hostname was used in dhcp requests.