### PR TITLE
BUILD_KERNEL: Include CPP libraries only if configured to do so

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -66,7 +66,10 @@ LDLIBPATH = $(addprefix -L,$(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs))
 # Link with user libraries
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
-  LDLIBS = -lapps -lxx -lmm -lc -lproxies
+  LDLIBS = -lapps -lmm -lc -lproxies
+  ifeq ($(CONFIG_HAVE_CXX),y)
+    LDLIBS += -lxx
+  endif
 ifneq ($(CONFIG_LIBM),y)
   LIBM = ${shell "$(CC)" $(ARCHCPUFLAGS) --print-file-name=libm.a}
 ifneq ($(LIBM),".")


### PR DESCRIPTION
Otherwise build without HAVE_CXX flag fails

## Summary
Don't add CPP library if it is not configured
## Impact
CONFIG_BUILD_KERNEL only
## Testing
Build succeeds without HAVE_CXX flag
