### PR TITLE
libuv: Don't add idna.c to CSRCS if test enabled

### DIFF
--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -69,7 +69,9 @@ CSRCS += posix-hrtime.c
 CSRCS += posix-poll.c
 CSRCS += uv-data-getter-setters.c
 CSRCS += version.c
+ifneq ($(CONFIG_LIBUV_UTILS_TEST),)
 CSRCS += idna.c
+endif
 CSRCS += no-fsevents.c
 CSRCS += uv-common.c
 CSRCS += strscpy.c


### PR DESCRIPTION
## Summary
test-idna.c will include idna.c and then cause multiple definition.
## Impact
libuv test suite only
## Testing
custom board
