### PR TITLE
Makefile: Fix make export for CONFIG_BUILD_KERNEL=y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,11 +154,13 @@ preconfig: Kconfig
 
 export:
 ifneq ($(EXPORTDIR),)
+	$(Q) mkdir -p "${EXPORTDIR}"$(DELIM)registry || exit 1;
+ifneq ($(CONFIG_BUILD_KERNEL),y)
 ifneq ($(BUILTIN_REGISTRY),)
-	$(Q) mkdir -p "${EXPORTDIR}"/registry || exit 1; \
-	for f in "${BUILTIN_REGISTRY}"/*.bdat "${BUILTIN_REGISTRY}"/*.pdat ; do \
-		[ -f "$${f}" ] && cp -f "$${f}" "${EXPORTDIR}"/registry ; \
+	for f in "${BUILTIN_REGISTRY}"$(DELIM)*.bdat "${BUILTIN_REGISTRY}"$(DELIM)*.pdat ; do \
+		[ -f "$${f}" ] && cp -f "$${f}" "${EXPORTDIR}"$(DELIM)registry ; \
 	done
+endif
 endif
 endif
 


### PR DESCRIPTION
## Summary

- I noticed that 'make export' does not work with swama5d4-ek:knsh
- This commit fixes this issue by always creating the registry directory
  but not copying pdat files for CONFIG_BUILD_KERNEL=y
- This commit also fixes the delimiter issue on Windows
- NOTE: nuttx needs to be updated as well
- See https://github.com/apache/incubator-nuttx/pull/5329

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Build (make and make export) with sama5d-ek:knsh
