### PR TITLE
feature: wapi add encode parse when scan

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -76,6 +76,10 @@
 #  define wapi_save_config(ifname, confname, conf) 0
 #endif
 
+/* Not a open network when IEEE80211_CAP_PRIVACY set */
+
+#define IEEE80211_CAP_PRIVACY	0x0010
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -193,6 +197,8 @@ struct wapi_scan_info_s
   int bitrate;
   int has_rssi;
   int rssi;
+  int has_encode;
+  int encode;
 };
 
 /* Linked list container for routing table rows. */

--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -388,6 +388,7 @@ static int iperf_run_tcp_server(void)
           iperf_start_report();
 
           t.tv_sec = IPERF_SOCKET_RX_TIMEOUT;
+          t.tv_usec = 0;
           setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &t, sizeof(t));
         }
 
@@ -476,6 +477,7 @@ static int iperf_run_udp_server(void)
   printf("want recv=%d", want_recv);
 
   t.tv_sec = IPERF_SOCKET_RX_TIMEOUT;
+  t.tv_usec = 0;
   setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &t, sizeof(t));
 
   while (!s_iperf_ctrl.finish)

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg.h
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg.h
@@ -27,6 +27,11 @@
 
 #include <nuttx/net/usrsock.h>
 
+#ifdef CONFIG_NETDEV_WIRELESS_IOCTL
+#  include <nuttx/wireless/wireless.h>
+#  include <metal/cache.h>
+#endif
+
 /****************************************************************************
  * Pre-processor definitions
  ****************************************************************************/
@@ -34,6 +39,16 @@
 #define USRSOCK_RPMSG_EPT_NAME      "rpmsg-usrsock"
 
 #define USRSOCK_RPMSG_DNS_EVENT      127
+
+#ifdef CONFIG_NETDEV_WIRELESS_IOCTL
+#  define WL_IS80211POINTERCMD(cmd)  ((cmd) == SIOCGIWSCAN || \
+                                      (cmd) == SIOCSIWCOUNTRY || \
+                                      (cmd) == SIOCGIWRANGE || \
+                                      (cmd) == SIOCSIWENCODEEXT || \
+                                      (cmd) == SIOCGIWENCODEEXT || \
+                                      (cmd) == SIOCGIWESSID || \
+                                      (cmd) == SIOCSIWESSID)
+#endif
 
 /****************************************************************************
  * Public Types

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -694,6 +694,7 @@ static int usrsock_rpmsg_accept_handler(struct rpmsg_endpoint *ept,
       pthread_mutex_lock(&priv->mutex);
       priv->pfds[i].ptr = &priv->socks[i];
       priv->pfds[i].events = POLLIN;
+      priv->pfds[req->usockid].events |= POLLIN;
       usrsock_rpmsg_notify_poll(priv);
       pthread_mutex_unlock(&priv->mutex);
       usrsock_rpmsg_send_event(ept, i, USRSOCK_EVENT_SENDTO_READY);
@@ -716,9 +717,26 @@ static int usrsock_rpmsg_ioctl_handler(struct rpmsg_endpoint *ept,
   if (req->usockid >= 0 &&
       req->usockid < CONFIG_NETUTILS_USRSOCK_NSOCK_DESCRIPTORS)
     {
+#ifdef CONFIG_NETDEV_WIRELESS_IOCTL
+      FAR struct iwreq *wlreq = (FAR struct iwreq *)(req + 1);
+      if (WL_IS80211POINTERCMD(req->cmd))
+        {
+          metal_cache_invalidate(wlreq->u.data.pointer,
+                                 wlreq->u.data.length);
+        }
+#endif
+
       memcpy(ack + 1, req + 1, req->arglen);
       ret = psock_ioctl(&priv->socks[req->usockid],
               req->cmd, (unsigned long)(ack + 1));
+
+#ifdef CONFIG_NETDEV_WIRELESS_IOCTL
+      if (WL_IS80211POINTERCMD(req->cmd))
+        {
+          metal_cache_flush(wlreq->u.data.pointer,
+                            wlreq->u.data.length);
+        }
+#endif
     }
 
   return usrsock_rpmsg_send_data_ack(ept,

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -708,14 +708,30 @@ static int wapi_scan_results_cmd(int sock, int argc, FAR char **argv)
 
   /* Print found aps */
 
-  printf("bssid / frequency / signal level / ssid\n");
-  for (info = list.head.scan; info; info = info->next)
+  info = list.head.scan;
+  if (info && info->has_encode == 1)
     {
-      printf("%02x:%02x:%02x:%02x:%02x:%02x\t%g\t%d\t%s\n",
-             info->ap.ether_addr_octet[0], info->ap.ether_addr_octet[1],
-             info->ap.ether_addr_octet[2], info->ap.ether_addr_octet[3],
-             info->ap.ether_addr_octet[4],  info->ap.ether_addr_octet[5],
-             info->freq, info->rssi, info->essid);
+      printf("bssid / frequency / signal level / encode / ssid\n");
+      for (; info; info = info->next)
+        {
+          printf("%02x:%02x:%02x:%02x:%02x:%02x\t%g\t%d\t%d\t%s\n",
+                info->ap.ether_addr_octet[0], info->ap.ether_addr_octet[1],
+                info->ap.ether_addr_octet[2], info->ap.ether_addr_octet[3],
+                info->ap.ether_addr_octet[4],  info->ap.ether_addr_octet[5],
+                info->freq, info->rssi, info->encode, info->essid);
+        }
+    }
+  else
+    {
+      printf("bssid / frequency / signal level / ssid\n");
+      for (; info; info = info->next)
+        {
+          printf("%02x:%02x:%02x:%02x:%02x:%02x\t%g\t%d\t%s\n",
+                info->ap.ether_addr_octet[0], info->ap.ether_addr_octet[1],
+                info->ap.ether_addr_octet[2], info->ap.ether_addr_octet[3],
+                info->ap.ether_addr_octet[4],  info->ap.ether_addr_octet[5],
+                info->freq, info->rssi, info->essid);
+        }
     }
 
   /* Free ap list */

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -263,6 +263,7 @@ static int wapi_event_stream_extract(FAR struct wapi_event_stream_s *stream,
   switch (iwe_stream->cmd)
     {
       case SIOCGIWESSID:
+      case SIOCGIWENCODE:
       case IWEVGENIE:
         iwe->cmd = iwe_stream->cmd;
         iwe->len = offsetof(struct iw_event, u) + sizeof(struct iw_point);
@@ -436,6 +437,14 @@ static int wapi_scan_event(FAR struct iw_event *event,
               }
           }
 
+        break;
+      }
+
+    case SIOCGIWENCODE:
+      {
+        info->has_encode = 1;
+        if (!(event->u.data.flags & IW_ENCODE_DISABLED))
+            info->encode |= IEEE80211_CAP_PRIVACY;
         break;
       }
     }


### PR DESCRIPTION
wapi add encode parse when scan
fix: ap socket can not accept twice
rpmsg: pointer of netdev ioctl support cross-core access via clean dcache
fix: iperf can not exit when stop

Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>
Change-Id: Ic9959a7426091ee2f35b68cb41c14a9e343468ac

## Summary

## Impact

## Testing

