### PR TITLE
netutils/webserver: Fix the compiler error when -no-builtin is removed

### DIFF
--- a/netutils/webserver/httpd.c
+++ b/netutils/webserver/httpd.c
@@ -668,8 +668,8 @@ static inline int httpd_parse(struct httpd_state *pstate)
 #ifdef CONFIG_NETUTILS_HTTPD_CLASSIC
   if (0 == strcmp(pstate->ht_filename, "/"))
     {
-      strncpy(pstate->ht_filename, "/" CONFIG_NETUTILS_HTTPD_INDEX,
-              strlen("/" CONFIG_NETUTILS_HTTPD_INDEX));
+      strlcpy(pstate->ht_filename, "/" CONFIG_NETUTILS_HTTPD_INDEX,
+              sizeof(pstate->ht_filename));
     }
 #endif
 


### PR DESCRIPTION
## Summary
Report at https://github.com/apache/incubator-nuttx/runs/5396269209?check_suite_focus=true:
```
Error: httpd.c:671:7: error: 'strncpy' output truncated before terminating nul copying 12 bytes from a string of the same length [-Werror=stringop-truncation]
  671 |       strncpy(pstate->ht_filename, "/" CONFIG_NETUTILS_HTTPD_INDEX,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  672 |               strlen("/" CONFIG_NETUTILS_HTTPD_INDEX));
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Impact
Simple fix

## Testing
Pass CI
