### PR TITLE
Fix error: 'memset' forming offset [16, 27] is out of the bounds [0, 16] of object 'inaddr' with type 'union <anonymous>'

### DIFF
--- a/nshlib/nsh_routecmds.c
+++ b/nshlib/nsh_routecmds.c
@@ -327,7 +327,7 @@ int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
            * /128 -> ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
            */
 
-          memset(&inaddr.ipv6, 0, sizeof(struct sockaddr_in6));
+          memset(&inaddr.ipv6, 0, sizeof(inaddr.ipv6));
           for (i = 0; i < 8 && shift >= 16; i++, shift -= 16)
             {
               inaddr.ipv6.s6_addr16[i] = 0xffff;


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/runs/5431760938?check_suite_focus=true

## Impact
Fix the warning

## Testing
Pass CI
