### PR TITLE
hts221_reader_main.c: Fix the start IOCTL.

### DIFF
--- a/examples/hts221_reader/hts221_reader_main.c
+++ b/examples/hts221_reader/hts221_reader_main.c
@@ -55,7 +55,7 @@ int main(int argc, FAR char *argv[])
       return -ENOENT;
     }
 
-  ret = ioctl(fileno(sensor), SNIOC_START, 0);
+  ret = ioctl(fileno(sensor), SNIOC_START_CONVERSION, 0);
   if (ret < 0)
     {
       printf("IOCTL SNIOC_START failed %d\n", ret);


### PR DESCRIPTION
## Summary
SNIOC_START is not handled by the hts221 driver.
## Impact
hts221 example
## Testing
hts221 example.
