### PR TITLE
examples/pca9635: change O_RDONLY to O_WRONLY for driver open call

### DIFF
--- a/examples/pca9635/pca9635_main.c
+++ b/examples/pca9635/pca9635_main.c
@@ -59,7 +59,7 @@ int main(int argc, FAR char *argv[])
   int fd;
   int ret;
 
-  fd = open(CONFIG_EXAMPLES_PCA9635_DEVNAME, O_RDONLY);
+  fd = open(CONFIG_EXAMPLES_PCA9635_DEVNAME, O_WRONLY);
   if (fd < 0)
     {
       fprintf(stderr, "ERROR: Failed to open %s: %d\n",


### PR DESCRIPTION
## Summary
PCA9635 driver does not support neither need nor write operations.
The ioctl is supports PWMIOC_SETLED_BRIGHTNESS that is a write like operation

## Impact
None

## Testing
Pass CI
