### PR TITLE
Fix some edge case bugs in nsh_parse

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -829,7 +829,7 @@ static FAR char *nsh_filecat(FAR struct nsh_vtbl_s *vtbl, FAR char *s1,
   fd = open(filename, O_RDONLY);
   if (fd < 0)
     {
-      nsh_error(vtbl, g_fmtcmdfailed,  "``", "open", NSH_ERRNO);
+      nsh_error(vtbl, g_fmtcmdfailed, "``", "open", NSH_ERRNO);
       goto errout_with_alloc;
     }
 
@@ -876,6 +876,13 @@ static FAR char *nsh_filecat(FAR struct nsh_vtbl_s *vtbl, FAR char *s1,
 
       index += nbytesread;
     }
+
+  /* Remove trailing whitespace */
+
+  for (;
+       index > s1size &&
+       strchr(g_token_separator, argument[index - 1]) != NULL;
+       index--);
 
   /* Make sure that the new string is null terminated */
 

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -943,8 +943,15 @@ static FAR char *nsh_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
 
   /* Concatenate the file contents with the current allocation */
 
-  argument    = nsh_filecat(vtbl, *allocation, tmpfile);
-  *allocation = argument;
+  argument = nsh_filecat(vtbl, *allocation, tmpfile);
+  if (argument == NULL)
+    {
+      argument = (FAR char *)g_nullstring;
+    }
+  else
+    {
+      *allocation = argument;
+    }
 
   /* We can now unlink the tmpfile and free the tmpfile string */
 
@@ -2305,8 +2312,8 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
        * status.
        */
 
-      NSH_MEMLIST_FREE(&memlist);
-      return OK;
+      ret = 0;
+      goto exit;
     }
 
   /* Parse all of the arguments following the command name.  The form
@@ -2346,6 +2353,7 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
 
   /* Restore the backgrounding and redirection state */
 
+exit:
 #ifndef CONFIG_NSH_DISABLEBG
   vtbl->np.np_bg       = bgsave;
 #endif
@@ -2522,17 +2530,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
         }
     }
 
-  /* Last argument vector must be empty */
-
-  argv[argc] = NULL;
-
   /* Check if the command should run in background */
 
 #ifndef CONFIG_NSH_DISABLEBG
   if (argc > 1 && strcmp(argv[argc - 1], "&") == 0)
     {
       vtbl->np.np_bg = true;
-      argv[argc - 1] = NULL;
       argc--;
     }
 #endif
@@ -2565,6 +2568,10 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
         }
     }
 #endif
+
+  /* Last argument vector must be empty */
+
+  argv[argc] = NULL;
 
   /* Check if the maximum number of arguments was exceeded */
 


### PR DESCRIPTION
## Summary
Fix some edge case bugs in nsh_parse (these cause serious errors):

- Handle nsh_filecat returning NULL on failure
- Background and redirect must be restored after an empty line
- Output redirection should be removed from argv like background

Remove trailing whitespace from commands as parameters (this is cosmetic). Technically the output should be reparsed, so that quoting can take effect, but this fixes the simple case of feeding the output of one command to another.

## Impact
nsh doesn't crash on edge cases and arguments do not have internal newlines

## Testing
Test cases for each bug:
```
echo `rm /tmp/tmp1.dat`
``
hostname > /tmp/x
echo -n `echo hello`
```
