### PR TITLE
netutils/netcat: fixed crash on accept() invocation.

### DIFF
--- a/netutils/netcat/netcat_main.c
+++ b/netutils/netcat/netcat_main.c
@@ -174,6 +174,7 @@ int netcat_server(int argc, char * argv[])
       goto out;
     }
 
+  addrlen = sizeof(struct sockaddr_in);
   if ((conn = accept(id, (struct sockaddr *)&client, &addrlen)) != -1)
     {
       result = do_io(conn, outfd,


### PR DESCRIPTION
## Summary

Sometimes netcat in server mode crashed with "psock_accept: ERROR: si_accept failed: -9".
And sometimes it crashed with "up_assert: Assertion failed at file:inet/inet_sockif.c line: 841 task: netcat".

## Impact

netutils/netcat

## Testing

```
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
nsh> netcat -l 31337
log: net: listening on :31337
[42949702.410000] up_assert: Assertion failed at file:inet/inet_sockif.c line: 841 task: netcat

```
```
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
nsh> netcat -l 31337
log: net: listening on :31337
[42949669.600000] psock_accept: ERROR: si_accept failed: -9
accept failed: Error 9
```