### PR TITLE
fsutils/passwd: fix out of bounds array access during password encryption

### DIFF
--- a/fsutils/passwd/passwd_encrypt.c
+++ b/fsutils/passwd/passwd_encrypt.c
@@ -93,11 +93,11 @@ static char passwd_base64(uint8_t binary)
 
   /* 62 -> '+' */
 
- binary -= 10;
- if (binary == 0)
-   {
-     return '+';
-   }
+  binary -= 10;
+  if (binary == 0)
+    {
+      return '+';
+    }
 
   /* 63 -> '/' */
 
@@ -123,7 +123,8 @@ static char passwd_base64(uint8_t binary)
  *
  ****************************************************************************/
 
-int passwd_encrypt(FAR const char *password, char encrypted[MAX_ENCRYPTED + 1])
+int passwd_encrypt(FAR const char *password,
+                   char encrypted[MAX_ENCRYPTED + 1])
 {
   union
   {
@@ -138,7 +139,6 @@ int passwd_encrypt(FAR const char *password, char encrypted[MAX_ENCRYPTED + 1])
   uint32_t tmp;
   uint8_t remainder;
   int remaining;
-  int converted;
   int gulpsize;
   int nbits;
   int i;
@@ -160,11 +160,11 @@ int passwd_encrypt(FAR const char *password, char encrypted[MAX_ENCRYPTED + 1])
   remainder  = 0;
   nbits      = 0;
 
-  for (converted = 0; converted < remaining; converted += 8)
+  for (; remaining > 0; remaining -= gulpsize)
     {
       /* Copy bytes */
 
-      gulpsize = 8;
+      gulpsize = sizeof(value.b);
       if (gulpsize > remaining)
         {
           gulpsize = remaining;
@@ -178,7 +178,7 @@ int passwd_encrypt(FAR const char *password, char encrypted[MAX_ENCRYPTED + 1])
 
       /* Pad with spaces if necessary */
 
-      for (; i < 8; i++)
+      for (; i < sizeof(value.b); i++)
         {
           *bptr++ = ' ';
         }

--- a/nshlib/nsh_passwdcmds.c
+++ b/nshlib/nsh_passwdcmds.c
@@ -80,7 +80,7 @@ int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #endif /* !CONFIG_NSH_DISABLE_USERDEL */
 
 /****************************************************************************
- * Name: cmd_useradd
+ * Name: cmd_passwd
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_PASSWD


### PR DESCRIPTION
## Summary
Fix out of bounds array access during password encryption

## Impact
Boards with `FSUTILS_PASSWD` enabled that have passwords with length not multiple of `8` stored in `FSUTILS_PASSWD_PATH` file.
After applying this change my `/ect/passwd` became unusable and I had to recreate it again.

## Testing
Tested with custom SAME70 based board.