### PR TITLE
system/cfgdata: add missing include file

### DIFF
--- a/system/cfgdata/cfgdata_main.c
+++ b/system/cfgdata/cfgdata_main.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/mtd/mtd.h>
 #include <nuttx/mtd/configdata.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>


### PR DESCRIPTION
## Summary
Add missing include file

## Impact
Fix the build

## Testing
Pass build locally with `cfgdata` enabled