### PR TITLE
Fix incorrect argument count error message

### DIFF
--- a/nshlib/nsh_codeccmd.c
+++ b/nshlib/nsh_codeccmd.c
@@ -308,7 +308,7 @@ static int cmd_codecs_proc(FAR struct nsh_vtbl_s *vtbl, int argc,
     {
       sdata = argv[optind];
     }
-  else if (optind >= argc)
+  else if (optind < argc)
     {
       fmt = g_fmttoomanyargs;
       goto errout;

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1307,7 +1307,7 @@ int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
           return ERROR;
         }
     }
-  else if (optind >= argc)
+  else if (optind < argc)
     {
       nsh_error(vtbl, g_fmttoomanyargs, argv[0]);
       return ERROR;
@@ -1426,7 +1426,7 @@ int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
     {
       nsectors = (uint32_t)atoi(argv[optind]);
     }
-  else if (optind >= argc)
+  else if (optind < argc)
     {
       fmt = g_fmttoomanyargs;
       goto errout_with_fmt;

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -1306,7 +1306,7 @@ int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
     {
       url = argv[optind];
     }
-  else if (optind >= argc)
+  else if (optind < argc)
     {
       fmt = g_fmttoomanyargs;
       goto errout;


### PR DESCRIPTION
## Summary
The `too many arguments` and `missing required argument(s)` messages are shown the wrong way around and need to be switched in order for the correct message to be shown to the user.

## Impact
Messages when commands are run with `too many arguments` or `missing required argument(s)` are now correct.

## Testing
Tested `md5`, `mkrd`, `mkfatfs` and `wget` (the working one in nshlib, not the terrible one in examples)