### PR TITLE
sched/note: add support of trace section mark 

### DIFF
--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -77,27 +77,27 @@ int main(int argc, FAR char *argv[])
 
   while (1)
     {
-      sched_note_printf("shced note test count = %d.", count++);
-      sched_note_string(str);
-      sched_note_dump(MAIN_MODULE, 1, &binary, sizeof(struct binary));
-      sched_note_bprintf(MAIN_MODULE, 2, "%hhd", c);
-      sched_note_bprintf(MAIN_MODULE, 3, "%hd", s);
-      sched_note_bprintf(MAIN_MODULE, 4, "%d", i);
-      sched_note_bprintf(MAIN_MODULE, 5, "%ld", l);
-      sched_note_bprintf(MAIN_MODULE, 6, "%lld", ll);
-      sched_note_bprintf(MAIN_MODULE, 7, "%jd", im);
-      sched_note_bprintf(MAIN_MODULE, 8, "%zd", sz);
-      sched_note_bprintf(MAIN_MODULE, 9, "%td", ptr);
+      SCHED_NOTE_PRINTF("shced note test count = %d.", count++);
+      SCHED_NOTE_STRING(str);
+      SCHED_NOTE_DUMP(1, &binary, sizeof(struct binary));
+      SCHED_NOTE_BPRINTF(2, "%hhd", c);
+      SCHED_NOTE_BPRINTF(3, "%hd", s);
+      SCHED_NOTE_BPRINTF(4, "%d", i);
+      SCHED_NOTE_BPRINTF(5, "%ld", l);
+      SCHED_NOTE_BPRINTF(6, "%lld", ll);
+      SCHED_NOTE_BPRINTF(7, "%jd", im);
+      SCHED_NOTE_BPRINTF(8, "%zd", sz);
+      SCHED_NOTE_BPRINTF(9, "%td", ptr);
 #ifdef CONFIG_HAVE_FLOAT
-      sched_note_bprintf(MAIN_MODULE, 10, "%e", f);
+      SCHED_NOTE_BPRINTF(10, "%e", f);
 #endif
 #ifdef CONFIG_HAVE_DOUBLE
-      sched_note_bprintf(MAIN_MODULE, 11, "%le", d);
+      SCHED_NOTE_BPRINTF(11, "%le", d);
 #endif
 #ifdef CONFIG_HAVE_LONG_DOUBLE
-      sched_note_bprintf(MAIN_MODULE, 12, "%Le", ld);
+      SCHED_NOTE_BPRINTF(12, "%Le", ld);
 #endif
-      sched_note_bprintf(MAIN_MODULE, 13,
+      SCHED_NOTE_BPRINTF(13,
                          "%hhd  %hd  %d  %ld  %lld  %jd  %zd  %td",
                           c,    s,   i,  l,    ll,  im,  sz,  ptr);
       usleep(10);

--- a/system/sched_note/note_main.c
+++ b/system/sched_note/note_main.c
@@ -737,7 +737,7 @@ static void dump_notes(size_t nread)
                   {
                     FAR struct note_binary_s *note_binary =
                       (FAR struct note_binary_s *)note;
-                    uint32_t module;
+                    uintptr_t ip;
                     char out[1280];
                     int count;
                     int ret = 0;
@@ -758,15 +758,15 @@ static void dump_notes(size_t nread)
                         ret += sprintf(&out[ret], " 0x%x", note_binary->nbi_data[i]);
                       }
 
-                    trace_dump_unflatten(&module,
-                                         note_binary->nbi_module,
-                                         sizeof(module));
+                    trace_dump_unflatten(&ip, note_binary->nbi_ip,
+                                         sizeof(ip));
 
                     syslog_time(LOG_INFO,
-                           "Task %u priority %u, binary:module=%lx "
-                            "event=%u count=%u%s\n",
+                           "Task %u priority %u, ip=0x%" PRIdPTR
+                            " event=%u count=%u%s\n",
                            (unsigned int)pid,
-                           (unsigned int)note->nc_priority, module,
+                           (unsigned int)note->nc_priority,
+                           note_binary->nbi_ip,
                            note_binary->nbi_event,
                            count,
                            out);

--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -142,10 +142,22 @@ static int trace_cmd_start(int index, int argc, FAR char **argv,
 static int trace_cmd_dump(int index, int argc, FAR char **argv,
                           int notectlfd)
 {
+  trace_dump_t type = TRACE_TYPE_LTTNG_KERNEL;
   FAR FILE *out = stdout;
-  int ret;
   bool changed = false;
   bool cont = false;
+  int ret;
+
+  /* Usage: trace dump [-a] "Custom Format : Android SysTrace" */
+
+  if (index < argc)
+    {
+      if (strcmp(argv[index], "-a") == 0)
+        {
+          index++;
+          type = TRACE_TYPE_ANDROID;
+        }
+    }
 
   /* Usage: trace dump [-c][<filename>] */
 
@@ -189,7 +201,7 @@ static int trace_cmd_dump(int index, int argc, FAR char **argv,
 
   /* Dump the trace data */
 
-  ret = trace_dump(out);
+  ret = trace_dump(type, out);
 
   if (changed)
     {
@@ -788,8 +800,9 @@ static void show_usage(void)
                                 " Get the trace while running <command>\n"
 #endif
 #ifdef CONFIG_DRIVER_NOTERAM
-          "  dump [-c][<filename>]           :"
+          "  dump [-a][-c][<filename>]           :"
                                 " Output the trace result\n"
+                                " [-a] <Android SysTrace>\n"
 #endif
           "  mode [{+|-}{o|w|s|a|i|d}...]        :"
                                 " Set task trace options\n"

--- a/system/trace/trace.h
+++ b/system/trace/trace.h
@@ -38,6 +38,20 @@ extern "C"
 #endif
 
 /****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef enum
+{
+  TRACE_TYPE_LTTNG_KERNEL = 0,  /* Common Trace Format : Linux Kernel Trace */
+  TRACE_TYPE_GENERIC_CTF  = 1,  /* Common Trace Format : Generic CTF Trace */
+  TRACE_TYPE_LTTNG_UST    = 2,  /* Common Trace Format : LTTng UST Trace */
+  TRACE_TYPE_CUSTOM_TEXT  = 3,  /* Custom Text :         TmfGeneric */
+  TRACE_TYPE_CUSTOM_XML   = 4,  /* Custom XML :          Custom XML Log */
+  TRACE_TYPE_ANDROID      = 5,  /* Custom Format :       Android ATrace */
+} trace_dump_t;
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
@@ -51,7 +65,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int trace_dump(FAR FILE *out);
+int trace_dump(trace_dump_t type, FAR FILE *out);
 
 /****************************************************************************
  * Name: trace_dump_clear
@@ -85,7 +99,7 @@ void trace_dump_set_overwrite(bool mode);
 
 #else /* CONFIG_DRIVER_NOTERAM */
 
-#define trace_dump(out)
+#define trace_dump(type,out)
 #define trace_dump_clear()
 #define trace_dump_get_overwrite()      0
 #define trace_dump_set_overwrite(mode)  (void)(mode)

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -592,8 +592,8 @@ static int trace_dump_one(FAR FILE *out,
 
           nih = (FAR struct note_irqhandler_s *)p;
           trace_dump_header(out, note, ctx);
-          fprintf(out, "irq_handler_entry: irq=%u\n",
-                  nih->nih_irq);
+          fprintf(out, "irq_handler_entry: irq=%u name=%d\n",
+                  nih->nih_irq, nih->nih_irq);
           cctx->intr_nest++;
         }
         break;
@@ -604,7 +604,7 @@ static int trace_dump_one(FAR FILE *out,
 
           nih = (FAR struct note_irqhandler_s *)p;
           trace_dump_header(out, note, ctx);
-          fprintf(out, "irq_handler_exit: irq=%u\n",
+          fprintf(out, "irq_handler_exit: irq=%u ret=handled\n",
                   nih->nih_irq);
           cctx->intr_nest--;
 

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -615,31 +615,30 @@ static int trace_dump_one(FAR FILE *out,
       case NOTE_DUMP_STRING:
         {
           FAR struct note_string_s *nst;
+          uintptr_t ip;
 
           nst = (FAR struct note_string_s *)p;
           trace_dump_header(out, note, ctx);
-          fprintf(out, "dump_string: %s\n",
-                  nst->nst_data);
+          trace_dump_unflatten(&ip, nst->nst_ip, sizeof(ip));
+          fprintf(out, "0x%" PRIdPTR ": %s\n", ip, nst->nst_data);
         }
         break;
 
       case NOTE_DUMP_BINARY:
         {
           FAR struct note_binary_s *nbi;
-          uint32_t module;
           uint8_t count;
+          uintptr_t ip;
           int i;
 
           nbi = (FAR struct note_binary_s *)p;
           trace_dump_header(out, note, ctx);
           count = note->nc_length - sizeof(struct note_binary_s) + 1;
 
-          trace_dump_unflatten(&module,
-                               note_binary->nbi_module,
-                               sizeof(module));
+          trace_dump_unflatten(&ip, nbi->nbi_ip, sizeof(ip));
 
-          fprintf(out, "dump_binary: module=%lx event=%u count=%u",
-                  module, nbi->nbi_event, count);
+          fprintf(out, "0x%" PRIdPTR ": event=%u count=%u",
+                  ip, nbi->nbi_event, count);
           for (i = 0; i < count; i++)
             {
               fprintf(out, " 0x%x", nbi->nbi_data[i]);

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -653,6 +653,8 @@ static int trace_dump_one(FAR FILE *out,
         break;
     }
 
+  fflush(out);
+
   /* Return the length of the processed note */
 
   return note->nc_length;

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -317,7 +317,7 @@ static void trace_dump_header(FAR FILE *out,
   int cpu = 0;
 #endif
 
-  pid = ctx->cpu[cpu].current_pid;
+  trace_dump_unflatten(&pid, note->nc_pid, sizeof(pid));
 
   fprintf(out, "%8s-%-3u [%d] %3" PRIu32 ".%09" PRIu32 ": ",
           get_task_name(pid, ctx), get_pid(pid), cpu,


### PR DESCRIPTION
## Summary

sched/note: add support of trace section mark

The implementation of this feature is based on android systrace:

https://source.android.com/devices/tech/debug/ftrace

Application developers are more concerned about the performance of
the specified application section,
added two APIs to implement performance measurement:

```
void sched_note_begin(FAR const char *str);
void sched_note_end(FAR const char *str);
or
SCHED_NOTE_BEGIN();  /* defined to sched_note_begin(__FUNCTION__) */
SCHED_NOTE_END();    /* defined to sched_note_end(__FUNCTION__) */
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Depends on: https://github.com/apache/incubator-nuttx/pull/5915

## Testing

https://source.android.com/devices/tech/debug/ftrace
https://github.com/catapult-project/catapult/


test code:

```
void ccc(void)
{
  SCHED_NOTE_BEGIN();
  usleep(10);
  SCHED_NOTE_END();
}

void bbb(void)
{
  SCHED_NOTE_BEGIN();
  ccc();
  SCHED_NOTE_END();
}

void aaa(void)
{
  SCHED_NOTE_BEGIN();
  bbb();
  SCHED_NOTE_END();
}

int main(int argc, FAR char *argv[])
{
  while (1)
    {
      SCHED_NOTE_BEGIN();
      aaa();
      SCHED_NOTE_END();
    }
  return 0;
}

```

![Screenshot from 2022-03-30 22-34-16](https://user-images.githubusercontent.com/758493/160860334-a5006bbe-c506-4d59-b067-74651a863982.png)


## How To Use

https://nuttx.apache.org/docs/latest/guides/tasktraceuser.html

1. enable sched  instrumentation

```
CONFIG_DRIVER_NOTERAM=y
...
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y
CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER=y
CONFIG_SCHED_INSTRUMENTATION_DUMP=y
```
2. Capture sched note info

```
nsh> trace switch +
nsh> trace syscall +
nsh> trace print +
nsh> trace start
nsh> trace dump
```

3. convert to systrace

https://source.android.com/devices/tech/debug/ftrace

If you captured your systrace with --no-compress, this is in the html file in the section beginning with BEGIN TRACE.
If not, run html2trace from the [Catapult tree](https://github.com/catapult-project/catapult/tree/master/) (tracing/bin/html2trace) to uncompress the trace.

```
$ git clone git@github.com:catapult-project/catapult.git
$ cd catapult/
$ ./tracing/bin/trace2html trace.txt
trace.html
```
[systrace.txt](https://github.com/apache/incubator-nuttx/files/8381565/systrace.txt)


4. open the trace html via web browser:
`$ google-chrome trace.html`