### PR TITLE
nxwm: Fix warning about on_exit() dependency

### DIFF
--- a/include/graphics/nxwm/nxwmconfig.hxx
+++ b/include/graphics/nxwm/nxwmconfig.hxx
@@ -79,8 +79,8 @@
  * exit.
  */
 
-#ifndef CONFIG_SCHED_ONEXIT
-#  warning "on_exit() support may be needed (CONFIG_SCHED_ONEXIT)"
+#if CONFIG_LIBC_MAX_EXITFUNS == 0
+#  warning "on_exit() support may be needed (CONFIG_LIBC_MAX_EXITFUNS)"
 #endif
 
 /**


### PR DESCRIPTION
## Summary
Follow up to kernel side https://github.com/apache/incubator-nuttx/pull/6197
## Impact

## Testing

