### PR TITLE
wireless: gs2200m: Fix recvfrom_request() in gs2200m_main.c

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -884,6 +884,7 @@ static int recvfrom_request(int fd, FAR struct gs2200m_s *priv,
 {
   FAR struct usrsock_request_recvfrom_s *req = hdrbuf;
   struct usrsock_message_datareq_ack_s resp;
+  struct usrsock_message_req_ack_s resp1;
   struct gs2200m_recv_msg rmsg;
   FAR struct usock_s *usock;
   int ret = 0;
@@ -967,6 +968,14 @@ prepare:
           usock_send_event(fd, priv, usock,
                            USRSOCK_EVENT_REMOTE_CLOSED
                            );
+
+          /* Send ack only */
+
+          memset(&resp1, 0, sizeof(resp1));
+          resp1.result = ret;
+          ret = _send_ack_common(fd, req->head.xid, &resp1);
+
+          goto err_out;
         }
     }
 


### PR DESCRIPTION
## Summary

- I noticed that wget causes ASSERT in gs2200m_main.c recently.
- Finally, I found that it sends a wrong ack message in
  recvfrom_request() when the socket is closed passively
- This commit fixes this issue.

## Impact

- gs2200m only

## Testing

- Tested with spresense:wifi_smp
