### PR TITLE
apps: Enable Rust based application.

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -57,6 +57,7 @@ $(foreach BDIR, $(BUILDIRS), $(eval $(call Add_Application,$(BDIR))))
 # File extensions
 
 CXXEXT ?= .cxx
+RUSTEXT ?= .rs
 
 # Library path
 


### PR DESCRIPTION
## Summary
Extend Application.mk and Make.defs to compile Rust based applications.

## Impact
nothing as it's new

## Testing
Simulation on MacBook Air M1 with Monterey 12.2.1 using rustc rustc 1.58.1 (stable) via Homebrew.
