### PR TITLE
net/usrsock: replace xid type to uint64_t to avoid limitation of connections

### DIFF
--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -54,10 +54,10 @@ struct usrsock_rpmsg_s
  ****************************************************************************/
 
 static int usrsock_rpmsg_send_ack(struct rpmsg_endpoint *ept,
-                                  uint8_t xid, int32_t result);
+                                  uint64_t xid, int32_t result);
 static int usrsock_rpmsg_send_data_ack(struct rpmsg_endpoint *ept,
                                   struct usrsock_message_datareq_ack_s *ack,
-                                  uint8_t xid, int32_t result,
+                                  uint64_t xid, int32_t result,
                                   uint16_t valuelen,
                                   uint16_t valuelen_nontrunc);
 static int usrsock_rpmsg_send_event(struct rpmsg_endpoint *ept,
@@ -141,7 +141,7 @@ static const rpmsg_ept_cb g_usrsock_rpmsg_handler[] =
  ****************************************************************************/
 
 static int usrsock_rpmsg_send_ack(struct rpmsg_endpoint *ept,
-                                  uint8_t xid, int32_t result)
+                                  uint64_t xid, int32_t result)
 {
   struct usrsock_message_req_ack_s ack;
 
@@ -156,7 +156,7 @@ static int usrsock_rpmsg_send_ack(struct rpmsg_endpoint *ept,
 
 static int usrsock_rpmsg_send_data_ack(struct rpmsg_endpoint *ept,
                                   struct usrsock_message_datareq_ack_s *ack,
-                                  uint8_t xid, int32_t result,
+                                  uint64_t xid, int32_t result,
                                   uint16_t valuelen,
                                   uint16_t valuelen_nontrunc)
 {

--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -226,7 +226,7 @@ static int _write_to_usock(int fd, void *buf, size_t count)
  ****************************************************************************/
 
 static int _send_ack_common(int fd,
-                            uint8_t xid,
+                            uint64_t xid,
                             FAR struct usrsock_message_req_ack_s *resp)
 {
   resp->head.msgid = USRSOCK_MESSAGE_RESPONSE_ACK;


### PR DESCRIPTION
## Summary

net/usrsock: replace xid type to uint64_t to avoid limitation of connections

## Impact

remove connect index logic and use usrsock_conn instance address 

Depends on:
https://github.com/apache/incubator-nuttx/pull/5154

## Testing

usrsock rpmsg test