### PR TITLE
apps/nsh:add resetcause command

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -547,6 +547,12 @@ config NSH_DISABLE_XD
 	bool "Disable xd"
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_RESET_CAUSE
+	bool "Disable reset cause"
+	default n if !DEFAULT_SMALL
+	default y if DEFAULT_SMALL
+	depends on BOARDCTL_RESET_CAUSE
+
 endmenu
 
 if MMCSD

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1157,6 +1157,10 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
   int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 #endif
 
+#if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
+  int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+#endif
+
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
   int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -439,6 +439,10 @@ static const struct cmdmap_s g_cmdmap[] =
   { "reboot",   cmd_reboot,   1, 2, NULL },
 #endif
 
+#if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
+  { "resetcause",   cmd_reset_cause,   1, 1, NULL },
+#endif
+
 #ifdef NSH_HAVE_DIROPTS
 # ifndef CONFIG_NSH_DISABLE_RM
   { "rm",       cmd_rm,       2, 3, "[-r] <file-path>" },

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -319,6 +319,26 @@ int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 }
 #endif
 
+#if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
+int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+{
+  int ret;
+  struct boardioc_reset_cause_s cause;
+
+  memset(&cause, 0, sizeof(cause));
+  ret = boardctl(BOARDIOC_RESET_CAUSE, &cause);
+  if (ret < 0)
+    {
+      nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);
+      return ERROR;
+    }
+
+  nsh_output(vtbl, "cause:0x%x, flag:0x" PRIx32 "\n",
+             cause.cause, cause.flag);
+  return OK;
+}
+#endif
+
 /****************************************************************************
  * Name: cmd_rptun
  ****************************************************************************/


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
add resetcause nsh command, this will call boardctl to read last reset cause
## Impact
N/A
## Testing
Vela tested
