### PR TITLE
interpreters/wamr/Kconfig: enable text heap when necessary

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -33,6 +33,7 @@ endif
 
 config INTERPRETERS_WAMR_AOT
 	bool "Enable AOT"
+	select ARCH_USE_TEXT_HEAP if ARCH_HAVE_TEXT_HEAP
 	default n
 
 choice


### PR DESCRIPTION
## Summary
aot requires executable memory. make it explicit in Kconfig.

## Impact

## Testing
tested on esp32

