### PR TITLE
system/adb: Change the default value of ADBD_PAYLOAD_SIZE to 1024

### DIFF
--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -83,7 +83,7 @@ config ADBD_FEATURES
 
 config ADBD_PAYLOAD_SIZE
 	int "Normal ADB frame size"
-	default 64
+	default 1024
 	---help---
 		Normal frame size in bytes.
 


### PR DESCRIPTION
## Summary
improve the speed of "adb push" and "adb pull", follow the upstream change:
https://github.com/spiriou/microADB/pull/22

## Impact
Kconfig default vaule

## Testing
Pass CI and local test
