### PR TITLE
Fix compiler warning

### DIFF
--- a/examples/chrono/chrono_main.c
+++ b/examples/chrono/chrono_main.c
@@ -298,7 +298,7 @@ static void slcd_puts(FAR struct lib_outstream_s *outstream,
 int main(int argc, FAR char *argv[])
 {
   FAR struct slcd_chrono_s *priv = &g_slcd;
-  FAR char str[8] = "00:00.0";
+  FAR char str[16] = "00:00.0";
   int fd;
   int ret;
   long sec;
@@ -393,7 +393,7 @@ int main(int argc, FAR char *argv[])
         {
           /* Copy the initial value */
 
-          strncpy(str, "00:00.0", 7);
+          strlcpy(str, "00:00.0", sizeof(str));
 
           /* Print the initial reset value */
 
@@ -431,8 +431,8 @@ int main(int argc, FAR char *argv[])
 
           sec = sec % 60;
 
-          sprintf(str, "%02ld:%02ld:%01ld", min, sec,
-                  (priv->ts_end.tv_nsec / 100000000));
+          snprintf(str, sizeof(str), "%02ld:%02ld:%01ld",
+                   min, sec, (priv->ts_end.tv_nsec / 100000000));
 
           /* Print it into LCD */
 

--- a/nshlib/nsh_routecmds.c
+++ b/nshlib/nsh_routecmds.c
@@ -608,7 +608,7 @@ int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
            * /128 -> ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
            */
 
-          memset(&inaddr.ipv6, 0, sizeof(struct sockaddr_in6));
+          memset(&inaddr.ipv6, 0, sizeof(inaddr.ipv6));
           for (i = 0; i < 8 && shift >= 16; i++, shift -= 16)
             {
               inaddr.ipv6.s6_addr16[i] = 0xffff;


### PR DESCRIPTION
## Summary
```
chrono_main.c: In function 'chrono_main':
Error: chrono_main.c:396:11: error: 'strncpy' output truncated before terminating nul copying 7 bytes from a string of the same length [-Werror=stringop-truncation]
  396 |           strncpy(str, "00:00.0", 7);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~
Error: chrono_main.c:434:25: error: '%02ld' directive writing between 2 and 9 bytes into a region of size 8 [-Werror=format-overflow=]
  434 |           sprintf(str, "%02ld:%02ld:%01ld", min, sec,
      |                         ^~~~~
chrono_main.c:434:24: note: directive argument in the range [-35791394, 35791394]
  434 |           sprintf(str, "%02ld:%02ld:%01ld", min, sec,
      |                        ^~~~~~~~~~~~~~~~~~~
chrono_main.c:434:24: note: directive argument in the range [-59, 59]
chrono_main.c:434:24: note: directive argument in the range [-21, 21]
chrono_main.c:434:11: note: 'sprintf' output between 8 and 18 bytes into a destination of size 8
  434 |           sprintf(str, "%02ld:%02ld:%01ld", min, sec,
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  435 |                   (priv->ts_end.tv_nsec / 100000000));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

nsh_routecmds.c: In function 'cmd_delroute':
Error: nsh_routecmds.c:611:11: error: 'memset' forming offset [16, 27] is out of the bounds [0, 16] of object 'inaddr' with type 'union <anonymous>' [-Werror=array-bounds]
  611 |           memset(&inaddr.ipv6, 0, sizeof(struct sockaddr_in6));
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nsh_routecmds.c:491:5: note: 'inaddr' declared here
  491 |   } inaddr;
      |     ^~~~~~
```

## Impact
Minor

## Testing
Pass CI
