### PR TITLE
Fix readline_common.c:277:19: error: 'strncpy' destination unchanged after copying no bytes

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -274,7 +274,7 @@ static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
 
               if (tmp_name[0] == '\0')
                 {
-                  strncpy(tmp_name, name, sizeof(tmp_name) - 1);
+                  strlcpy(tmp_name, name, sizeof(tmp_name));
                 }
 
               RL_PUTC(vtbl, ' ');
@@ -309,7 +309,7 @@ static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
 
               if (tmp_name[0] == '\0')
                 {
-                  strncpy(tmp_name, name, sizeof(tmp_name) - 1);
+                  strlcpy(tmp_name, name, sizeof(tmp_name));
                 }
 
               RL_PUTC(vtbl, ' ');


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/runs/5431571859?check_suite_focus=true

## Impact
Fix warning

## Testing
Pass CI
