### PR TITLE
import: Make.defs: Fix 'make import' for CONFIG_BUILD_KERNEL=y

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -77,14 +77,21 @@ endif
 # Link with user libraries
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
-  LDLIBS = -lapps -lxx -lmm -lc -lm -lproxies
+  LDLIBS = -lapps -lxx -lmm -lc -lproxies
+ifneq ($(CONFIG_LIBM),y)
+  LIBM = ${shell "$(CC)" $(ARCHCPUFLAGS) --print-file-name=libm.a}
+ifneq ($(LIBM),".")
+  LDLIBPATH += -L "${shell dirname $(LIBM)}"
+  LDLIBS += -lm
+endif
+endif
 endif
 
 # Try to get the path to libgcc.a.  Of course, this only works for GCC
 # toolchains.
 
-LIBGCC = ${shell "$(CC)" $(ARCHCPUFLAGS) -print-file-name=libgcc.a}
-ifneq ($(LIBGCC),)
+LIBGCC = ${shell "$(CC)" $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+ifneq ($(LIBGCC),".")
   LDLIBPATH += -L "${shell dirname $(LIBGCC)}"
   LDLIBS += -lgcc
 endif


### PR DESCRIPTION
## Summary

- I noticed that 'make import' failed due to recent changes in nuttx
- This commit fixes this issue by adding logic for -lm

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Build (mkimport, make import) with sama5d4-ek:knsh
