### PR TITLE
neutils/thttpd: Remove CONFIG_SDCLONE_DISABLE

### DIFF
--- a/netutils/thttpd/config.h
+++ b/netutils/thttpd/config.h
@@ -37,8 +37,7 @@
 
 #undef CONFIG_THTTPD
 #if defined(CONFIG_NET) && defined(CONFIG_NET_TCP) && \
-    defined(CONFIG_NET_TCPBACKLOG) && !defined(CONFIG_DISABLE_ENVIRON) && \
-    !defined(CONFIG_SDCLONE_DISABLE)
+    defined(CONFIG_NET_TCPBACKLOG) && !defined(CONFIG_DISABLE_ENVIRON)
 
 #  define CONFIG_THTTPD 1
 


### PR DESCRIPTION
## Summary
since this option doesn't exist anymore. See https://github.com/apache/incubator-nuttx/pull/5392

## Impact
No

## Testing
Pass CI
