### PR TITLE
dq_saturate bug

### DIFF
--- a/industry/foc/fixed16/foc_picontrol.c
+++ b/industry/foc/fixed16/foc_picontrol.c
@@ -345,9 +345,9 @@ static void foc_control_current_run_b16(FAR foc_handler_b16_t *h,
   /* Saturate voltage DQ vector */
 
 #ifndef CONFIG_INDUSTRY_FOC_CORDIC_DQSAT
-  dq_saturate_b16(dq_ref, mag_max);
+  dq_saturate_b16(&v_dq_ref, mag_max);
 #else
-  foc_cordic_dqsat_b16(h->fd, dq_ref, mag_max);
+  foc_cordic_dqsat_b16(h->fd, &v_dq_ref, mag_max);
 #endif
 
   /* Call FOC voltage control */

--- a/industry/foc/float/foc_picontrol.c
+++ b/industry/foc/float/foc_picontrol.c
@@ -346,9 +346,9 @@ static void foc_control_current_run_f32(FAR foc_handler_f32_t *h,
   /* Saturate voltage DQ vector */
 
 #ifndef CONFIG_INDUSTRY_FOC_CORDIC_DQSAT
-  dq_saturate(dq_ref, mag_max);
+  dq_saturate(&v_dq_ref, mag_max);
 #else
-  foc_cordic_dqsat_f32(h->fd, dq_ref, mag_max);
+  foc_cordic_dqsat_f32(h->fd, &v_dq_ref, mag_max);
 #endif
 
   /* Call FOC voltage control */


### PR DESCRIPTION
## Summary
it should Limiting amplitude of voltage DQ,not current DQ
## Impact
when the current is large enough,there will error
## Testing
Motor drive verification
