### PR TITLE
Fix warning after removing -fno-builtin

### DIFF
--- a/system/nxlooper/nxlooper.c
+++ b/system/nxlooper/nxlooper.c
@@ -121,7 +121,7 @@ static int nxlooper_opendevice(FAR struct nxlooper_s *plooper)
       struct audio_caps_s caps;
       FAR struct dirent *pdevice;
       FAR DIR *dirp;
-      char path[64];
+      char path[PATH_MAX];
 
       /* Search for a device in the audio device directory */
 
@@ -851,11 +851,11 @@ int nxlooper_setdevice(FAR struct nxlooper_s *plooper,
 
   if (caps.ac_controls.b[0] & AUDIO_TYPE_OUTPUT)
     {
-      strncpy(plooper->playdev, pdevice, sizeof(plooper->playdev));
+      strlcpy(plooper->playdev, pdevice, sizeof(plooper->playdev));
     }
   else if (caps.ac_controls.b[0] & AUDIO_TYPE_INPUT)
     {
-      strncpy(plooper->recorddev, pdevice, sizeof(plooper->playdev));
+      strlcpy(plooper->recorddev, pdevice, sizeof(plooper->recorddev));
     }
 
   return OK;
@@ -1297,7 +1297,7 @@ int nxlooper_systemreset(FAR struct nxlooper_s *plooper)
   struct audio_caps_s caps;
   FAR struct dirent   *pdevice;
   FAR DIR             *dirp;
-  char                path[64];
+  char                path[PATH_MAX];
   int                 temp_fd;
 
   /* Search for a device in the audio device directory */

--- a/system/nxlooper/nxlooper_main.c
+++ b/system/nxlooper/nxlooper_main.c
@@ -348,7 +348,7 @@ static int nxlooper_cmd_resume(FAR struct nxlooper_s *plooper, char *parg)
 static int nxlooper_cmd_device(FAR struct nxlooper_s *plooper, char *parg)
 {
   int  ret;
-  char path[32];
+  char path[PATH_MAX];
 
   /* First try to open the file directly */
 

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -1683,7 +1683,7 @@ int nxplayer_setdevice(FAR struct nxplayer_s *pplayer,
 
   /* Save the path and format capabilities of the preferred device */
 
-  strncpy(pplayer->prefdevice, pdevice, sizeof(pplayer->prefdevice));
+  strlcpy(pplayer->prefdevice, pdevice, sizeof(pplayer->prefdevice));
   pplayer->prefformat = caps.ac_format.b[0] | (caps.ac_format.b[1] << 8);
   pplayer->preftype = caps.ac_controls.b[0];
 
@@ -2087,7 +2087,7 @@ int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
 void nxplayer_setmediadir(FAR struct nxplayer_s *pplayer,
      FAR const char *mediadir)
 {
-  strncpy(pplayer->mediadir, mediadir, sizeof(pplayer->mediadir));
+  strlcpy(pplayer->mediadir, mediadir, sizeof(pplayer->mediadir));
 }
 #endif
 
@@ -2312,7 +2312,7 @@ int nxplayer_systemreset(FAR struct nxplayer_s *pplayer)
 {
   struct dirent *pdevice;
   DIR           *dirp;
-  char           path[64];
+  char           path[PATH_MAX];
 
   /* Search for a device in the audio device directory */
 

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -590,8 +590,8 @@ static int nxplayer_cmd_resume(FAR struct nxplayer_s *pplayer, char *parg)
 #ifdef CONFIG_NXPLAYER_INCLUDE_PREFERRED_DEVICE
 static int nxplayer_cmd_device(FAR struct nxplayer_s *pplayer, char *parg)
 {
-  int     ret;
-  char    path[32];
+  int  ret;
+  char path[PATH_MAX];
 
   /* First try to open the file directly */
 
@@ -738,8 +738,11 @@ static int nxplayer_cmd_help(FAR struct nxplayer_s *pplayer, char *parg)
 int main(int argc, FAR char *argv[])
 {
   char                    buffer[CONFIG_NSH_LINELEN];
-  int                     len, x, running;
-  char                    *cmd, *arg;
+  int                     len;
+  int                     x;
+  int                     running;
+  char                    *cmd;
+  char                    *arg;
   FAR struct nxplayer_s   *pplayer;
 
   printf("NxPlayer version " NXPLAYER_VER "\n");

--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -692,7 +692,7 @@ int nxrecorder_setdevice(FAR struct nxrecorder_s *precorder,
 
   /* Save the path and format capabilities of the device */
 
-  strncpy(precorder->device, pdevice, sizeof(precorder->device));
+  strlcpy(precorder->device, pdevice, sizeof(precorder->device));
 
   return OK;
 }

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -301,8 +301,8 @@ static int nxrecorder_cmd_resume(FAR struct nxrecorder_s *precorder,
 static int nxrecorder_cmd_device(FAR struct nxrecorder_s *precorder,
                                  FAR char *parg)
 {
-  int     ret;
-  char    path[32];
+  int  ret;
+  char path[PATH_MAX];
 
   /* First try to open the file directly */
 

--- a/wireless/wapi/src/driver_wext.c
+++ b/wireless/wapi/src/driver_wext.c
@@ -99,7 +99,7 @@ int wpa_driver_wext_get_key_ext(int sockfd, FAR const char *ifname,
     }
 
   memset(&iwr, 0, sizeof(iwr));
-  strncpy(iwr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(iwr.ifr_name, ifname, IFNAMSIZ);
 
   iwr.u.encoding.pointer = (caddr_t) ext;
   iwr.u.encoding.length = sizeof(*ext) + *req_len;
@@ -171,7 +171,7 @@ int wpa_driver_wext_set_key_ext(int sockfd, FAR const char *ifname,
     }
 
   memset(&iwr, 0, sizeof(iwr));
-  strncpy(iwr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(iwr.ifr_name, ifname, IFNAMSIZ);
 
   iwr.u.encoding.pointer = (caddr_t) ext;
   iwr.u.encoding.length = sizeof(*ext) + key_len;
@@ -253,7 +253,7 @@ int wpa_driver_wext_associate(FAR struct wpa_wconfig_s *wconfig)
 
   /* Put the driver name into the request */
 
-  strncpy(req.ifr_name, wconfig->ifname, IFNAMSIZ);
+  strlcpy(req.ifr_name, wconfig->ifname, IFNAMSIZ);
 
   ret = wapi_set_mode(sockfd, wconfig->ifname, wconfig->sta_mode);
   if (ret < 0)
@@ -354,7 +354,7 @@ static int wpa_driver_wext_process_auth_param(int sockfd,
   DEBUGASSERT(ifname != NULL);
 
   memset(&iwr, 0, sizeof(iwr));
-  strncpy(iwr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(iwr.ifr_name, ifname, IFNAMSIZ);
   iwr.u.param.flags = idx & IW_AUTH_INDEX;
   iwr.u.param.value = set ? *value : 0;
 
@@ -443,7 +443,7 @@ void wpa_driver_wext_disconnect(int sockfd, FAR const char *ifname)
    */
 
   memset(&iwr, 0, sizeof(iwr));
-  strncpy(iwr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(iwr.ifr_name, ifname, IFNAMSIZ);
 
   if (ioctl(sockfd, SIOCGIWMODE, (unsigned long)&iwr) < 0)
     {

--- a/wireless/wapi/src/network.c
+++ b/wireless/wapi/src/network.c
@@ -64,7 +64,7 @@ static int wapi_get_addr(int sock, FAR const char *ifname, int cmd,
 
   WAPI_VALIDATE_PTR(addr);
 
-  strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, ifname, IFNAMSIZ);
   if ((ret = ioctl(sock, cmd, (unsigned long)((uintptr_t)&ifr))) >= 0)
     {
       struct sockaddr_in *sin = (struct sockaddr_in *)&ifr.ifr_addr;
@@ -92,7 +92,7 @@ static int wapi_set_addr(int sock, FAR const char *ifname, int cmd,
   sin.sin_family = AF_INET;
   memcpy(&sin.sin_addr, addr, sizeof(struct in_addr));
   memcpy(&ifr.ifr_addr, &sin, sizeof(struct sockaddr_in));
-  strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, ifname, IFNAMSIZ);
   if ((ret = ioctl(sock, cmd, (unsigned long)((uintptr_t)&ifr))) < 0)
     {
       int errcode = errno;
@@ -177,7 +177,7 @@ int wapi_get_ifup(int sock, FAR const char *ifname, FAR int *is_up)
 
   WAPI_VALIDATE_PTR(is_up);
 
-  strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
   if (ret >= 0)
     {
@@ -206,7 +206,7 @@ int wapi_set_ifup(int sock, FAR const char *ifname)
   struct ifreq ifr;
   int ret;
 
-  strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
   if (ret >= 0)
     {
@@ -242,7 +242,7 @@ int wapi_set_ifdown(int sock, FAR const char *ifname)
   struct ifreq ifr;
   int ret;
 
-  strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIFFLAGS, (unsigned long)((uintptr_t)&ifr));
   if (ret >= 0)
     {

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -476,7 +476,7 @@ int wapi_get_freq(int sock, FAR const char *ifname, FAR double *freq,
   WAPI_VALIDATE_PTR(freq);
   WAPI_VALIDATE_PTR(flag);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWFREQ, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -544,7 +544,7 @@ int wapi_set_freq(int sock, FAR const char *ifname, double freq,
       break;
     }
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWFREQ, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -588,7 +588,7 @@ int wapi_freq2chan(int sock, FAR const char *ifname, double freq,
 
   /* Get range. */
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWRANGE, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -654,7 +654,7 @@ int wapi_chan2freq(int sock, FAR const char *ifname, int chan,
 
   /* Get range. */
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWRANGE, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -712,7 +712,7 @@ int wapi_get_essid(int sock, FAR const char *ifname, FAR char *essid,
   wrq.u.essid.length = WAPI_ESSID_MAX_SIZE + 1;
   wrq.u.essid.flags = 0;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWESSID, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -755,7 +755,7 @@ int wapi_set_essid(int sock, FAR const char *ifname, FAR const char *essid,
     snprintf(buf, ((WAPI_ESSID_MAX_SIZE + 1) * sizeof(char)), "%s", essid);
   wrq.u.essid.flags = flag;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWESSID, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -786,7 +786,7 @@ int wapi_get_mode(int sock, FAR const char *ifname,
 
   WAPI_VALIDATE_PTR(mode);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWMODE, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -820,7 +820,7 @@ int wapi_set_mode(int sock, FAR const char *ifname, enum wapi_mode_e mode)
 
   wrq.u.mode = mode;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWMODE, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -880,7 +880,7 @@ int wapi_get_ap(int sock, FAR const char *ifname, FAR struct ether_addr *ap)
 
   WAPI_VALIDATE_PTR(ap);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWAP, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -917,7 +917,7 @@ int wapi_set_ap(int sock, FAR const char *ifname,
 
   wrq.u.ap_addr.sa_family = ARPHRD_ETHER;
   memcpy(wrq.u.ap_addr.sa_data, ap, sizeof(struct ether_addr));
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
 
   ret = ioctl(sock, SIOCSIWAP, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
@@ -950,7 +950,7 @@ int wapi_get_bitrate(int sock, FAR const char *ifname,
   WAPI_VALIDATE_PTR(bitrate);
   WAPI_VALIDATE_PTR(flag);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWRATE, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -997,7 +997,7 @@ int wapi_set_bitrate(int sock, FAR const char *ifname, int bitrate,
   wrq.u.bitrate.value = bitrate;
   wrq.u.bitrate.fixed = (flag == WAPI_BITRATE_FIXED);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWRATE, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -1055,7 +1055,7 @@ int wapi_get_txpower(int sock, FAR const char *ifname, FAR int *power,
   WAPI_VALIDATE_PTR(power);
   WAPI_VALIDATE_PTR(flag);
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWTXPOW, (unsigned long)((uintptr_t)&wrq));
   if (ret >= 0)
     {
@@ -1138,7 +1138,7 @@ int wapi_set_txpower(int sock, FAR const char *ifname, int power,
 
   /* Issue the set command. */
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWTXPOW, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -1193,7 +1193,7 @@ int wapi_scan_channel_init(int sock, FAR const char *ifname,
         }
     }
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWSCAN, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -1241,7 +1241,7 @@ int wapi_scan_stat(int sock, FAR const char *ifname)
 
   wrq.u.data.pointer = &buf;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWSCAN, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -1309,7 +1309,7 @@ alloc:
   wrq.u.data.pointer = buf;
   wrq.u.data.length  = buflen;
   wrq.u.data.flags   = 0;
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
 
   ret = ioctl(sock, SIOCGIWSCAN, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0 && errno == E2BIG)
@@ -1428,7 +1428,7 @@ int wapi_set_country(int sock, FAR const char *ifname,
   wrq.u.data.pointer = (FAR void *)country;
   wrq.u.data.length = 2;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCSIWCOUNTRY, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {
@@ -1456,7 +1456,7 @@ int wapi_get_sensitivity(int sock, FAR const char *ifname, FAR int *sense)
 
   int ret;
 
-  strncpy(wrq.ifr_name, ifname, IFNAMSIZ);
+  strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(sock, SIOCGIWSENS, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
Found by change https://github.com/apache/incubator-nuttx/pull/5476:
- wireless/wapi: Fix warning: 'strncpy' specified bound 16 equals destination size
- system: Fix nx[looper|player|recorder] warning

## Impact
Minor

## Testing
Pass CI
