### PR TITLE
netutils/dhcpc: Change the timeout unit to milliseconds

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -18,8 +18,8 @@ config NETUTILS_DHCPC_HOST_NAME
 	default "nuttx"
 
 config NETUTILS_DHCPC_RECV_TIMEOUT
-	int "Number of receive timeout in second"
-	default 3
+	int "Number of receive timeout in millisecond"
+	default 3000
 	---help---
 		This is the timeout value when dhcp client receives response
 

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -552,8 +552,8 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
 
       /* Configure for read timeouts */
 
-      tv.tv_sec  = CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT;
-      tv.tv_usec = 0;
+      tv.tv_sec  = CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT / 1000;
+      tv.tv_usec = (CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT % 1000) * 1000;
 
       ret = setsockopt(pdhcpc->sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv,
                        sizeof(struct timeval));


### PR DESCRIPTION
## Summary
netutils/dhcpc: Change the timeout unit to milliseconds
## Impact
None
## Testing
bl602evb:wifi