### PR TITLE
examples/mqttc: Fix handling of getaddrinfo errors

### DIFF
--- a/examples/mqttc/mqttc_pub.c
+++ b/examples/mqttc/mqttc_pub.c
@@ -153,9 +153,10 @@ static int initserver(const FAR struct mqttc_cfg_s *cfg)
   printf("Connecting to %s:%s...\n", cfg->host, cfg->port);
 
   ret = getaddrinfo(cfg->host, cfg->port, &hints, &servinfo);
-  if (ret < 0)
+  if (ret != OK)
     {
       printf("ERROR! getaddrinfo() failed: %s\n", gai_strerror(ret));
+      return -1;
     }
 
   itr = servinfo;


### PR DESCRIPTION
## Summary
commit 36d4bfa7749ecd48ace51eddb613418350c614d7 set a hostname to work around getaddrinfo failing. getaddrinfo returns a non-zero value on error, and there should be an early return after the error message is printed.

## Impact
mqttc no longer crashes when getaddrinfo fails.

## Testing
Tested on a bl602 microcontroller.