### PR TITLE
interpreters: lua: replace awk command with shell script

### DIFF
--- a/interpreters/lua/Makefile
+++ b/interpreters/lua/Makefile
@@ -84,9 +84,11 @@ CSRCS += $(CORELIBS_SRCS)
 
 register::
 	# collect core module names from defines in lualib.h
-	$(Q) awk '{ if (match($$0,/LUA_[A-Z]+LIBNAME\s"([a-z]+)"$$/,m)) \
-		printf "{ \"%s\", luaopen_%s },\n", m[1], m[1] > "registry$(DELIM)"m[1]".bdat" }' \
-		$(LUA_SRC)$(DELIM)lualib.h
+	$(Q) while read -r line; do \
+		name=$$(expr "$$line" : '#define LUA_[[:upper:]]\+LIBNAME[[:space:]]\+"\([[:lower:]]\+\)"'); \
+		if [ ! -z $$name ]; then \
+			printf '{ "%s", luaopen_%s },\n' $$name $$name > registry$(DELIM)$$name.bdat; \
+		fi done < $(LUA_SRC)$(DELIM)lualib.h
 endif
 
 # Lua builtin module registry


### PR DESCRIPTION
## Summary

The `apps/interpreters/lua/Makefile` used an `awk` command that was only compatible with GNU `awk`. The build failed on platforms with BSD `awk`, like MacOS.

Replace the `awk` command with a POSIX shell script, using the `expr` command for regex group capture.

## Impact

Only affects the Lua interpreter used by defconfigs with `CONFIG_INTERPRETERS_LUA` enabled.

## Testing

The same output is produced by the previous and new make step.
