### PR TITLE
examples/foc: make the FOC current controller configurable

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -43,6 +43,16 @@ config EXAMPLES_FOC_VERBOSE
 	default 1
 	range 0 2
 
+choice
+	prompt "FOC current controller selection"
+	default EXAMPLES_FOC_CONTROL_PI
+
+config EXAMPLES_FOC_CONTROL_PI
+	bool "FOC use PI current controller"
+	select INDUSTRY_FOC_CONTROL_PI
+
+endchoice # FOC current controller
+
 config EXAMPLES_FOC_PWM_FREQ
 	int "FOC PWM frequency"
 	default 10000
@@ -315,6 +325,8 @@ config EXAMPLES_FOC_OPENLOOP_Q
 	default 200
 	depends on EXAMPLES_FOC_HAVE_OPENLOOP
 
+if EXAMPLES_FOC_CONTROL_PI
+
 config EXAMPLES_FOC_IDQ_KP
 	int "FOC PI controller Kp gain [x1000]"
 	default 0
@@ -330,6 +342,8 @@ config EXAMPLES_FOC_IDQ_KI
 		It is set to 0 by default and must be properly configured by the user!
 		The value of Kp and Ki depends on the controlled motor parameters.
 		For more instructions see README.md for this example.
+
+endif #EXAMPLES_FOC_CONTROL_PI
 
 config EXAMPLES_FOC_RAMP_THR
 	int "FOC velocity ramp threshold [x1000]"

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -58,6 +58,12 @@
 #  endif
 #endif
 
+/* For now only the FOC PI current controller supported */
+
+#ifndef CONFIG_EXAMPLES_FOC_CONTROL_PI
+#  error For now only the FOC PI current controller supported
+#endif
+
 /* Velocity ramp must be configured */
 
 #if (CONFIG_EXAMPLES_FOC_RAMP_THR == 0)

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -75,10 +75,13 @@ static void init_args(FAR struct args_s *args)
   args->qparam =
     (args->qparam == 0 ? CONFIG_EXAMPLES_FOC_OPENLOOP_Q : args->qparam);
 #endif
-  args->pi_kp =
-    (args->pi_kp == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KP : args->pi_kp);
-  args->pi_ki =
-    (args->pi_ki == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KI : args->pi_ki);
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  args->foc_pi_kp =
+    (args->foc_pi_kp == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KP : args->foc_pi_kp);
+  args->foc_pi_ki =
+    (args->foc_pi_ki == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KI : args->foc_pi_ki);
+#endif
 
   /* Setpoint configuration */
 
@@ -129,13 +132,15 @@ static int validate_args(FAR struct args_s *args)
 {
   int ret = -EINVAL;
 
-  /* FOC PI controller */
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  /* Current PI controller */
 
-  if (args->pi_kp == 0 && args->pi_ki == 0)
+  if (args->foc_pi_kp == 0 && args->foc_pi_ki == 0)
     {
-      PRINTF("ERROR: missing Kp/Ki configuration\n");
+      PRINTF("ERROR: missing FOC Kp/Ki configuration\n");
       goto errout;
     }
+#endif
 
   /* FOC operation mode */
 
@@ -366,8 +371,10 @@ int main(int argc, char *argv[])
 #endif
       foc[i].fmode    = args.fmode;
       foc[i].mmode    = args.mmode;
-      foc[i].pi_kp    = args.pi_kp;
-      foc[i].pi_ki    = args.pi_ki;
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+      foc[i].foc_pi_kp = args.foc_pi_kp;
+      foc[i].foc_pi_ki = args.foc_pi_ki;
+#endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
       foc[i].torqmax  = args.torqmax;
 #endif

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -188,7 +188,9 @@ errout:
 
 static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
 {
-#ifdef CONFIG_INDUSTRY_FOC_CONTROL_PI
+  FAR struct foc_control_ops_b16_s    *foc_ctrl = NULL;
+  FAR struct foc_modulation_ops_b16_s *foc_mod  = NULL;
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   struct foc_initdata_b16_s ctrl_cfg;
 #endif
 #ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
@@ -216,24 +218,45 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
     }
 #endif
 
+  /* Get FOC controller */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  foc_ctrl = &g_foc_control_pi_b16;
+#else
+#  error FOC controller not selected
+#endif
+
+  /* Get FOC modulation */
+
+#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+  foc_mod = &g_foc_mod_svm3_b16;
+#else
+#  error FOC modulation not selected
+#endif
+
+  /* Initialize FOC handler */
+
+  DEBUGASSERT(foc_ctrl != NULL);
+  DEBUGASSERT(foc_mod != NULL);
+
   /* Initialize FOC handler */
 
   ret = foc_handler_init_b16(&motor->handler,
-                             &g_foc_control_pi_b16,
-                             &g_foc_mod_svm3_b16);
+                             foc_ctrl,
+                             foc_mod);
   if (ret < 0)
     {
       PRINTF("ERROR: foc_handler_init failed %d\n", ret);
       goto errout;
     }
 
-#ifdef CONFIG_INDUSTRY_FOC_CONTROL_PI
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   /* Get PI controller configuration */
 
-  ctrl_cfg.id_kp = ftob16(motor->envp->pi_kp / 1000.0f);
-  ctrl_cfg.id_ki = ftob16(motor->envp->pi_ki / 1000.0f);
-  ctrl_cfg.iq_kp = ftob16(motor->envp->pi_kp / 1000.0f);
-  ctrl_cfg.iq_ki = ftob16(motor->envp->pi_ki / 1000.0f);
+  ctrl_cfg.id_kp = ftob16(motor->envp->foc_pi_kp / 1000.0f);
+  ctrl_cfg.id_ki = ftob16(motor->envp->foc_pi_ki / 1000.0f);
+  ctrl_cfg.iq_kp = ftob16(motor->envp->foc_pi_kp / 1000.0f);
+  ctrl_cfg.iq_ki = ftob16(motor->envp->foc_pi_ki / 1000.0f);
 #endif
 
 #ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -188,7 +188,9 @@ errout:
 
 static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
 {
-#ifdef CONFIG_INDUSTRY_FOC_CONTROL_PI
+  FAR struct foc_control_ops_f32_s    *foc_ctrl = NULL;
+  FAR struct foc_modulation_ops_f32_s *foc_mod  = NULL;
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   struct foc_initdata_f32_s ctrl_cfg;
 #endif
 #ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
@@ -216,24 +218,43 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
     }
 #endif
 
+  /* Get FOC controller */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  foc_ctrl = &g_foc_control_pi_f32;
+#else
+#  error FOC controller not selected
+#endif
+
+  /* Get FOC modulation */
+
+#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+  foc_mod = &g_foc_mod_svm3_f32;
+#else
+#  error FOC modulation not selected
+#endif
+
   /* Initialize FOC handler */
 
+  DEBUGASSERT(foc_ctrl != NULL);
+  DEBUGASSERT(foc_mod != NULL);
+
   ret = foc_handler_init_f32(&motor->handler,
-                             &g_foc_control_pi_f32,
-                             &g_foc_mod_svm3_f32);
+                             foc_ctrl,
+                             foc_mod);
   if (ret < 0)
     {
       PRINTF("ERROR: foc_handler_init failed %d\n", ret);
       goto errout;
     }
 
-#ifdef CONFIG_INDUSTRY_FOC_CONTROL_PI
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   /* Get PI controller configuration */
 
-  ctrl_cfg.id_kp = (motor->envp->pi_kp / 1000.0f);
-  ctrl_cfg.id_ki = (motor->envp->pi_ki / 1000.0f);
-  ctrl_cfg.iq_kp = (motor->envp->pi_kp / 1000.0f);
-  ctrl_cfg.iq_ki = (motor->envp->pi_ki / 1000.0f);
+  ctrl_cfg.id_kp = (motor->envp->foc_pi_kp / 1000.0f);
+  ctrl_cfg.id_ki = (motor->envp->foc_pi_ki / 1000.0f);
+  ctrl_cfg.iq_kp = (motor->envp->foc_pi_kp / 1000.0f);
+  ctrl_cfg.iq_ki = (motor->envp->foc_pi_ki / 1000.0f);
 #endif
 
 #ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -62,8 +62,10 @@ static struct option g_long_options[] =
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
     { "oqset", required_argument, 0, 'o' },
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
     { "fkp", required_argument, 0, OPT_FKP },
     { "fki", required_argument, 0, OPT_FKI },
+#endif
     { 0, 0, 0, 0 }
   };
 
@@ -106,8 +108,10 @@ static void foc_help(void)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
   PRINTF("  [-o] openloop Vq/Iq setting [x1000]\n");
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   PRINTF("  [--fki] PI Kp coefficient [x1000]\n");
   PRINTF("  [--fkp] PI Ki coefficient [x1000]\n");
+#endif
 }
 
 /****************************************************************************
@@ -135,17 +139,19 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 
       switch (c)
         {
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
           case OPT_FKP:
             {
-              args->pi_kp = atoi(optarg);
+              args->foc_pi_kp = atoi(optarg);
               break;
             }
 
           case OPT_FKI:
             {
-              args->pi_ki = atoi(optarg);
+              args->foc_pi_ki = atoi(optarg);
               break;
             }
+#endif
 
           case 't':
             {

--- a/examples/foc/foc_parseargs.h
+++ b/examples/foc/foc_parseargs.h
@@ -47,8 +47,12 @@ struct args_s
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
   int      qparam;              /* Open-loop Q setting (x1000) */
 #endif
-  uint32_t pi_kp;               /* PI Kp (x1000) */
-  uint32_t pi_ki;               /* PI Ki (x1000) */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  uint32_t foc_pi_kp;           /* FOC PI Kp (x1000) */
+  uint32_t foc_pi_ki;           /* FOC PI Ki (x1000) */
+#endif
+
   int      state;               /* Example state (FREE, CW, CCW, STOP) */
   int8_t   en;                  /* Enabled instances (bit-encoded) */
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -102,8 +102,12 @@ struct foc_ctrl_env_s
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
   int                 qparam;   /* Open-loop Q setting (x1000) */
 #endif
-  uint32_t            pi_kp;    /* FOC PI Kp (x1000) */
-  uint32_t            pi_ki;    /* FOC PI Ki (x1000) */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  uint32_t            foc_pi_kp; /* FOC PI Kp (x1000) */
+  uint32_t            foc_pi_ki; /* FOC PI Ki (x1000) */
+#endif
+
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
   uint32_t            torqmax;  /* Torque max (x1000) */
 #endif


### PR DESCRIPTION
## Summary
examples/foc: make the FOC current controller configurable
For now only the FOC PI current controller is supported, but this can be easily extended to support other control methods

## Impact
Modularity improved

## Testing
CI
