### PR TITLE
nshlib/nsh_fscmds.c: Make losetup command take optional sector size

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -278,7 +278,8 @@ static const struct cmdmap_s g_cmdmap[] =
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 # if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
   { "losetup",   cmd_losetup, 3, 6,
-    "[-d <dev-path>] | [[-o <offset>] [-r] <dev-path> <file-path>]" },
+    "[-d <dev-path>] | [[-o <offset>] [-r] [-s <sect-size>] "
+    "<dev-path> <file-path>]" },
 # endif
 #endif
 

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -670,6 +670,7 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   bool teardown = false;
   bool readonly = false;
   off_t offset = 0;
+  int sectsize = 512;
   bool badarg = false;
   int ret = ERROR;
   int option;
@@ -678,13 +679,13 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   /* Get the losetup options:  Two forms are supported:
    *
    *   losetup -d <loop-device>
-   *   losetup [-o <offset>] [-r] <loop-device> <filename>
+   *   losetup [-o <offset>] [-r] [-s <sectsize> ] <loop-device> <filename>
    *
    * NOTE that the -o and -r options are accepted with the -d option, but
    * will be ignored.
    */
 
-  while ((option = getopt(argc, argv, "d:o:r")) != ERROR)
+  while ((option = getopt(argc, argv, "d:o:rs:")) != ERROR)
     {
       switch (option)
         {
@@ -699,6 +700,10 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
         case 'r':
           readonly = true;
+          break;
+
+        case 's':
+          sectsize = atoi(optarg);
           break;
 
         case '?':
@@ -777,7 +782,7 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
       setup.devname  = loopdev;   /* The loop block device to be created */
       setup.filename = filepath;  /* The file or character device to use */
-      setup.sectsize = 512;       /* The sector size to use with the block device */
+      setup.sectsize = sectsize;  /* The sector size to use with the block device */
       setup.offset   = offset;    /* An offset that may be applied to the device */
       setup.readonly = readonly;  /* True: Read access will be supported only */
 


### PR DESCRIPTION
## Summary
nshlib/nsh_fscmds.c: Make losetup command take optional sector size

## Impact
losetup command

## Testing
tested with littlefs, sim/macOS, https://github.com/apache/incubator-nuttx/pull/6023
