### PR TITLE
industry/foc: add support for angle from sensorless observer

### DIFF
--- a/include/industry/foc/float/foc_angle.h
+++ b/include/industry/foc/float/foc_angle.h
@@ -106,6 +106,26 @@ struct foc_openloop_cfg_f32_s
 };
 #endif  /* CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP */
 
+#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+struct foc_angle_onfo_cfg_f32_s
+{
+  float per;            /* Controller period */
+  float gain;
+  float gain_slow;
+  struct motor_phy_params_f32_s phy;
+};
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_ANGLE_OSMO
+struct foc_angle_osmo_cfg_f32_s
+{
+  float per;            /* Controller period */
+  float k_slide;        /* Bang-bang controller gain */
+  float err_max;        /* Linear mode threshold */
+  struct motor_phy_params_f32_s phy;
+};
+#endif
+
 #ifdef CONFIG_INDUSTRY_FOC_ANGLE_QENCO
 /* Qencoder configuration data */
 
@@ -134,6 +154,18 @@ struct foc_hall_cfg_f32_s
 /* Open-loop angle operations (float) */
 
 extern struct foc_angle_ops_f32_s g_foc_angle_ol_f32;
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+/* NFO oberver angle operations (float) */
+
+extern struct foc_angle_ops_f32_s g_foc_angle_onfo_f32;
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_ANGLE_OSMO
+/* SMO oberver angle operations (float) */
+
+extern struct foc_angle_ops_f32_s g_foc_angle_osmo_f32;
 #endif
 
 #ifdef CONFIG_INDUSTRY_FOC_ANGLE_QENCO

--- a/include/industry/foc/float/foc_handler.h
+++ b/include/industry/foc/float/foc_handler.h
@@ -66,6 +66,7 @@ struct foc_state_f32_s
   ab_frame_f32_t  vab;
   dq_frame_f32_t  vdq;
   dq_frame_f32_t  idq;
+  float           mod_scale;
 };
 
 /* Forward declaration */

--- a/industry/foc/Kconfig
+++ b/industry/foc/Kconfig
@@ -58,6 +58,27 @@ config INDUSTRY_FOC_ANGLE_OPENLOOP
 	---help---
 		Enable support for open-loop angle handler
 
+config INDUSTRY_FOC_ANGLE_OBSERVER
+	bool "FOC angle observer handler"
+	default n
+	---help---
+		Enable support for observer angle handler
+
+if INDUSTRY_FOC_ANGLE_OBSERVER
+
+choice
+	prompt "FOC observer type selection"
+
+config INDUSTRY_FOC_ANGLE_OSMO
+	bool "Enable slidmode observer"
+
+config INDUSTRY_FOC_ANGLE_ONFO
+	bool "Enable fluxlink observer"
+
+endchoice # FOC observer type selection
+
+endif # INDUSTRY_FOC_ANGLE_OBSERVER
+
 config INDUSTRY_FOC_ANGLE_QENCO
 	bool "FOC angle quadrature encoder handler"
 	default n

--- a/industry/foc/Makefile
+++ b/industry/foc/Makefile
@@ -36,6 +36,12 @@ CSRCS += float/foc_routine.c
 ifeq ($(CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP),y)
 CSRCS += float/foc_ang_openloop.c
 endif
+ifeq ($(CONFIG_INDUSTRY_FOC_ANGLE_ONFO),y)
+CSRCS += float/foc_ang_onfo.c
+endif
+ifeq ($(CONFIG_INDUSTRY_FOC_ANGLE_OSMO),y)
+CSRCS += float/foc_ang_osmo.c
+endif
 ifeq ($(CONFIG_INDUSTRY_FOC_ANGLE_QENCO),y)
 CSRCS += float/foc_ang_qenco.c
 endif

--- a/industry/foc/float/foc_ang_onfo.c
+++ b/industry/foc/float/foc_ang_onfo.c
@@ -1,0 +1,328 @@
+/****************************************************************************
+ * apps/industry/foc/float/foc_ang_onfo.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "industry/foc/foc_log.h"
+#include "industry/foc/float/foc_angle.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SIGN(x)	((x > 0.0f) ? 1.0f : -1.0f)
+
+#define LINEAR_MAP(x, in_min, in_max, out_min, out_max) \
+  ((x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min)
+
+/****************************************************************************
+ * Private Data Types
+ ****************************************************************************/
+
+/* sensorless observer data */
+
+struct foc_observer_f32_s
+{
+  struct foc_observer_cfg_f32_s cfg;
+  struct motor_aobserver_f32_s  data;
+  float                         dir;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int foc_angle_onfo_init_f32(FAR foc_angle_f32_t *h);
+static void foc_angle_onfo_deinit_f32(FAR foc_angle_f32_t *h);
+static int foc_angle_onfo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg);
+static int foc_angle_onfo_zero_f32(FAR foc_angle_f32_t *h);
+static int foc_angle_onfo_dir_f32(FAR foc_angle_f32_t *h, float dir);
+static int foc_angle_onfo_run_f32(FAR foc_angle_f32_t *h,
+                                FAR struct foc_angle_in_f32_s *in,
+                                FAR struct foc_angle_out_f32_s *out);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* FOC angle float interface */
+
+struct foc_angle_ops_f32_s g_foc_angle_onfo_f32 =
+{
+  .init   = foc_angle_onfo_init_f32,
+  .deinit = foc_angle_onfo_deinit_f32,
+  .cfg    = foc_angle_onfo_cfg_f32,
+  .zero   = foc_angle_onfo_zero_f32,
+  .dir    = foc_angle_onfo_dir_f32,
+  .run    = foc_angle_onfo_run_f32,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_angle_onfo_init_f32
+ *
+ * Description:
+ *   Initialize the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static int foc_angle_onfo_init_f32(FAR foc_angle_f32_t *h)
+{
+  int ret = OK;
+
+  DEBUGASSERT(h);
+
+  /* Connect angle data */
+
+  h->data = zalloc(sizeof(struct foc_observer_f32_s));
+  if (h->data == NULL)
+    {
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_angle_onfo_deinit_f32
+ *
+ * Description:
+ *   De-initialize the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static void foc_angle_onfo_deinit_f32(FAR foc_angle_f32_t *h)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Free angle data */
+
+  if (h->data)
+    {
+      ob = h->data;
+      if (ob->data.ao)
+        {
+           free(ob->data.ao);
+        }
+
+      free(h->data);
+    }
+}
+
+/****************************************************************************
+ * Name: foc_angle_onfo_cfg_f32
+ *
+ * Description:
+ *   Configure the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   cfg - pointer to angle handler configuration data
+ *         (struct foc_observer_f32_s)
+ *
+ ****************************************************************************/
+
+static int foc_angle_onfo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
+{
+  int ret = OK;
+  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR struct motor_aobserver_nfo_f32_s *ao = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Copy configuration */
+
+  memcpy(&ob->cfg, cfg, sizeof(struct foc_observer_cfg_f32_s));
+
+  /* Initialize sensorless observer controller data */
+
+  DEBUGASSERT(ob->cfg.per > 0.0f);
+
+  ao = zalloc(sizeof(struct motor_aobserver_nfo_f32_s));
+  if (ao == NULL)
+    {
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+  /* Initialize nolinear fluxlink angle observer */
+
+  motor_aobserver_nfo_init(ao);
+
+  /* Initialize sensorless observer */
+
+  motor_aobserver_init(&ob->data, ao, ob->cfg.per);
+
+  /* Initialize with CW direction */
+
+  ob->dir = DIR_CW;
+
+  return OK;
+errout:
+  if (ao)
+    {
+      free(ao);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_angle_onfo_zero_f32
+ *
+ * Description:
+ *   Zero the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static int foc_angle_onfo_zero_f32(FAR foc_angle_f32_t *h)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Reset angle */
+
+  ob->data.angle = 0.0f;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_angle_onfo_dir_f32
+ *
+ * Description:
+ *   Set the sensorless observer FOC angle handler direction (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   dir - sensor direction (1 if normal -1 if inverted)
+ *
+ ****************************************************************************/
+
+static int foc_angle_onfo_dir_f32(FAR foc_angle_f32_t *h, float dir)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Configure direction */
+
+  ob->dir = dir;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_angle_onfo_run_f32
+ *
+ * Description:
+ *   Process the FOC sensorless observer angle data (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   in  - pointer to FOC angle handler input data
+ *   out - pointer to FOC angle handler output data
+ *
+ ****************************************************************************/
+
+static int foc_angle_onfo_run_f32(FAR foc_angle_f32_t *h,
+                                FAR struct foc_angle_in_f32_s *in,
+                                FAR struct foc_angle_out_f32_s *out)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR dq_frame_f32_t  v_dq_mod;
+  float duty_now;
+  float dyn_gain;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Normalize the d-q voltage to get the d-q modulation
+   * voltage
+   */
+
+  v_dq_mod.d = in->state->vdq.d * in->state->mod_scale;
+  v_dq_mod.q = in->state->vdq.q * in->state->mod_scale;
+
+  /* Update duty cycle now */
+
+  duty_now = SIGN(in->state->vdq.q) * vector2d_mag(v_dq_mod.d, v_dq_mod.q);
+
+  /* Update and the observer gain. */
+
+  dyn_gain = LINEAR_MAP(fabsf(duty_now), 0.0, 1.0,
+             ob->cfg.gain * ob->cfg.gain_slow, ob->cfg.gain) * 0.5;
+
+  /* Update observer */
+
+  motor_aobserver_nfo(&ob->data, &in->state->iab, &in->state->vab,
+                      &ob->cfg.phy, dyn_gain);
+
+  /* Copy data */
+
+  out->type  = FOC_ANGLE_TYPE_ELE;
+  out->angle = ob->data.angle;
+
+  return OK;
+}

--- a/industry/foc/float/foc_ang_osmo.c
+++ b/industry/foc/float/foc_ang_osmo.c
@@ -1,0 +1,302 @@
+/****************************************************************************
+ * apps/industry/foc/float/foc_ang_osmo.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "industry/foc/foc_log.h"
+#include "industry/foc/float/foc_angle.h"
+
+/****************************************************************************
+ * Private Data Types
+ ****************************************************************************/
+
+/* sensorless observer data */
+
+struct foc_observer_f32_s
+{
+  struct foc_observer_cfg_f32_s cfg;
+  struct motor_aobserver_f32_s  data;
+  float                         dir;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int foc_angle_osmo_init_f32(FAR foc_angle_f32_t *h);
+static void foc_angle_osmo_deinit_f32(FAR foc_angle_f32_t *h);
+static int foc_angle_osmo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg);
+static int foc_angle_osmo_zero_f32(FAR foc_angle_f32_t *h);
+static int foc_angle_osmo_dir_f32(FAR foc_angle_f32_t *h, float dir);
+static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
+                                FAR struct foc_angle_in_f32_s *in,
+                                FAR struct foc_angle_out_f32_s *out);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* FOC angle float interface */
+
+struct foc_angle_ops_f32_s g_foc_angle_osmo_f32 =
+{
+  .init   = foc_angle_osmo_init_f32,
+  .deinit = foc_angle_osmo_deinit_f32,
+  .cfg    = foc_angle_osmo_cfg_f32,
+  .zero   = foc_angle_osmo_zero_f32,
+  .dir    = foc_angle_osmo_dir_f32,
+  .run    = foc_angle_osmo_run_f32,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_angle_osmo_init_f32
+ *
+ * Description:
+ *   Initialize the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static int foc_angle_osmo_init_f32(FAR foc_angle_f32_t *h)
+{
+  int ret = OK;
+
+  DEBUGASSERT(h);
+
+  /* Connect angle data */
+
+  h->data = zalloc(sizeof(struct foc_observer_f32_s));
+  if (h->data == NULL)
+    {
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_angle_osmo_deinit_f32
+ *
+ * Description:
+ *   De-initialize the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static void foc_angle_osmo_deinit_f32(FAR foc_angle_f32_t *h)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+  DEBUGASSERT(h);
+
+  /* Free angle data */
+
+  if (h->data)
+    {
+      ob = h->data;
+      if (ob->data.ao)
+        {
+           free(ob->data.ao);
+        }
+
+      free(h->data);
+    }
+}
+
+/****************************************************************************
+ * Name: foc_angle_osmo_cfg_f32
+ *
+ * Description:
+ *   Configure the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   cfg - pointer to angle handler configuration data
+ *         (struct foc_observer_f32_s)
+ *
+ ****************************************************************************/
+
+static int foc_angle_osmo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
+{
+  int ret = OK;
+  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR struct motor_aobserver_smo_f32_s *ao = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Copy configuration */
+
+  memcpy(&ob->cfg, cfg, sizeof(struct foc_observer_cfg_f32_s));
+
+  /* Initialize sensorless observer controller data */
+
+  DEBUGASSERT(ob->cfg.per > 0.0f);
+
+  ao = zalloc(sizeof(struct motor_aobserver_smo_f32_s));
+  if (ao == NULL)
+    {
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+  /* Initialize SMO angle observer */
+
+  motor_aobserver_smo_init(ao, ob->cfg.k_slide, ob->cfg.err_max);
+
+  /* Initialize sensorless observer */
+
+  motor_aobserver_init(&ob->data, ao, ob->cfg.per);
+
+  /* Initialize with CW direction */
+
+  ob->dir = DIR_CW;
+
+  return OK;
+errout:
+  if (ao)
+    {
+      free(ao);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: foc_angle_osmo_zero_f32
+ *
+ * Description:
+ *   Zero the sensorless observer FOC angle handler (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *
+ ****************************************************************************/
+
+static int foc_angle_osmo_zero_f32(FAR foc_angle_f32_t *h)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Reset angle */
+
+  ob->data.angle = 0.0f;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_angle_osmo_dir_f32
+ *
+ * Description:
+ *   Set the sensorless observer FOC angle handler direction (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   dir - sensor direction (1 if normal -1 if inverted)
+ *
+ ****************************************************************************/
+
+static int foc_angle_osmo_dir_f32(FAR foc_angle_f32_t *h, float dir)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Configure direction */
+
+  ob->dir = dir;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_angle_osmo_run_f32
+ *
+ * Description:
+ *   Process the FOC sensorless observer angle data (float32)
+ *
+ * Input Parameter:
+ *   h   - pointer to FOC angle handler
+ *   in  - pointer to FOC angle handler input data
+ *   out - pointer to FOC angle handler output data
+ *
+ ****************************************************************************/
+
+static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
+                                FAR struct foc_angle_in_f32_s *in,
+                                FAR struct foc_angle_out_f32_s *out)
+{
+  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR dq_frame_f32_t  v_dq_mod;
+  float duty_now;
+  float dyn_gain;
+
+  DEBUGASSERT(h);
+
+  /* Get sensorless observer data */
+
+  DEBUGASSERT(h->data);
+  ob = h->data;
+
+  /* Update observer */
+
+  motor_aobserver_smo(&ob->data, &in->state->iab, &in->state->vab,
+                      &ob->cfg.phy, ob->dir);
+
+  /* Copy data */
+
+  out->type  = FOC_ANGLE_TYPE_ELE;
+  out->angle = ob->data.angle;
+
+  return OK;
+}

--- a/industry/foc/float/foc_picontrol.c
+++ b/industry/foc/float/foc_picontrol.c
@@ -416,4 +416,8 @@ static void foc_control_state_get_f32(FAR foc_handler_f32_t *h,
   state->volt[0] = foc->data.v_abc.a;
   state->volt[1] = foc->data.v_abc.b;
   state->volt[2] = foc->data.v_abc.c;
+
+  /* Copy modulation scale */
+
+  state->mod_scale = foc->data.vab_mod_scale;
 }


### PR DESCRIPTION
## Summary
Add support park transform angle from sensorless observer, support both nolinear fluxlink observer and sliding mode observer
## Impact
The former foc control lib in industry just support open-loop,encoder and hall, now we can use sensorless observer mode
## Testing
Tested on FOC controller based on stm32f405
