### PR TITLE
system/adb: Replace printf with syslog since adb is a service

### DIFF
--- a/system/adb/adb_banner.c
+++ b/system/adb/adb_banner.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/adb/adb_main.c
+ * apps/system/adb/adb_banner.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary

## Impact
adb output through syslog instead printf

## Testing
Pass CI
