### PR TITLE
Fix boarctl typos

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1447,7 +1447,7 @@ int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   ret = boardctl(BOARDIOC_MKRD, (uintptr_t)&desc);
   if (ret < 0)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boarctl(BOARDIOC_MKRD)",
+      nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl(BOARDIOC_MKRD)",
                 NSH_ERRNO_OF(-ret));
       return ERROR;
     }

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -157,7 +157,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
 #endif
 
-  /* boarctl() will not return in any case.  It if does, it means that
+  /* boardctl() will not return in any case.  It if does, it means that
    * there was a problem with the shutdown/resaet operation.
    */
 
@@ -280,7 +280,7 @@ int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
       boardctl(BOARDIOC_POWEROFF, EXIT_SUCCESS);
     }
 
-  /* boarctl() will not return in any case.  It if does, it means that
+  /* boardctl() will not return in any case.  It if does, it means that
    * there was a problem with the shutdown operation.
    */
 
@@ -310,7 +310,7 @@ int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
       boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
     }
 
-  /* boarctl() will not return in this case.  It if does, it means that
+  /* boardctl() will not return in this case.  It if does, it means that
    * there was a problem with the reset operation.
    */
 

--- a/system/usbmsc/README.md
+++ b/system/usbmsc/README.md
@@ -8,7 +8,7 @@ board-specific logic must provide the function:
 void board_usbmsc_initialize(void);
 ```
 
-This function will be called by the `system/usbmsc` indirectly via the `boarctl`
+This function will be called by the `system/usbmsc` indirectly via the `boardctl`
 `BOARDIOC_USBDEV_CONTROL` command in order to do the actual registration of the
 block device drivers. For examples of the implementation of
 `board_usbmsc_initialize()` see


### PR DESCRIPTION
I noticed `boardctl` misspelt as `boarctl` in an error message. This fixes the error message and two other files with comments and documentation.