### PR TITLE
Fix link error due to missing libapps.a in KERNEL build

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -59,10 +59,14 @@ else
 CWD = $(CURDIR)
 endif
 
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-  LDLIBS += "${shell cygpath -w $(BIN)}"
-else
-  LDLIBS += $(BIN)
+# Add the static application library to the linked libraries. Don't do this
+# with CONFIG_BUILD_KERNEL as there is no static app library
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
+    LDLIBS += "${shell cygpath -w $(BIN)}"
+  else
+    LDLIBS += $(BIN)
+  endif
 endif
 
 SUFFIX = $(subst $(DELIM),.,$(CWD))


### PR DESCRIPTION
## Summary
The import target for kernel build now fails, due to setting libapps.a
as the default value for the BIN variable.

The fail happens when the ELFLD function passes the LDLIBS parameter
(which contains BIN / libapps.a) for the linker. There is no rule to
create libapps.a in the case of the kernel build, so the linker gives
an error due to it being missing.

This commit patches this behavior so that BIN is not appended to
LDLIBS. Another option would be to implement a dummy rule to create
libapps.a, but looking at the git history this is no longer wanted
behavior, thus the error is patched like this.

## Impact
Should fix the ELFLD function / linkage when using CONFIG_BUILD_KERNEL

## Testing
Tested that it builds. Created a ROMFS image with the .elf binaries. Did _not_ test that the elf files themselves work / contain a valid application (elfloader does work however).
