### PR TITLE
romfsimg: add attribute to set minimum 4 bytes aignment for romfs image data

### DIFF
--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -84,7 +84,8 @@ $(ROMFS_IMG): install
 # Create the romfs.c file from the romfs.img file
 
 $(FSIMG_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(TESTS_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 else
 # Make sure that the NuttX gencromfs tool has been built

--- a/examples/module/drivers/Makefile
+++ b/examples/module/drivers/Makefile
@@ -72,7 +72,8 @@ $(ROMFS_IMG): install
 # Create the romfs.c file from the romfs.img file
 
 $(FSIMG_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(DRIVER_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(DRIVER_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 else ifeq ($(CONFIG_EXAMPLES_MODULE_CROMFS),y)
 # Make sure that the NuttX gencromfs tool has been built

--- a/examples/nxflat/tests/Makefile
+++ b/examples/nxflat/tests/Makefile
@@ -64,7 +64,8 @@ $(ROMFS_IMG): install
 # Create the romfs.c file from the romfs.img file
 
 $(ROMFS_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(TESTS_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(TESTS_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 # Create the dirlist.c file from the romfs directory
 

--- a/examples/posix_spawn/filesystem/Makefile
+++ b/examples/posix_spawn/filesystem/Makefile
@@ -53,7 +53,8 @@ $(ROMFS_IMG): hello/hello redirect/redirect testdata.txt
 # Create the romfs.c file from the romfs.img file
 
 $(ROMFS_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(FILESYSTEM_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(FILESYSTEM_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 # Create the exported symbol table
 

--- a/examples/sotest/lib/Makefile
+++ b/examples/sotest/lib/Makefile
@@ -63,7 +63,8 @@ $(ROMFS_IMG): install
 # Create the romfs.c file from the romfs.img file
 
 $(ROMFS_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(LIB_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(LIB_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 endif
 
 # Create the exported symbol table

--- a/examples/thttpd/content/Makefile.binfs
+++ b/examples/thttpd/content/Makefile.binfs
@@ -55,7 +55,8 @@ $(ROMFS_IMG): $(ROMFS_DIR)/index.html $(ROMFS_DIR)/style.css
 # Create the romfs.c file from the romfs.img file
 
 $(ROMFS_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(CONTENT_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+	      xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 all:: $(ROMFS_SRC)
 

--- a/examples/thttpd/content/Makefile.nxflat
+++ b/examples/thttpd/content/Makefile.nxflat
@@ -58,7 +58,8 @@ $(ROMFS_IMG): install
 # Create the romfs.c file from the romfs.img file
 
 $(ROMFS_SRC): $(ROMFS_IMG)
-	$(Q) (cd $(CONTENT_DIR); xxd -i romfs.img | sed -e "s/^unsigned/const unsigned/g" >$@)
+	$(Q) (cd $(CONTENT_DIR) && echo "#include <nuttx/compiler.h>" >$@ && \
+	      xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@)
 
 # Create the exported symbol table list from the derived *-thunk.S files
 

--- a/tools/mkromfsimg.sh
+++ b/tools/mkromfsimg.sh
@@ -55,6 +55,7 @@ genromfs -f ${romfsimg} -d ${fsdir} -V "NuttXBootVol" || { echo "genromfs failed
 
 # And, finally, create the header file
 
-xxd -i ${romfsimg} | sed 's/unsigned/const unsigned/' >${headerfile} || \
+echo '#include <nuttx/compiler.h>' >${headerfile}
+xxd -i ${romfsimg} | sed 's/^unsigned char/const unsigned char aligned_data(4)/g' >>${headerfile} || \
   { echo "ERROR: xxd of $< failed" ; rm -f ${romfsimg}; exit 1 ; }
 rm -f ${romfsimg}


### PR DESCRIPTION
## Summary
Followup of https://github.com/apache/incubator-nuttx/pull/5330

## Impact
None

## Testing
Pass CI