### PR TITLE
mlearning: cmsis: enable FPU support

### DIFF
--- a/mlearning/cmsis/libcmsisdsp/Makefile
+++ b/mlearning/cmsis/libcmsisdsp/Makefile
@@ -26,6 +26,10 @@ endif
 ifeq ($(CONFIG_CMSIS_DSP_ARM_MATH_ROUNDING),y)
 CFLAGS += -DARM_MATH_ROUNDING
 endif
+ifeq ($(CONFIG_ARCH_FPU),y)
+CFLAGS += -D__FPU_PRESENT=1U
+CXXFLAGS += -D__FPU_PRESENT=1U
+endif
 
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/cmsis/CMSIS_5/CMSIS/DSP/PrivateInclude/}
 CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/cmsis/CMSIS_5/CMSIS/DSP/PrivateInclude/}

--- a/mlearning/cmsis/libcmsisnn/Makefile
+++ b/mlearning/cmsis/libcmsisnn/Makefile
@@ -22,6 +22,11 @@ include $(APPDIR)/Make.defs
 
 CMSIS5_NN := ../CMSIS_5/CMSIS/NN/Source
 
+ifeq ($(CONFIG_ARCH_FPU),y)
+CFLAGS += -D__FPU_PRESENT=1U
+CXXFLAGS += -D__FPU_PRESENT=1U
+endif
+
 CSRCS += $(CMSIS5_NN)/ActivationFunctions/arm_nn_activations_q15.c
 CSRCS += $(CMSIS5_NN)/ActivationFunctions/arm_relu6_s8.c
 CSRCS += $(CMSIS5_NN)/ActivationFunctions/arm_relu_q15.c


### PR DESCRIPTION
## Summary
In case of HW with FPU we can benefit from the FPU support.

# Impact
CMSIS

## Testing
Spresense
