### PR TITLE
system/cu: Don't select SERIAL_TERMIOS in Kconfig

### DIFF
--- a/system/cu/Kconfig
+++ b/system/cu/Kconfig
@@ -6,8 +6,6 @@
 menuconfig SYSTEM_CUTERM
 	tristate "CU minimal serial terminal"
 	default n
-	depends on ARCH_HAVE_SERIAL_TERMIOS
-	select SERIAL_TERMIOS
 	---help---
 		Enable the CU serial terminal.  This is a minimalistic
 		implementation of the 'cu' terminal program (part of Taylor UUCP for


### PR DESCRIPTION
## Summary
since all terminal related code is already guarded by CONFIG_SERIAL_TERMIOS

## Impact
Minor

## Testing

