### PR TITLE
examples/timer: fix timer notification asignment

### DIFF
--- a/examples/timer/timer_main.c
+++ b/examples/timer/timer_main.c
@@ -217,7 +217,8 @@ int main(int argc, FAR char *argv[])
 
   printf("Attach timer handler\n");
 
-  notify.pid   = getpid();
+  notify.pid      = getpid();
+  notify.periodic = true;
 
   notify.event.sigev_notify = SIGEV_SIGNAL;
   notify.event.sigev_signo  = CONFIG_EXAMPLES_TIMER_SIGNO;

--- a/examples/timer_gpio/timer_gpio_main.c
+++ b/examples/timer_gpio/timer_gpio_main.c
@@ -176,7 +176,9 @@ static int timer_gpio_daemon(int argc, char *argv[])
 
   printf("Configure the timer notification.\n");
 
-  notify.pid   = getpid();
+  notify.pid      = getpid();
+  notify.periodic = true;
+
   notify.event.sigev_notify = SIGEV_SIGNAL;
   notify.event.sigev_signo  = CONFIG_EXAMPLES_TIMER_GPIO_SIGNO;
   notify.event.sigev_value.sival_ptr = NULL;


### PR DESCRIPTION
## Summary
After https://github.com/apache/incubator-nuttx/pull/5747 the apps examples should be updated to fix `struct timer_notify_s` assignment.

## Impact
Timer driver based examples

## Testing
Tested with same70-qmtech board