### PR TITLE
netutils/netcat: implemented NETUTILS_NETCAT_SENDFILE option.

### DIFF
--- a/netutils/netcat/Kconfig
+++ b/netutils/netcat/Kconfig
@@ -47,4 +47,16 @@ config NETUTILS_NETCAT_STACKSIZE
 	int "netcat stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config NETUTILS_NETCAT_SENDFILE
+	bool "Use sendfile() in netcat when possible"
+	default y
+	depends on NET_SENDFILE
+	---help---
+		This option enables using sendfile() in netcat client mode
+		if a normal file (not stdin) is sent. If the option is enabled
+		but stdin is sent rather than a normal file, netcat falls back
+		to the combination of read() and write().
+		Using sendfile() provides a higher performance compared to
+		the combination of read() and write().
+
 endif


### PR DESCRIPTION
## Summary

This option enables using sendfile() in netcat client mode if a normal file (not stdin) is sent.
If the option is enabled but stdin is sent rather than a normal file, netcat falls back to the combination of read() and write().
Using sendfile() provides a higher performance compared to the combination of read() and write().

Also this option is useful for testing / debugging tcp_sendfile() functionality of NuttX TCP/IP stack.

## Impact

netutils/netcat

## Testing

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig (enable CONFIG_NETUTILS_NETCAT_SENDFILE, enable / disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```
Run netcat server on Linux host:
`$ netcat -l -p 31337`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
```
Start Wireshark (or tcpdump) and capture appeared tap0 interface.

Run in NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin
```
Observe TCP dump.

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`