### PR TITLE
apps/ping: fix ping statistics error problem

### DIFF
--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -329,18 +329,16 @@ void icmp_ping(FAR const struct ping_info_s *info)
                                 ntohs(inhdr->seqno));
                   retry = true;
                 }
+              else if (ntohs(inhdr->seqno) < result.seqno)
+                {
+                  icmp_callback(&result, ICMP_W_SEQNOSMALL,
+                                ntohs(inhdr->seqno));
+                  retry = true;
+                }
               else
                 {
                   bool verified = true;
                   long pktdelay = elapsed;
-
-                  if (ntohs(inhdr->seqno) < result.seqno)
-                    {
-                      icmp_callback(&result, ICMP_W_SEQNOSMALL,
-                                    ntohs(inhdr->seqno));
-                      pktdelay += info->delay * USEC_PER_MSEC;
-                      retry     = true;
-                    }
 
                   icmp_callback(&result, ICMP_I_ROUNDTRIP, pktdelay);
 

--- a/netutils/ping/icmpv6_ping.c
+++ b/netutils/ping/icmpv6_ping.c
@@ -328,18 +328,16 @@ void icmp6_ping(FAR const struct ping6_info_s *info)
                                  ntohs(inhdr->seqno));
                   retry = true;
                 }
+              else if (ntohs(inhdr->seqno) < result.seqno)
+                {
+                  icmp6_callback(&result, ICMPv6_W_SEQNOSMALL,
+                                 ntohs(inhdr->seqno));
+                  retry = true;
+                }
               else
                 {
                   bool verified = true;
                   long pktdelay = elapsed;
-
-                  if (ntohs(inhdr->seqno) < result.seqno)
-                    {
-                      icmp6_callback(&result, ICMPv6_W_SEQNOSMALL,
-                                     ntohs(inhdr->seqno));
-                      pktdelay += info->delay * USEC_PER_MSEC;
-                      retry     = true;
-                    }
 
                   icmp6_callback(&result, ICMPv6_I_ROUNDTRIP, pktdelay);
 


### PR DESCRIPTION
## Summary
Fix bug in ping result.

nsh> ping 192.168.31.162
PING 192.168.31.162 56 bytes of data
56 bytes from 192.168.31.162: icmp_seq=0 time=8 ms
56 bytes from 192.168.31.162: icmp_seq=1 time=27 ms
56 bytes from 192.168.31.162: icmp_seq=2 time=17 ms
56 bytes from 192.168.31.162: icmp_seq=3 time=14 ms
56 bytes from 192.168.31.162: icmp_seq=4 time=16 ms
56 bytes from 192.168.31.162: icmp_seq=5 time=14 ms
56 bytes from 192.168.31.162: icmp_seq=6 time=8 ms
56 bytes from 192.168.31.162: icmp_seq=7 time=87 ms
WARNING: Received after timeout
56 bytes from 192.168.31.162: icmp_seq=8 time=1003 ms
56 bytes from 192.168.31.162: icmp_seq=8 time=6 ms
56 bytes from 192.168.31.162: icmp_seq=9 time=5 ms
10 packets transmitted, 11 received, 4294967287% packet loss, time 10011 ms

## Impact
None.

## Testing
Pass.
