### PR TITLE
usrsock/rpmsg: Change the dependence from OPENAMP to RPTUN

### DIFF
--- a/netutils/usrsock_rpmsg/Kconfig
+++ b/netutils/usrsock_rpmsg/Kconfig
@@ -6,7 +6,7 @@
 config NETUTILS_USRSOCK_RPMSG
 	tristate "RPMSG usrsock"
 	default n
-	depends on NET && OPENAMP
+	depends on NET && RPTUN
 	select EVENT_FD if !NET_USRSOCK
 	---help---
 		Enable usrsock through rpmsg channel.


### PR DESCRIPTION
## Summary
since all rpmsg driver need the extension api exposed by rptun driver
follow up nuttx side change: https://github.com/apache/incubator-nuttx/pull/5982

## Impact
Minor

## Testing
Pass CI
