### PR TITLE
fsutils/passwd: fix compilation

### DIFF
--- a/fsutils/passwd/passwd_deluser.c
+++ b/fsutils/passwd/passwd_deluser.c
@@ -25,7 +25,6 @@
 #include <semaphore.h>
 
 #include "fsutils/passwd.h"
-
 #include "passwd.h"
 
 /****************************************************************************

--- a/fsutils/passwd/passwd_update.c
+++ b/fsutils/passwd/passwd_update.c
@@ -25,7 +25,7 @@
 #include <semaphore.h>
 
 #include "fsutils/passwd.h"
-#include <passwd.h>
+#include "passwd.h"
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary
`passwd` compilation fails with
```
./passwd_update.c:28:10: fatal error: passwd.h: No such file or directory
   28 | #include <passwd.h>
```

## Impact
None. Fix build issue

## Testing
Pass CI
