### PR TITLE
interpreters/wamr: Remove WAMR_VERSION_STUB and always use actual tags

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -11,9 +11,9 @@ if INTERPRETERS_WAMR
 
 config INTERPRETERS_WAMR_VERSION
 	string "WAMR Version"
-	default "04-15-2021"
+	default "WAMR-04-15-2021"
 	---help---
-	Version 09-29-2020 and later (include main) supported.
+	Version WAMR-09-29-2020 and later (include main) supported.
 
 config INTERPRETERS_IWASM_TASK
 	bool "Webassembly iwasm task"

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -23,16 +23,7 @@ include $(APPDIR)/Make.defs
 WAMR_VERSION  = $(patsubst "%",%,$(strip $(CONFIG_INTERPRETERS_WAMR_VERSION)))
 WAMR_UNPACK   = wamr
 
-# Tarball of main branch and tagged release have little difference
-# in name after unpack and URL
-
-ifeq ($(WAMR_VERSION), main)
-WAMR_VERSION_STUB  = 
-else
-WAMR_VERSION_STUB  = WAMR-
-endif
-
-WAMR_TARBALL  = $(WAMR_VERSION_STUB)$(WAMR_VERSION).zip
+WAMR_TARBALL  = $(WAMR_VERSION).zip
 WAMR_URL_BASE = https://github.com/bytecodealliance/wasm-micro-runtime/archive/
 WAMR_URL      = $(WAMR_URL_BASE)/$(WAMR_TARBALL)
 
@@ -56,7 +47,7 @@ $(WAMR_TARBALL):
 $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) echo "Unpacking $(WAMR_TARBALL) to $(WAMR_UNPACK)"
 	$(Q) unzip $(WAMR_TARBALL)
-	$(Q) mv wasm-micro-runtime-$(WAMR_VERSION_STUB)$(WAMR_VERSION) $(WAMR_UNPACK)
+	$(Q) mv wasm-micro-runtime-$(WAMR_VERSION) $(WAMR_UNPACK)
 	$(Q) touch $(WAMR_UNPACK)
 
 context:: $(WAMR_UNPACK)


### PR DESCRIPTION
## Summary

This allows to use a commit sha1 for CONFIG_INTERPRETERS_WAMR_VERSION.

Note: the existing configs with specific wamr version
need to be updated.

Tested with:
CONFIG_INTERPRETERS_WAMR_VERSION=main
CONFIG_INTERPRETERS_WAMR_VERSION=WAMR-04-15-2021
CONFIG_INTERPRETERS_WAMR_VERSION=3168ba8dcf20d9d8539d75c637420f5fd8682335

## Impact

## Testing

