### PR TITLE
nsh/memdump: support dynamic turn on/off backtrace in heap

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -218,7 +218,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifdef CONFIG_DEBUG_MM
 # ifndef CONFIG_NSH_DISABLE_MEMDUMP
-  { "memdump",  cmd_memdump,  1, 3, "[pid/used/free]" },
+  { "memdump",  cmd_memdump,  1, 3, "[pid/used/free/on/off]" },
 # endif
 #endif
 


### PR DESCRIPTION


## Summary
nsh/memdump: support dynamic turn on/off backtrace in heap.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
Add: memdump on and memdump off
## Testing
Ci 
