### PR TITLE
webclient: Remove a duplicated "Connection:" header

### DIFF
--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -245,7 +245,6 @@ static const char g_httplocation[]         = "location: ";
 static const char g_httptransferencoding[] = "transfer-encoding: ";
 
 static const char g_httpuseragentfields[] =
-  "Connection: close\r\n"
   "User-Agent: "
   CONFIG_NSH_WGET_USERAGENT
   "\r\n\r\n";


### PR DESCRIPTION
## Summary

When making the following change, I haven't noticed that
g_httpuseragentfields contains a "Connection" header.

```
commit 092ce8144445a9b287554e59e3150bab3d67bedb
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Mon Mar 7 09:30:23 2022 +0900

    webclient: Always use "connection: close" for HTTP 1.1 for now

    * This matches the HTTP 1.0 behavior.

    * Persistent connection doesn't make much sense with the current API.
```

It seems that some servers are not happy with the duplicated header
and ignore them. (and do the default keep-alive for HTTP 1.1)
eg. Azure Blob (global)

## Impact

## Testing
tested against Azure Blob.
