### PR TITLE
Modifying the ping command

### DIFF
--- a/include/netutils/icmp_ping.h
+++ b/include/netutils/icmp_ping.h
@@ -79,7 +79,7 @@ struct ping_info_s
 struct ping_result_s
 {
   int code;                 /* Notice code ICMP_I/E/W_XXX */
-  int extra;                /* Extra information for code */
+  long extra;               /* Extra information for code */
   struct in_addr dest;      /* Target address to ping */
   uint16_t nrequests;       /* Number of ICMP ECHO requests sent */
   uint16_t nreplies;        /* Number of matching ICMP ECHO replies received */

--- a/include/netutils/icmpv6_ping.h
+++ b/include/netutils/icmpv6_ping.h
@@ -79,7 +79,7 @@ struct ping6_info_s
 struct ping6_result_s
 {
   int code;                 /* Notice code ICMPv6_I/E/W_XXX */
-  int extra;                /* Extra information for code */
+  long extra;               /* Extra information for code */
   struct in6_addr dest;     /* Target address to ping */
   uint16_t nrequests;       /* Number of ICMP ECHO requests sent */
   uint16_t nreplies;        /* Number of matching ICMP ECHO replies received */

--- a/system/ping/ping.c
+++ b/system/ping/ping.c
@@ -23,12 +23,16 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/clock.h>
 
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <nuttx/lib/math.h>
+#include <limits.h>
+#include <fixedmath.h>
 
 #include "netutils/icmp_ping.h"
 
@@ -48,6 +52,10 @@
 struct ping_priv_s
 {
   int code;                      /* Notice code ICMP_I/E/W_XXX */
+  long tmin;                     /* Minimum round trip time */
+  long tmax;                     /* Maximum round trip time */
+  long long tsum;                /* Sum of all times, for doing average */
+  long long tsum2;               /* Sum2 is the sum of the squares of sum ,for doing mean deviation */
 };
 
 /****************************************************************************
@@ -118,7 +126,7 @@ static void ping_result(FAR const struct ping_result_s *result)
         break;
 
       case ICMP_E_SOCKET:
-        fprintf(stderr, "ERROR: socket() failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: socket() failed: %ld\n", result->extra);
         break;
 
       case ICMP_I_BEGIN:
@@ -131,21 +139,21 @@ static void ping_result(FAR const struct ping_result_s *result)
         break;
 
       case ICMP_E_SENDTO:
-        fprintf(stderr, "ERROR: sendto failed at seqno %u: %d\n",
+        fprintf(stderr, "ERROR: sendto failed at seqno %u: %ld\n",
                 result->seqno, result->extra);
         break;
 
       case ICMP_E_SENDSMALL:
-        fprintf(stderr, "ERROR: sendto returned %d, expected %u\n",
+        fprintf(stderr, "ERROR: sendto returned %ld, expected %u\n",
                 result->extra, result->outsize);
         break;
 
       case ICMP_E_POLL:
-        fprintf(stderr, "ERROR: poll failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: poll failed: %ld\n", result->extra);
         break;
 
       case ICMP_W_TIMEOUT:
-        printf("No response from %u.%u.%u.%u: icmp_seq=%u time=%d ms\n",
+        printf("No response from %u.%u.%u.%u: icmp_seq=%u time=%ld ms\n",
                (unsigned int)(result->dest.s_addr) & 0xff,
                (unsigned int)(result->dest.s_addr >> 8) & 0xff,
                (unsigned int)(result->dest.s_addr >> 16) & 0xff,
@@ -154,23 +162,23 @@ static void ping_result(FAR const struct ping_result_s *result)
         break;
 
       case ICMP_E_RECVFROM:
-        fprintf(stderr, "ERROR: recvfrom failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: recvfrom failed: %ld\n", result->extra);
         break;
 
       case ICMP_E_RECVSMALL:
-        fprintf(stderr, "ERROR: short ICMP packet: %d\n", result->extra);
+        fprintf(stderr, "ERROR: short ICMP packet: %ld\n", result->extra);
         break;
 
       case ICMP_W_IDDIFF:
         fprintf(stderr,
-                "WARNING: Ignoring ICMP reply with ID %d.  "
+                "WARNING: Ignoring ICMP reply with ID %ld.  "
                 "Expected %u\n",
                 result->extra, result->id);
         break;
 
       case ICMP_W_SEQNOBIG:
         fprintf(stderr,
-                "WARNING: Ignoring ICMP reply to sequence %d.  "
+                "WARNING: Ignoring ICMP reply to sequence %ld.  "
                 "Expected <= %u\n",
                 result->extra, result->seqno);
         break;
@@ -180,19 +188,32 @@ static void ping_result(FAR const struct ping_result_s *result)
         break;
 
       case ICMP_I_ROUNDTRIP:
-        printf("%u bytes from %u.%u.%u.%u: icmp_seq=%u time=%d ms\n",
+        priv->tsum += result->extra;
+        priv->tsum2 += (long long)result->extra * result->extra;
+        if (result->extra < priv->tmin)
+          {
+            priv->tmin = result->extra;
+          }
+
+        if (result->extra > priv->tmax)
+          {
+            priv->tmax = result->extra;
+          }
+
+        printf("%u bytes from %u.%u.%u.%u: icmp_seq=%u time=%ld.%ld ms\n",
                result->info->datalen,
                (unsigned int)(result->dest.s_addr) & 0xff,
                (unsigned int)(result->dest.s_addr >> 8) & 0xff,
                (unsigned int)(result->dest.s_addr >> 16) & 0xff,
                (unsigned int)(result->dest.s_addr >> 24) & 0xff,
-               result->seqno, result->extra);
+               result->seqno, result->extra / USEC_PER_MSEC,
+               result->extra % USEC_PER_MSEC / MSEC_PER_DSEC);
         break;
 
       case ICMP_W_RECVBIG:
         fprintf(stderr,
                 "WARNING: Ignoring ICMP reply with different payload "
-                "size: %d vs %u\n",
+                "size: %ld vs %u\n",
                 result->extra, result->outsize);
         break;
 
@@ -201,7 +222,7 @@ static void ping_result(FAR const struct ping_result_s *result)
         break;
 
       case ICMP_W_TYPE:
-        fprintf(stderr, "WARNING: ICMP packet with unknown type: %d\n",
+        fprintf(stderr, "WARNING: ICMP packet with unknown type: %ld\n",
                 result->extra);
         break;
 
@@ -217,8 +238,25 @@ static void ping_result(FAR const struct ping_result_s *result)
                    result->nrequests;
 
             printf("%u packets transmitted, %u received, %u%% packet loss, "
-                   "time %d ms\n",
-                   result->nrequests, result->nreplies, tmp, result->extra);
+                   "time %ld ms\n",
+                   result->nrequests, result->nreplies, tmp,
+                   result->extra / USEC_PER_MSEC);
+            if (result->nreplies > 0)
+              {
+                long avg = priv->tsum / result->nreplies;
+                long long tempnum = priv->tsum2 / result->nreplies -
+                                    (long long)avg * avg;
+                long tmdev = ub16toi(ub32sqrtub16(uitoub32(tempnum)));
+
+                printf("rtt min/avg/max/mdev = %ld.%03ld/%ld.%03ld/"
+                       "%ld.%03ld/%ld.%03ld ms\n",
+                       priv->tmin / USEC_PER_MSEC,
+                       priv->tmin % USEC_PER_MSEC,
+                       avg / USEC_PER_MSEC, avg % USEC_PER_MSEC,
+                       priv->tmax / USEC_PER_MSEC,
+                       priv->tmax % USEC_PER_MSEC,
+                       tmdev / USEC_PER_MSEC, tmdev % USEC_PER_MSEC);
+              }
           }
         break;
     }
@@ -243,6 +281,10 @@ int main(int argc, FAR char *argv[])
   info.callback  = ping_result;
   info.priv      = &priv;
   priv.code      = ICMP_I_OK;
+  priv.tmin      = LONG_MAX;
+  priv.tmax      = 0;
+  priv.tsum      = 0;
+  priv.tsum2     = 0;
 
   /* Parse command line options */
 

--- a/system/ping6/ping6.c
+++ b/system/ping6/ping6.c
@@ -23,12 +23,16 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/clock.h>
 
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <nuttx/lib/math.h>
+#include <limits.h>
+#include <fixedmath.h>
 
 #include <arpa/inet.h>
 
@@ -50,6 +54,10 @@
 struct ping6_priv_s
 {
   int code;                        /* Notice code ICMP_I/E/W_XXX */
+  long tmin;                       /* Minimum round trip time */
+  long tmax;                       /* Maximum round trip time */
+  long long tsum;                  /* Sum of all times, for doing average */
+  long long tsum2;                 /* Sum2 is the sum of the squares of sum ,for doing mean deviation */
 };
 
 /****************************************************************************
@@ -121,7 +129,7 @@ static void ping6_result(FAR const struct ping6_result_s *result)
         break;
 
       case ICMPv6_E_SOCKET:
-        fprintf(stderr, "ERROR: socket() failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: socket() failed: %ld\n", result->extra);
         break;
 
       case ICMPv6_I_BEGIN:
@@ -132,44 +140,44 @@ static void ping6_result(FAR const struct ping6_result_s *result)
         break;
 
       case ICMPv6_E_SENDTO:
-        fprintf(stderr, "ERROR: sendto failed at seqno %u: %d\n",
+        fprintf(stderr, "ERROR: sendto failed at seqno %u: %ld\n",
                 result->seqno, result->extra);
         break;
 
       case ICMPv6_E_SENDSMALL:
-        fprintf(stderr, "ERROR: sendto returned %d, expected %u\n",
+        fprintf(stderr, "ERROR: sendto returned %ld, expected %u\n",
                 result->extra, result->outsize);
         break;
 
       case ICMPv6_E_POLL:
-        fprintf(stderr, "ERROR: poll failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: poll failed: %ld\n", result->extra);
         break;
 
       case ICMPv6_W_TIMEOUT:
         inet_ntop(AF_INET6, result->dest.s6_addr16, strbuffer,
                   INET6_ADDRSTRLEN);
-        printf("No response from %s: icmp_seq=%u time=%d ms\n",
+        printf("No response from %s: icmp_seq=%u time=%ld ms\n",
                strbuffer, result->seqno, result->extra);
         break;
 
       case ICMPv6_E_RECVFROM:
-        fprintf(stderr, "ERROR: recvfrom failed: %d\n", result->extra);
+        fprintf(stderr, "ERROR: recvfrom failed: %ld\n", result->extra);
         break;
 
       case ICMPv6_E_RECVSMALL:
-        fprintf(stderr, "ERROR: short ICMP packet: %d\n", result->extra);
+        fprintf(stderr, "ERROR: short ICMP packet: %ld\n", result->extra);
         break;
 
       case ICMPv6_W_IDDIFF:
         fprintf(stderr,
-                "WARNING: Ignoring ICMP reply with ID %d.  "
+                "WARNING: Ignoring ICMP reply with ID %ld.  "
                 "Expected %u\n",
                 result->extra, result->id);
         break;
 
       case ICMPv6_W_SEQNOBIG:
         fprintf(stderr,
-                "WARNING: Ignoring ICMP reply to sequence %d.  "
+                "WARNING: Ignoring ICMP reply to sequence %ld.  "
                 "Expected <= %u\n",
                 result->extra, result->seqno);
         break;
@@ -179,17 +187,30 @@ static void ping6_result(FAR const struct ping6_result_s *result)
         break;
 
       case ICMPv6_I_ROUNDTRIP:
+        priv->tsum += result->extra;
+        priv->tsum2 += (long long)result->extra * result->extra;
+        if (result->extra < priv->tmin)
+          {
+            priv->tmin = result->extra;
+          }
+
+        if (result->extra > priv->tmax)
+          {
+            priv->tmax = result->extra;
+          }
+
         inet_ntop(AF_INET6, result->dest.s6_addr16, strbuffer,
                   INET6_ADDRSTRLEN);
-        printf("%u bytes from %s icmp_seq=%u time=%u ms\n",
+        printf("%u bytes from %s icmp_seq=%u time=%ld.%ld ms\n",
                result->info->datalen, strbuffer, result->seqno,
-               result->extra);
+               result->extra / USEC_PER_MSEC,
+               result->extra % USEC_PER_MSEC / MSEC_PER_DSEC);
         break;
 
       case ICMPv6_W_RECVBIG:
         fprintf(stderr,
                 "WARNING: Ignoring ICMP reply with different payload "
-                "size: %d vs %u\n",
+                "size: %ld vs %u\n",
                 result->extra, result->outsize);
         break;
 
@@ -198,7 +219,7 @@ static void ping6_result(FAR const struct ping6_result_s *result)
         break;
 
       case ICMPv6_W_TYPE:
-        fprintf(stderr, "WARNING: ICMP packet with unknown type: %d\n",
+        fprintf(stderr, "WARNING: ICMP packet with unknown type: %ld\n",
                 result->extra);
         break;
 
@@ -213,9 +234,26 @@ static void ping6_result(FAR const struct ping6_result_s *result)
                    (result->nrequests >> 1)) /
                    result->nrequests;
 
-            printf("%u packets transmitted, %u received, "
-                   "%u%% packet loss, time %d ms\n",
-                   result->nrequests, result->nreplies, tmp, result->extra);
+            printf("%u packets transmitted, %u received, %u%% packet loss,"
+                   "time %ld ms\n",
+                   result->nrequests, result->nreplies, tmp,
+                   result->extra / USEC_PER_MSEC);
+            if (result->nreplies > 0)
+              {
+                long avg = priv->tsum / result->nreplies;
+                long long tempnum = priv->tsum2 / result->nreplies -
+                                    (long long)avg * avg;
+                long tmdev = ub16toi(ub32sqrtub16(uitoub32(tempnum)));
+
+                printf("rtt min/avg/max/mdev = %ld.%03ld/%ld.%03ld/"
+                       "%ld.%03ld/%ld.%03ld ms\n",
+                       priv->tmin / USEC_PER_MSEC,
+                       priv->tmin % USEC_PER_MSEC,
+                       avg / USEC_PER_MSEC, avg % USEC_PER_MSEC,
+                       priv->tmax / USEC_PER_MSEC,
+                       priv->tmax % USEC_PER_MSEC,
+                       tmdev / USEC_PER_MSEC, tmdev % USEC_PER_MSEC);
+              }
           }
         break;
     }
@@ -240,6 +278,10 @@ int main(int argc, FAR char *argv[])
   info.callback  = ping6_result;
   info.priv      = &priv;
   priv.code      = ICMPv6_I_OK;
+  priv.tmin      = LONG_MAX;
+  priv.tmax      = 0;
+  priv.tsum      = 0;
+  priv.tsum2     = 0;
 
   /* Parse command line options */
 


### PR DESCRIPTION
## Summary
1、Round trip times in the ping command range from millisecond to subtle
2、Add statistics on RTT related min/avg/Max/mdev in ping program
3、The ping command supports ctrl+c interruption operations

## Impact
The ping and ping6 commands are affected

## Testing
PASSED
