### PR TITLE
interpreters/duktape: Remove v from tar command

### DIFF
--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -54,7 +54,7 @@ $(DUKTAPE_TARBALL):
 
 $(DUKTAPE_UNPACK): $(DUKTAPE_TARBALL)
 	$(Q) echo "Unpacking $(DUKTAPE_TARBALL) to $(DUKTAPE_UNPACK)"
-	$(Q) tar xvfJ $(DUKTAPE_TARBALL)
+	$(Q) tar xfJ $(DUKTAPE_TARBALL)
 	$(Q) mv duktape-$(DUKTAPE_VERSION) $(DUKTAPE_UNPACK)
 	$(Q) echo "Patching $(DUKTAPE_UNPACK)"
 	$(Q) patch -p0 < duk_cmdline.patch


### PR DESCRIPTION
## Summary
to avoid the verbose unzip message

## Impact
Minor

## Testing
Pass CI
