### PR TITLE
import: Make.defs: Do not link thumb-based libraries for BUILD_KERNEL

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -66,6 +66,10 @@ LDLIBPATH = $(addprefix -L,$(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs))
 # Link with user libraries
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+ifeq ($(CONFIG_ARCH_ARMV7A),y)
+  # Clear ARCHCPUFLAGS not to link thumb-based libraries to avoid a crash
+  ARCHCPUFLAGS =
+endif
   LDLIBS = -lapps -lxx -lmm -lc -lproxies
 ifneq ($(CONFIG_LIBM),y)
   LIBM = ${shell "$(CC)" $(ARCHCPUFLAGS) --print-file-name=libm.a}


### PR DESCRIPTION
## Summary

- I noticed that the current BUILD_KERNEL for armv7-a sometimes
  does not work correctly with thumb-based libraries.
- This is a workaround to avoid such a crash.

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)

