### PR TITLE
nshlib/nsh_fileapps.c: Pass global environ instead of NULL for posix_spawnp

### DIFF
--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -30,6 +30,7 @@
 #endif
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <spawn.h>
 #include <errno.h>
 #include <string.h>
@@ -126,7 +127,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
    * failure.
    */
 
-  ret = posix_spawnp(&pid, cmd, &file_actions, &attr, argv, NULL);
+  ret = posix_spawnp(&pid, cmd, &file_actions, &attr, argv, environ);
   if (ret == OK)
     {
       /* The application was successfully started with pre-emption disabled.


### PR DESCRIPTION

Now that the environ pointer is a list of pointers-to-string, it can be
passed to the standard posix_spawn function as-is.

## Summary

## Impact

## Testing
icicle:nsh & icicle:knsh
