### PR TITLE
netutils: Check lo by CONFIG_NET_LOOPBACK not CONFIG_NET_LOCAL

### DIFF
--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -186,7 +186,7 @@
 #elif defined(CONFIG_NET_TUN)
 #  define NET_DEVNAME "tun0"
 #  define NETINIT_HAVE_NETDEV
-#elif defined(CONFIG_NET_LOCAL)
+#elif defined(CONFIG_NET_LOOPBACK)
 #  define NET_DEVNAME "lo"
 #  define NETINIT_HAVE_NETDEV
 #elif defined(CONFIG_NET_CAN)


### PR DESCRIPTION
## Summary
CONFIG_NET_LOCAL is used to enable Unix Domain Socket

## Impact
Minor

## Testing
Local test
