### PR TITLE
Check for too many arguments to hostname

### DIFF
--- a/system/hostname/hostname_main.c
+++ b/system/hostname/hostname_main.c
@@ -46,6 +46,12 @@ int main(int argc, FAR char *argv[])
 
   if (argc > 1)
     {
+      if (argc > 2)
+        {
+          fprintf(stderr, "ERROR: Too many arguments\n");
+          return EXIT_FAILURE;
+        }
+
       ret = sethostname(argv[1], strlen(argv[1]));
       if (ret != 0)
         {
@@ -65,5 +71,5 @@ int main(int argc, FAR char *argv[])
       printf("%s\n", hostname);
     }
 
-  return 0;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
Follow up to https://github.com/apache/incubator-nuttx-apps/pull/944

Check for too many arguments to hostname

Also use the symbolic value for the success exit code.

## Impact
Hostname now rejects multiple arguments

## Testing
[FAIL] (expected) `hostname foo bar`
[OK] `hostname foo`
[OK] `hostname`