### PR TITLE
note main: system/sched_note add output of string and binary

### DIFF
--- a/system/sched_note/note_main.c
+++ b/system/sched_note/note_main.c
@@ -60,6 +60,7 @@ static uint8_t g_note_buffer[CONFIG_SYSTEM_NOTE_BUFFERSIZE];
 
 /* Names of task/thread states */
 
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
 static FAR const char *g_statenames[] =
 {
   "Invalid",
@@ -76,6 +77,7 @@ static FAR const char *g_statenames[] =
 };
 
 #define NSTATES (sizeof(g_statenames)/sizeof(FAR const char *))
+#endif
 
 /************************************************************************************
  * Private Functions
@@ -706,6 +708,68 @@ static void dump_notes(size_t nread)
                            (unsigned int)pid,
                            note->nc_type == NOTE_IRQ_ENTER ? "Enter" : "Leave",
                            note_irq->nih_irq);
+                  }
+                  break;
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
+                case NOTE_DUMP_STRING:
+                  {
+                    FAR struct note_string_s *note_string =
+                      (FAR struct note_string_s *)note;
+
+                    if (note->nc_length < sizeof(struct note_string_s))
+                      {
+                        syslog(LOG_INFO,
+                               "ERROR: note too small for string note: %d\n",
+                               note->nc_length);
+                        return;
+                      }
+
+                    syslog_time(LOG_INFO,
+                           "Task %u priority %u, string:%s\n",
+                           (unsigned int)pid,
+                           (unsigned int)note->nc_priority,
+                           note_string->nst_data);
+                  }
+                  break;
+
+                case NOTE_DUMP_BINARY:
+                  {
+                    FAR struct note_binary_s *note_binary =
+                      (FAR struct note_binary_s *)note;
+                    char out[1280];
+                    int count;
+                    int ret = 0;
+                    int i;
+
+                    count = note->nc_length - sizeof(struct note_binary_s) + 1;
+
+                    if (count < 0)
+                      {
+                        syslog(LOG_INFO,
+                               "ERROR: note too small for binary note: %d\n",
+                               note->nc_length);
+                        return;
+                      }
+
+                    for (i = 0; i < count; i++)
+                      {
+                        ret += sprintf(&out[ret], " 0x%x", note_binary->nbi_data[i]);
+                      }
+
+                    syslog_time(LOG_INFO,
+                           "Task %u priority %u, binary:module=%c%c%c%c "
+                            "event=%u count=%u%s\n",
+                           (unsigned int)pid,
+                           (unsigned int)note->nc_priority,
+                           note_binary->nbi_module[0],
+                           note_binary->nbi_module[1],
+                           note_binary->nbi_module[2],
+                           note_binary->nbi_module[3],
+                           note_binary->nbi_event,
+                           count,
+                           out);
                   }
                   break;
 #endif


### PR DESCRIPTION
```
ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
case NOTE_DUMP_STRING:
case NOTE_DUMP_BINARY:
endif

[  198.244349] [25] [ap] 001e3fcc: Task 18 priority 100, string:shced note test count = 907592.
[  198.244468] [25] [ap] 001e3fcc: Task 18 priority 100, string:shced note test
[  198.244561] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=1 count=2 0x1 0x2
[  198.244679] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=2 count=1 0x1
[  198.244795] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=3 count=2 0x2 0x0
[  198.244921] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=4 count=4 0x3 0x0 0x0 0x0
[  198.245046] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=5 count=4 0x4 0x0 0x0 0x0
[  198.245180] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=6 count=8 0x5 0x0 0x0 0x0 0x0 0x0 0x0 0x0
[  198.245332] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=7 count=8 0x6 0x0 0x0 0x0 0x0 0x0 0x0 0x0
[  198.245473] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=8 count=4 0x7 0x0 0x0 0x0
[  198.245589] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=9 count=4 0x8 0x0 0x0 0x0
[  198.245700] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=10 count=4 0x0 0x0 0x0 0x0
[  198.245815] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=11 count=8 0x9a 0x99 0x99 0x99 0x99 0x99 0xc9 0x3f
[  198.245966] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=12 count=12 0x0 0x98 0x99 0x99 0x99 0x99 0x99 0x99 0xfd 0x3f 0x0 0x6d
[  198.246145] [25] [ap] 001e3fcc: Task 18 priority 100, binary:module=main event=13 count=35 0x1 0x2 0x0 0x3 0x0 0x0 0x0 0x4 0x0 0x0 0x0 0x5 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x6 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x7 0x0 0x0 0x0 0x8 0x0 0x0 0x0
```