### PR TITLE
ostest: fix assert when enable CONFIG_PRIORITY_INHERITANCE

### DIFF
--- a/testing/ostest/roundrobin.c
+++ b/testing/ostest/roundrobin.c
@@ -188,6 +188,7 @@ void rr_test(void)
 
   sched_lock();
   sem_init(&g_rrsem, 0, 0);
+  sem_setprotocol(&g_rrsem, SEM_PRIO_NONE);
 
   /* Start the threads */
 


### PR DESCRIPTION
## Summary
```
ostest: fix assert when enable CONFIG_PRIORITY_INHERITANCE

[ 96.555456] [265] ap: up_assert: Assertion failed at file:semaphore/sem_holder.c line: 112 task: pt-0x5b09fd0b
[ 96.555657] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.555828] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.556023] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.556222] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.556437] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.556639] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.556842] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
[ 96.557036] [265] ap: up_assert: Assertion failed at file:semaphore/sem_recover.c line: 86 task: pt-0x5b09fd0b
```

## Impact
N/A

## Testing
daily test
