### PR TITLE
nshlib: add memory dump cmd[ps && memdump]

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -475,6 +475,12 @@ config NSH_DISABLE_PS
 	default y if DEFAULT_SMALL || !FS_PROCFS || FS_PROCFS_EXCLUDE_PROCESS
 	default n if !DEFAULT_SMALL && FS_PROCFS && !FS_PROCFS_EXCLUDE_PROCESS
 
+config NSH_DISABLE_PSHEAPUSAGE
+	bool "Disable ps heap usage"
+	depends on DEBUG_MM && !NSH_DISABLE_PS
+	default y if DEFAULT_SMALL
+	default n if !DEFAULT_SMALL
+
 config NSH_DISABLE_PSSTACKUSAGE
 	bool "Disable ps stack usage"
 	depends on STACK_COLORATION && !NSH_DISABLE_PS

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -565,9 +565,15 @@
 #  define CONFIG_NSH_DISABLE_FREE 1
 #endif
 
+#if !defined(CONFIG_FS_PROCFS) || defined(CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP)
+#  undef  CONFIG_NSH_DISABLE_MEMDUMP
+#  define CONFIG_NSH_DISABLE_MEMDUMP 1
+#endif
+
 /* Suppress unused file utilities */
 
 #define NSH_HAVE_CATFILE          1
+#define NSH_HAVE_WRITEFILE        1
 #define NSH_HAVE_READFILE         1
 #define NSH_HAVE_FOREACH_DIRENTRY 1
 #define NSH_HAVE_TRIMDIR          1
@@ -940,6 +946,9 @@ void nsh_usbtrace(void);
 #ifndef CONFIG_NSH_DISABLE_FREE
   int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 #endif
+#ifndef CONFIG_NSH_DISABLE_MEMDUMP
+  int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+#endif
 #ifndef CONFIG_NSH_DISABLE_TIME
   int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 #endif
@@ -1292,6 +1301,30 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 #ifdef NSH_HAVE_READFILE
 int nsh_readfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                  FAR const char *filepath, FAR char *buffer, size_t buflen);
+#endif
+
+/****************************************************************************
+ * Name: nsh_writefile
+ *
+ * Description:
+ *   Dump the contents of a file to the current NSH terminal.
+ *
+ * Input Paratemets:
+ *   vtbl     - session vtbl
+ *   cmd      - NSH command name to use in error reporting
+ *   buffer   - The pointer of writting buffer
+ *   len      - The length of writting buffer
+ *   filepath - The full path to the file to be dumped
+ *
+ * Returned Value:
+ *   Zero (OK) on success; -1 (ERROR) on failure.
+ *
+ ****************************************************************************/
+
+#ifdef NSH_HAVE_WRITEFILE
+int nsh_writefile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
+                  FAR const char *buffer, size_t len,
+                  FAR const char *filepath);
 #endif
 
 /****************************************************************************

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -216,6 +216,12 @@ static const struct cmdmap_s g_cmdmap[] =
   { "free",     cmd_free,     1, 1, NULL },
 #endif
 
+#ifdef CONFIG_DEBUG_MM
+# ifndef CONFIG_NSH_DISABLE_MEMDUMP
+  { "memdump",  cmd_memdump,  1, 3, "[pid/used/free]" },
+# endif
+#endif
+
 #ifdef CONFIG_NET_UDP
 # ifndef CONFIG_NSH_DISABLE_GET
   { "get",      cmd_get,      4, 7,

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -27,11 +27,11 @@
 #include "nsh.h"
 #include "nsh_console.h"
 
-#if !defined(CONFIG_NSH_DISABLE_FREE) && defined(NSH_HAVE_CATFILE)
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+#if !defined(CONFIG_NSH_DISABLE_FREE) && defined(NSH_HAVE_CATFILE)
 
 /****************************************************************************
  * Name: cmd_free
@@ -43,3 +43,24 @@ int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 }
 
 #endif /* !CONFIG_NSH_DISABLE_FREE && NSH_HAVE_CATFILE */
+
+#if !defined(CONFIG_NSH_DISABLE_MEMDUMP) && defined(NSH_HAVE_WRITEFILE)
+
+/****************************************************************************
+ * Name: cmd_memdump
+ ****************************************************************************/
+
+int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+{
+  FAR const char *arg = "used";
+
+  if (argc > 1)
+    {
+      arg = argv[1];
+    }
+
+  return nsh_writefile(vtbl, argv[0], arg, strlen(arg),
+                       CONFIG_NSH_PROC_MOUNTPOINT "/memdump");
+}
+
+#endif /* !CONFIG_NSH_DISABLE_MEMDUMP && NSH_HAVE_WRITEFILE */


### PR DESCRIPTION
## Summary
nshlib: add memory dump cmd[ps && memdump]. This patch is related to https://github.com/apache/incubator-nuttx/pull/5585.

## Impact
add memory dump function
## Testing
daily test
