### PR TITLE
cmd_dd:if read nbyte less than bs,must write nbyte

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -102,7 +102,7 @@ static int dd_write(FAR struct dd_s *dd)
   written = 0;
   do
     {
-      nbytes = write(dd->outfd, buffer, dd->sectsize - written);
+      nbytes = write(dd->outfd, buffer, dd->nbytes - written);
       if (nbytes < 0)
         {
           FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
@@ -114,7 +114,7 @@ static int dd_write(FAR struct dd_s *dd)
       written += nbytes;
       buffer  += nbytes;
     }
-  while (written < dd->sectsize);
+  while (written < dd->nbytes);
 
   return OK;
 }


### PR DESCRIPTION
if a file size is 10
use dd if=a of=b bs = 8
b file size will 16, is a error
## Impact
use cmd dd app
## Testing

