### PR TITLE
testing/mm: repair the memory leak question when realloc failed.

### DIFF
--- a/testing/mm/mm_main.c
+++ b/testing/mm/mm_main.c
@@ -177,6 +177,7 @@ static void do_reallocs(FAR void **mem, FAR const int *oldsize,
 {
   int i;
   int j;
+  void *ptr;
 
   for (i = 0; i < n; i++)
     {
@@ -184,10 +185,19 @@ static void do_reallocs(FAR void **mem, FAR const int *oldsize,
       printf("(%d)Re-allocating at %p from %d to %d bytes\n",
              i, mem[j], oldsize[j], newsize[j]);
 
-      mem[j] = realloc(mem[j], newsize[j]);
-      printf("(%d)Memory re-allocated at %p\n", i, mem[j]);
+      /* Return null if realloc failed, so using a local variable to store
+       * the return value to avoid the missing of old memory pointer.
+       */
 
-      if (mem[j] == NULL)
+      ptr = realloc(mem[j], newsize[j]);
+      if (ptr != NULL)
+        {
+          mem[j] = ptr;
+        }
+
+      printf("(%d)Memory re-allocated at %p\n", i, ptr);
+
+      if (ptr == NULL)
         {
           int allocsize = MM_ALIGN_UP(newsize[j] + SIZEOF_MM_ALLOCNODE);
 


### PR DESCRIPTION
## Summary
Repair the memory leak question when realloc failed.
realloc return NULL if failed, so we have to use a local variable to store the return value to avoid the missing of old memory pointer.

## Testing
mm test pass, no memory leak.
