### PR TITLE
testing/ostest: set the default value to TESTING_OSTEST_FPUSIZE 

### DIFF
--- a/testing/ostest/Kconfig
+++ b/testing/ostest/Kconfig
@@ -88,6 +88,7 @@ if !TESTING_OSTEST_FPUTESTDISABLE
 
 config TESTING_OSTEST_FPUSIZE
 	int "Size of floating point register save area"
+	default 0
 
 config TESTING_OSTEST_FPULOOPS
 	int "Number of FPU test loops"

--- a/testing/ostest/fpu.c
+++ b/testing/ostest/fpu.c
@@ -43,11 +43,13 @@
 #undef HAVE_FPU
 #ifdef CONFIG_ARCH_FPU
 #  if defined(CONFIG_TESTING_OSTEST_FPUSIZE) && \
+      (CONFIG_TESTING_OSTEST_FPUSIZE != 0) && \
       defined(CONFIG_SCHED_WAITPID) && \
       defined(CONFIG_BUILD_FLAT)
 #    define HAVE_FPU 1
 #  else
-#    ifndef CONFIG_TESTING_OSTEST_FPUSIZE
+#    if defined(CONFIG_TESTING_OSTEST_FPUSIZE) && \
+        (CONFIG_TESTING_OSTEST_FPUSIZE == 0)
 #      warning "FPU test not built; CONFIG_TESTING_OSTEST_FPUSIZE not defined"
 #    endif
 #    ifndef CONFIG_SCHED_WAITPID


### PR DESCRIPTION
## Summary

testing/ostest: set the default value to TESTING_OSTEST_FPUSIZE 

.config:2053:warning: symbol value '' invalid for TESTING_OSTEST_FPUSIZE

## Impact

ostest / fpu

## Testing

CI-check