### PR TITLE
Makefile, import/Make.defs: Fix undefined symbols for CONFIG_BUILD_KERNEL=y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
 install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
 .import: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+	$(Q) for app in ${CONFIGURED_APPS}; do \
+		$(MAKE) -C "$${app}" archive ; \
+	done
+	$(Q) install libapps.a $(APPDIR)$(DELIM)import$(DELIM)libs
 	$(Q) $(MAKE) install
 
 import: $(IMPORT_TOOLS)

--- a/import/Make.defs
+++ b/import/Make.defs
@@ -74,6 +74,12 @@ else
   LDLIBPATH = -L $(TOPDIR)$(DELIM)libs
 endif
 
+# Link with user libraries
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+  LDLIBS = -lapps -lxx -lmm -lc -lm -lproxies
+endif
+
 # Try to get the path to libgcc.a.  Of course, this only works for GCC
 # toolchains.
 


### PR DESCRIPTION
## Summary

- I noticed that applications made by 'make import' contain
  undefined symbols such as printf for CONFIG_BUILD_KERNEL=y
- This commit fixes this issue by adding user libraries.
- Also, this commit generates libapps.a which is used for init

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Build (mkimport, make import) with sama5d4-ek:knsh

