### PR TITLE
According to the help text, the balance command without value

### DIFF
--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -466,11 +466,11 @@ static int nxplayer_cmd_balance(FAR struct nxplayer_s *pplayer, char *parg)
 {
   uint16_t   percent;
 
-  /* If no arg given, then print current volume */
+  /* If no arg given, then print current balance */
 
   if (parg == NULL || *parg == '\0')
     {
-      printf("balance: %d\n", pplayer->volume / 10);
+      printf("balance: %d\n", pplayer->balance / 10);
     }
   else
     {


### PR DESCRIPTION
## Summary
According to the help text, the balance command should display the current balance value. This patch adjusts
the code accordingly.

## Impact
Bugfix I hope.

## Testing

