### PR TITLE
nshlib/nsh_fscmds:use strchr instead of strstr

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1241,7 +1241,7 @@ int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
       for (; ; )
         {
-          slash = strstr(slash, "/");
+          slash = strchr(slash, '/');
           if (slash != NULL)
             {
               *slash = '\0';


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact

## Testing

