### PR TITLE
interpreters/ficl: add double include guard to nuttx.h

### DIFF
--- a/interpreters/ficl/src/nuttx.h
+++ b/interpreters/ficl/src/nuttx.h
@@ -18,6 +18,9 @@
  *
  ***************************************************************************/
 
+#ifndef __APPS_INTERPRETERS_FICL_SRC_NUTTX_H
+#define __APPS_INTERPRETERS_FICL_SRC_NUTTX_H
+
 /***************************************************************************
  * Included Files
  ***************************************************************************/
@@ -41,3 +44,5 @@ typedef float ficlFloat;
 
 #define FICL_PLATFORM_OS            "ansi"
 #define FICL_PLATFORM_ARCHITECTURE  "unknown"
+
+#endif /* __APPS_INTERPRETERS_FICL_SRC_NUTTX_H */


### PR DESCRIPTION
## Summary
Add double include guard to nuttx.h

## Impact
None

## Testing
Pass CI