### PR TITLE
system/trace: Define NCPUS without the preprocess guard

### DIFF
--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -45,11 +45,7 @@
 #  endif
 #endif
 
-#ifdef CONFIG_SMP
-#  define NCPUS CONFIG_SMP_NCPUS
-#else
-#  define NCPUS 1
-#endif
+#define NCPUS CONFIG_SMP_NCPUS
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
since CONFIG_SMP_NCPUS is always defined now.
Follow up NuttX side change: https://github.com/apache/incubator-nuttx/pull/5264

## Impact
Minor change

## Testing
Pass CI
