### PR TITLE
system/adb: Fix error: 'fd' may be used uninitialized in this function

### DIFF
--- a/system/adb/logcat_service.c
+++ b/system/adb/logcat_service.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/adb/logcat_service_uv.c
+ * apps/system/adb/logcat_service.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -133,9 +133,10 @@ static void logcat_on_data_available(uv_poll_t * handle,
       goto exit_stop_service;
     }
 
-  assert(uv_fileno((uv_handle_t *)handle, &fd) == 0);
-  ret = read(fd, ap->p.data, CONFIG_ADBD_PAYLOAD_SIZE);
+  ret = uv_fileno((uv_handle_t *)handle, &fd);
+  assert(ret == 0);
 
+  ret = read(fd, ap->p.data, CONFIG_ADBD_PAYLOAD_SIZE);
   if (ret < 0)
     {
       adb_log("frame read failed %d %d\n", ret, errno);


### PR DESCRIPTION
## Summary
Minor fix.

## Impact
Avoid skip the invocation of uv_fileno in case of NDEBUG.

## Testing
Pass CI
