### PR TITLE
netutils/ping: skip the id check

### DIFF
--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -315,12 +315,15 @@ void icmp_ping(FAR const struct ping_info_s *info)
 
           if (inhdr->type == ICMP_ECHO_REPLY)
             {
+#ifndef CONFIG_SIM_NETUSRSOCK
               if (ntohs(inhdr->id) != result.id)
                 {
                   icmp_callback(&result, ICMP_W_IDDIFF, ntohs(inhdr->id));
                   retry = true;
                 }
-              else if (ntohs(inhdr->seqno) > result.seqno)
+              else
+#endif
+              if (ntohs(inhdr->seqno) > result.seqno)
                 {
                   icmp_callback(&result, ICMP_W_SEQNOBIG,
                                 ntohs(inhdr->seqno));

--- a/netutils/ping/icmpv6_ping.c
+++ b/netutils/ping/icmpv6_ping.c
@@ -314,12 +314,15 @@ void icmp6_ping(FAR const struct ping6_info_s *info)
 
           if (inhdr->type == ICMPv6_ECHO_REPLY)
             {
+#ifndef CONFIG_SIM_NETUSRSOCK
               if (ntohs(inhdr->id) != result.id)
                 {
                   icmp6_callback(&result, ICMPv6_W_IDDIFF, ntohs(inhdr->id));
                   retry = true;
                 }
-              else if (ntohs(inhdr->seqno) > result.seqno)
+              else
+#endif
+              if (ntohs(inhdr->seqno) > result.seqno)
                 {
                   icmp6_callback(&result, ICMPv6_W_SEQNOBIG,
                                  ntohs(inhdr->seqno));


### PR DESCRIPTION
## Summary
https://joekuan.wordpress.com/2017/05/30/behaviour-of-identifier-field-in-icmp-ping-as-udp-between-linux-and-osx/
https://lwn.net/Articles/443051/

https: //github.com/apache/incubator-nuttx-apps/blob/master/netutils/ping/icmp_ping.c#L298

## Impact
ping on sim

## Testing

