### PR TITLE
cmd_mkdir:support mkdir opthon -p

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -312,7 +312,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifdef NSH_HAVE_DIROPTS
 # ifndef CONFIG_NSH_DISABLE_MKDIR
-  { "mkdir",    cmd_mkdir,    2, 2, "<path>" },
+  { "mkdir",    cmd_mkdir,    2, 3, "[-p] <path>" },
 # endif
 #endif
 


### PR DESCRIPTION
use "mkdir -p /test/test" to ceate a dir

Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
Create the A/B folder, if the A folder does not exist, create the A folder first, and then create the B folder under the A folder
## Impact

## Testing

