### PR TITLE
mlearning: nnabla: fix include path

### DIFF
--- a/mlearning/libnnablart/Make.defs
+++ b/mlearning/libnnablart/Make.defs
@@ -21,6 +21,6 @@
 ifeq ($(CONFIG_NNABLA_RT),y)
 CONFIGURED_APPS += $(APPDIR)/mlearning/libnnablart
 
-CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/libnnablart/nnabla-c-runtime/include/nnablart/}
-CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/libnnablart/nnabla-c-runtime/include/nnablart/}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/libnnablart/nnabla-c-runtime/include/}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/libnnablart/nnabla-c-runtime/include/}
 endif


### PR DESCRIPTION
## Summary
During contribution the folders have moved and the path
should be updated

## Impact
NNABLA 

## Testing
compiled