### PR TITLE
testing/ostest: remove CONFIG_TESTING_OSTEST_FPUSIZE

### DIFF
--- a/testing/ostest/Kconfig
+++ b/testing/ostest/Kconfig
@@ -86,10 +86,6 @@ config TESTING_OSTEST_FPUTESTDISABLE
 
 if !TESTING_OSTEST_FPUTESTDISABLE
 
-config TESTING_OSTEST_FPUSIZE
-	int "Size of floating point register save area"
-	default 0
-
 config TESTING_OSTEST_FPULOOPS
 	int "Number of FPU test loops"
 	default 16


### PR DESCRIPTION

## Summary

testing/ostest: remove CONFIG_TESTING_OSTEST_FPUSIZE

fptest should not need to care about the size of FPU

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact
fpu test

## Testing
 ./tools/configure.sh sabre-6quad/smp
ostest