### PR TITLE
open() options: pass file options 0 if only ioctl is used

### DIFF
--- a/examples/pca9635/pca9635_main.c
+++ b/examples/pca9635/pca9635_main.c
@@ -59,7 +59,7 @@ int main(int argc, FAR char *argv[])
   int fd;
   int ret;
 
-  fd = open(CONFIG_EXAMPLES_PCA9635_DEVNAME, O_WRONLY);
+  fd = open(CONFIG_EXAMPLES_PCA9635_DEVNAME, 0);
   if (fd < 0)
     {
       fprintf(stderr, "ERROR: Failed to open %s: %d\n",

--- a/system/cfgdata/cfgdata_main.c
+++ b/system/cfgdata/cfgdata_main.c
@@ -335,7 +335,7 @@ static void cfgdatacmd_set(int argc, char *argv[])
 
   /* Now open the /dev/config file and set the config item */
 
-  if ((fd = open(g_config_dev, O_WRONLY)) < 2)
+  if ((fd = open(g_config_dev, 0)) < 2)
     {
       /* Display error */
 
@@ -402,7 +402,7 @@ static void cfgdatacmd_unset(int argc, char *argv[])
 
   /* Try to open the /dev/config file */
 
-  if ((fd = open(g_config_dev, O_WRONLY)) < 2)
+  if ((fd = open(g_config_dev, 0)) < 2)
     {
       /* Display error */
 
@@ -549,7 +549,7 @@ static void cfgdatacmd_show_all_config_items(void)
 
   /* Try to open the /dev/config file */
 
-  if ((fd = open(g_config_dev, O_RDONLY)) < 2)
+  if ((fd = open(g_config_dev, 0)) < 2)
     {
       /* Display error */
 
@@ -658,7 +658,7 @@ static void cfgdatacmd_format(void)
 
   /* Try to open the /dev/config file */
 
-  if ((fd = open(g_config_dev, O_WRONLY)) < 2)
+  if ((fd = open(g_config_dev, 0)) < 2)
     {
       /* Display error */
 


### PR DESCRIPTION
## Summary
Pass file options 0 if only ioctl is used. if write or read handler is not available then `-EACCES` is returned by `inode_checkflags`

## Impact
Fix cfgdata and pca9635 example operation.

## Testing
Tested with custom board based on SAME70
