### PR TITLE
examples/chrono: Fix the compiler warning when -fno-builtin isn't set

### DIFF
--- a/examples/chrono/chrono_main.c
+++ b/examples/chrono/chrono_main.c
@@ -298,7 +298,7 @@ static void slcd_puts(FAR struct lib_outstream_s *outstream,
 int main(int argc, FAR char *argv[])
 {
   FAR struct slcd_chrono_s *priv = &g_slcd;
-  FAR char str[16] = "00:00.0";
+  FAR char str[32] = "00:00.0";
   int fd;
   int ret;
   long sec;


### PR DESCRIPTION
## Summary
```
Error: chrono_main.c:434:51: error: '%01ld' directive output may be truncated writing between 1 and 3 bytes into a region of size between 2 and 10 [-Werror=format-truncation=]
  434 |           snprintf(str, sizeof(str), "%02ld:%02ld:%01ld",
      |                                                   ^~~~~
chrono_main.c:434:38: note: directive argument in the range [-21, 21]
  434 |           snprintf(str, sizeof(str), "%02ld:%02ld:%01ld",
      |                                      ^~~~~~~~~~~~~~~~~~~
chrono_main.c:434:11: note: 'snprintf' output between 8 and 18 bytes into a destination of size 16
  434 |           snprintf(str, sizeof(str), "%02ld:%02ld:%01ld",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  435 |                    min, sec, (priv->ts_end.tv_nsec / 100000000));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Impact
Minor

## Testing
Pass CI
