### PR TITLE
import/Make.defs: Fix C++ library linkage with CONFIG_BUILD_KERNEL

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -132,7 +132,7 @@ endef
 
 define ELFLD
 	@echo "LD: $2"
-	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) $(ARCHCRT0OBJ) $1 $(LDLIBS) -o $2
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) $(ARCHCRT0OBJ) $1 $(LDSTARTGROUP) $(LDLIBS) $(LDENDGROUP) -o $2
 endef
 
 $(RAOBJS): %.s$(SUFFIX)$(OBJEXT): %.s


### PR DESCRIPTION
lxx must be before lmm at least, because new uses malloc().

## Summary
Fixes C++ library linkage with CONFIG_BUILD_KERNEL
## Impact

## Testing
icicle:knsh
