### PR TITLE
industry/foc: various fixes

### DIFF
--- a/industry/foc/Kconfig
+++ b/industry/foc/Kconfig
@@ -58,26 +58,17 @@ config INDUSTRY_FOC_ANGLE_OPENLOOP
 	---help---
 		Enable support for open-loop angle handler
 
-config INDUSTRY_FOC_ANGLE_OBSERVER
-	bool "FOC angle observer handler"
+config INDUSTRY_FOC_ANGLE_OSMO
+	bool "Enable slidmode angle observer"
 	default n
 	---help---
-		Enable support for observer angle handler
-
-if INDUSTRY_FOC_ANGLE_OBSERVER
-
-choice
-	prompt "FOC observer type selection"
-
-config INDUSTRY_FOC_ANGLE_OSMO
-	bool "Enable slidmode observer"
+		Enable support for SMO observer handler
 
 config INDUSTRY_FOC_ANGLE_ONFO
-	bool "Enable fluxlink observer"
-
-endchoice # FOC observer type selection
-
-endif # INDUSTRY_FOC_ANGLE_OBSERVER
+	bool "Enable fluxlink angle observer"
+	default n
+	---help---
+		Enable support for NFO observer handler
 
 config INDUSTRY_FOC_ANGLE_QENCO
 	bool "FOC angle quadrature encoder handler"

--- a/industry/foc/float/foc_ang_onfo.c
+++ b/industry/foc/float/foc_ang_onfo.c
@@ -50,7 +50,7 @@ struct foc_observer_f32_s
 {
   struct foc_observer_cfg_f32_s cfg;
   struct motor_aobserver_f32_s  data;
-  float                         dir;
+  float                         sensor_dir;
 };
 
 /****************************************************************************
@@ -198,7 +198,7 @@ static int foc_angle_onfo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
 
   /* Initialize with CW direction */
 
-  ob->dir = DIR_CW;
+  ob->sensor_dir = DIR_CW;
 
   return OK;
 errout:
@@ -264,7 +264,7 @@ static int foc_angle_onfo_dir_f32(FAR foc_angle_f32_t *h, float dir)
 
   /* Configure direction */
 
-  ob->dir = dir;
+  ob->sensor_dir = dir;
 
   return OK;
 }

--- a/industry/foc/float/foc_ang_osmo.c
+++ b/industry/foc/float/foc_ang_osmo.c
@@ -41,7 +41,7 @@ struct foc_observer_f32_s
 {
   struct foc_observer_cfg_f32_s cfg;
   struct motor_aobserver_f32_s  data;
-  float                         dir;
+  float                         sensor_dir;
 };
 
 /****************************************************************************
@@ -188,7 +188,7 @@ static int foc_angle_osmo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
 
   /* Initialize with CW direction */
 
-  ob->dir = DIR_CW;
+  ob->sensor_dir = DIR_CW;
 
   return OK;
 errout:
@@ -254,7 +254,7 @@ static int foc_angle_osmo_dir_f32(FAR foc_angle_f32_t *h, float dir)
 
   /* Configure direction */
 
-  ob->dir = dir;
+  ob->sensor_dir = dir;
 
   return OK;
 }

--- a/industry/foc/float/foc_ang_osmo.c
+++ b/industry/foc/float/foc_ang_osmo.c
@@ -37,11 +37,12 @@
 
 /* sensorless observer data */
 
-struct foc_observer_f32_s
+struct foc_ang_osmo_f32_s
 {
-  struct foc_observer_cfg_f32_s cfg;
-  struct motor_aobserver_f32_s  data;
-  float                         sensor_dir;
+  struct foc_angle_osmo_cfg_f32_s  cfg;
+  struct motor_aobserver_smo_f32_s data;
+  struct motor_aobserver_f32_s     o;
+  float                            sensor_dir;
 };
 
 /****************************************************************************
@@ -96,7 +97,7 @@ static int foc_angle_osmo_init_f32(FAR foc_angle_f32_t *h)
 
   /* Connect angle data */
 
-  h->data = zalloc(sizeof(struct foc_observer_f32_s));
+  h->data = zalloc(sizeof(struct foc_ang_osmo_f32_s));
   if (h->data == NULL)
     {
       ret = -ENOMEM;
@@ -120,18 +121,11 @@ errout:
 
 static void foc_angle_osmo_deinit_f32(FAR foc_angle_f32_t *h)
 {
-  FAR struct foc_observer_f32_s *ob = NULL;
   DEBUGASSERT(h);
-
-  /* Free angle data */
 
   if (h->data)
     {
-      ob = h->data;
-      if (ob->data.ao)
-        {
-           free(ob->data.ao);
-        }
+      /* Free angle data */
 
       free(h->data);
     }
@@ -146,15 +140,14 @@ static void foc_angle_osmo_deinit_f32(FAR foc_angle_f32_t *h)
  * Input Parameter:
  *   h   - pointer to FOC angle handler
  *   cfg - pointer to angle handler configuration data
- *         (struct foc_observer_f32_s)
+ *         (struct foc_ang_osmo_f32_s)
  *
  ****************************************************************************/
 
 static int foc_angle_osmo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
 {
-  int ret = OK;
-  FAR struct foc_observer_f32_s *ob = NULL;
-  FAR struct motor_aobserver_smo_f32_s *ao = NULL;
+  FAR struct foc_ang_osmo_f32_s *ob  = NULL;
+  int                            ret = OK;
 
   DEBUGASSERT(h);
 
@@ -165,37 +158,23 @@ static int foc_angle_osmo_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
 
   /* Copy configuration */
 
-  memcpy(&ob->cfg, cfg, sizeof(struct foc_observer_cfg_f32_s));
+  memcpy(&ob->cfg, cfg, sizeof(struct foc_angle_osmo_cfg_f32_s));
 
   /* Initialize sensorless observer controller data */
 
   DEBUGASSERT(ob->cfg.per > 0.0f);
 
-  ao = zalloc(sizeof(struct motor_aobserver_smo_f32_s));
-  if (ao == NULL)
-    {
-      ret = -ENOMEM;
-      goto errout;
-    }
-
   /* Initialize SMO angle observer */
 
-  motor_aobserver_smo_init(ao, ob->cfg.k_slide, ob->cfg.err_max);
+  motor_aobserver_smo_init(&ob->data, ob->cfg.k_slide, ob->cfg.err_max);
 
   /* Initialize sensorless observer */
 
-  motor_aobserver_init(&ob->data, ao, ob->cfg.per);
+  motor_aobserver_init(&ob->o, &ob->data, ob->cfg.per);
 
   /* Initialize with CW direction */
 
   ob->sensor_dir = DIR_CW;
-
-  return OK;
-errout:
-  if (ao)
-    {
-      free(ao);
-    }
 
   return ret;
 }
@@ -213,7 +192,7 @@ errout:
 
 static int foc_angle_osmo_zero_f32(FAR foc_angle_f32_t *h)
 {
-  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR struct foc_ang_osmo_f32_s *ob = NULL;
 
   DEBUGASSERT(h);
 
@@ -222,9 +201,13 @@ static int foc_angle_osmo_zero_f32(FAR foc_angle_f32_t *h)
   DEBUGASSERT(h->data);
   ob = h->data;
 
+  /* Reinitialize observer data */
+
+  motor_aobserver_smo_init(&ob->data, ob->cfg.k_slide, ob->cfg.err_max);
+
   /* Reset angle */
 
-  ob->data.angle = 0.0f;
+  ob->o.angle = 0.0f;
 
   return OK;
 }
@@ -243,7 +226,7 @@ static int foc_angle_osmo_zero_f32(FAR foc_angle_f32_t *h)
 
 static int foc_angle_osmo_dir_f32(FAR foc_angle_f32_t *h, float dir)
 {
-  FAR struct foc_observer_f32_s *ob = NULL;
+  FAR struct foc_ang_osmo_f32_s *ob = NULL;
 
   DEBUGASSERT(h);
 
@@ -276,10 +259,7 @@ static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
                                 FAR struct foc_angle_in_f32_s *in,
                                 FAR struct foc_angle_out_f32_s *out)
 {
-  FAR struct foc_observer_f32_s *ob = NULL;
-  FAR dq_frame_f32_t  v_dq_mod;
-  float duty_now;
-  float dyn_gain;
+  FAR struct foc_ang_osmo_f32_s *ob = NULL;
 
   DEBUGASSERT(h);
 
@@ -290,13 +270,13 @@ static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
 
   /* Update observer */
 
-  motor_aobserver_smo(&ob->data, &in->state->iab, &in->state->vab,
+  motor_aobserver_smo(&ob->o, &in->state->iab, &in->state->vab,
                       &ob->cfg.phy, in->dir, in->vel);
 
   /* Copy data */
 
   out->type  = FOC_ANGLE_TYPE_ELE;
-  out->angle = ob->data.angle;
+  out->angle = ob->sensor_dir * motor_aobserver_angle_get(&ob->o);
 
   return OK;
 }

--- a/industry/foc/float/foc_ang_osmo.c
+++ b/industry/foc/float/foc_ang_osmo.c
@@ -291,7 +291,7 @@ static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
   /* Update observer */
 
   motor_aobserver_smo(&ob->data, &in->state->iab, &in->state->vab,
-                      &ob->cfg.phy, ob->dir);
+                      &ob->cfg.phy, in->dir, in->vel);
 
   /* Copy data */
 

--- a/industry/foc/float/foc_ang_qenco.c
+++ b/industry/foc/float/foc_ang_qenco.c
@@ -48,7 +48,7 @@ struct foc_qenco_f32_s
   int32_t                    pos;
   int32_t                    offset;
   float                      one_by_posmax;
-  float                      dir;
+  float                      sensor_dir;
   float                      angle;
   struct foc_qenco_cfg_f32_s cfg;
 };
@@ -226,7 +226,7 @@ static int foc_angle_qe_cfg_f32(FAR foc_angle_f32_t *h, FAR void *cfg)
 
   /* Initialize with CW direction */
 
-  qe->dir = DIR_CW;
+  qe->sensor_dir = DIR_CW;
 
   /* Reset offset */
 
@@ -303,7 +303,7 @@ static int foc_angle_qe_dir_f32(FAR foc_angle_f32_t *h, float dir)
 
   /* Configure direction */
 
-  qe->dir = dir;
+  qe->sensor_dir = dir;
 
   return OK;
 }
@@ -346,7 +346,7 @@ static int foc_angle_qe_run_f32(FAR foc_angle_f32_t *h,
 
   /* Get mechanical angle */
 
-  qe->angle = (qe->dir * (qe->pos - qe->offset) *
+  qe->angle = (qe->sensor_dir * (qe->pos - qe->offset) *
                qe->one_by_posmax * MOTOR_ANGLE_M_MAX);
 
   /* Normalize angle */

--- a/industry/foc/float/foc_vel_odiv.c
+++ b/industry/foc/float/foc_vel_odiv.c
@@ -49,7 +49,7 @@ struct foc_div_f32_s
   struct foc_vel_div_f32_cfg_s     cfg;
   struct motor_sobserver_div_f32_s data;
   struct motor_sobserver_f32_s     o;
-  float                            dir;
+  float                            sensor_dir;
 };
 
 /****************************************************************************
@@ -176,7 +176,7 @@ static int foc_velocity_div_cfg_f32(FAR foc_velocity_f32_t *h, FAR void *cfg)
 
   /* Initialize with CW direction */
 
-  div->dir = DIR_CW;
+  div->sensor_dir = DIR_CW;
 
   return ret;
 }
@@ -237,7 +237,7 @@ static int foc_velocity_div_dir_f32(FAR foc_velocity_f32_t *h, float dir)
 
   /* Set direction */
 
-  div->dir = dir;
+  div->sensor_dir = dir;
 
   return OK;
 }
@@ -273,7 +273,7 @@ static int foc_velocity_div_run_f32(FAR foc_velocity_f32_t *h,
 
   /* Copy data */
 
-  out->velocity = div->dir * motor_sobserver_speed_get(&div->o);
+  out->velocity = div->sensor_dir * motor_sobserver_speed_get(&div->o);
 
   return OK;
 }

--- a/industry/foc/float/foc_vel_odiv.c
+++ b/industry/foc/float/foc_vel_odiv.c
@@ -90,6 +90,7 @@ struct foc_velocity_ops_f32_s g_foc_velocity_odiv_f32 =
  * Name: foc_velocity_div_init_f32
  *
  * Description:
+ *   Initialize the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h - pointer to FOC velocity handler
@@ -119,6 +120,7 @@ errout:
  * Name: foc_velocity_div_deinit_f32
  *
  * Description:
+ *   De-initialize the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h - pointer to FOC velocity handler
@@ -141,6 +143,7 @@ static void foc_velocity_div_deinit_f32(FAR foc_velocity_f32_t *h)
  * Name: foc_velocity_div_cfg_f32
  *
  * Description:
+ *   Configure the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -185,6 +188,7 @@ static int foc_velocity_div_cfg_f32(FAR foc_velocity_f32_t *h, FAR void *cfg)
  * Name: foc_velocity_div_zero_f32
  *
  * Description:
+ *   Zero the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -217,6 +221,7 @@ static int foc_velocity_div_zero_f32(FAR foc_velocity_f32_t *h)
  * Name: foc_velocity_div_dir_f32
  *
  * Description:
+ *   Set the DIV velocity observer direction (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -246,6 +251,7 @@ static int foc_velocity_div_dir_f32(FAR foc_velocity_f32_t *h, float dir)
  * Name: foc_velocity_div_run_f32
  *
  * Description:
+ *   Process the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler

--- a/industry/foc/float/foc_vel_opll.c
+++ b/industry/foc/float/foc_vel_opll.c
@@ -49,7 +49,7 @@ struct foc_pll_f32_s
   struct foc_vel_pll_f32_cfg_s     cfg;
   struct motor_sobserver_pll_f32_s data;
   struct motor_sobserver_f32_s     o;
-  float                            dir;
+  float                            sensor_dir;
 };
 
 /****************************************************************************
@@ -175,7 +175,7 @@ static int foc_velocity_pll_cfg_f32(FAR foc_velocity_f32_t *h, FAR void *cfg)
 
   /* Initialize with CW direction */
 
-  pll->dir = DIR_CW;
+  pll->sensor_dir = DIR_CW;
 
   return ret;
 }
@@ -235,7 +235,7 @@ static int foc_velocity_pll_dir_f32(FAR foc_velocity_f32_t *h, float dir)
 
   /* Set direction */
 
-  pll->dir = dir;
+  pll->sensor_dir = dir;
 
   return OK;
 }
@@ -271,7 +271,7 @@ static int foc_velocity_pll_run_f32(FAR foc_velocity_f32_t *h,
 
   /* Copy data */
 
-  out->velocity = pll->dir * motor_sobserver_speed_get(&pll->o);
+  out->velocity = pll->sensor_dir * motor_sobserver_speed_get(&pll->o);
 
   return OK;
 }

--- a/industry/foc/float/foc_vel_opll.c
+++ b/industry/foc/float/foc_vel_opll.c
@@ -90,6 +90,7 @@ struct foc_velocity_ops_f32_s g_foc_velocity_opll_f32 =
  * Name: foc_velocity_pll_init_f32
  *
  * Description:
+ *   Initialize the PLL velocity observer (float32)
  *
  * Input Parameter:
  *   h - pointer to FOC velocity handler
@@ -119,6 +120,7 @@ errout:
  * Name: foc_velocity_pll_deinit_f32
  *
  * Description:
+ *   De-initialize the PLL velocity observer (float32)
  *
  * Input Parameter:
  *   h - pointer to FOC velocity handler
@@ -141,6 +143,7 @@ static void foc_velocity_pll_deinit_f32(FAR foc_velocity_f32_t *h)
  * Name: foc_velocity_pll_cfg_f32
  *
  * Description:
+ *   Configure the PLL velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -184,6 +187,7 @@ static int foc_velocity_pll_cfg_f32(FAR foc_velocity_f32_t *h, FAR void *cfg)
  * Name: foc_velocity_pll_zero_f32
  *
  * Description:
+ *   Zero the DIV velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -215,6 +219,7 @@ static int foc_velocity_pll_zero_f32(FAR foc_velocity_f32_t *h)
  * Name: foc_velocity_pll_dir_f32
  *
  * Description:
+ *   Set the PLL velocity observer direction (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler
@@ -244,6 +249,7 @@ static int foc_velocity_pll_dir_f32(FAR foc_velocity_f32_t *h, float dir)
  * Name: foc_velocity_pll_run_f32
  *
  * Description:
+ *   Process the PLL velocity observer (float32)
  *
  * Input Parameter:
  *   h   - pointer to FOC velocity handler


### PR DESCRIPTION
## Summary

- industry/foc: rename dir to sensor_dir to be clear that it relates to the direction of the sensor, no movement direction
- industry/foc: fix compilation for smo
- industry/foc: update comments
- industry/foc: remove choice option for angle observers
- industry/foc: refactor and fixes for angle observers

## Impact

## Testing
sim/foc
