### PR TITLE
system/libuv: Skip compile strscpy.c when CONFIG_LIBUV_UTILS_TEST enable

### DIFF
--- a/system/libuv/0001-libuv-port-for-nuttx.patch
+++ b/system/libuv/0001-libuv-port-for-nuttx.patch
@@ -1900,20 +1900,6 @@ index 10cbf95e..7de04a91 100644
    uv_idle_init(uv_default_loop(), &idle_handle);
    uv_idle_start(&idle_handle, idle_cb);
  
-diff --git a/test/test-strscpy.c b/test/test-strscpy.c
-index 4e7db6ff..f1d3e3ac 100644
---- a/test/test-strscpy.c
-+++ b/test/test-strscpy.c
-@@ -24,7 +24,9 @@
- #include <string.h>
- 
- #include "../src/strscpy.h"
-+#ifndef __NuttX__
- #include "../src/strscpy.c"
-+#endif
- 
- TEST_IMPL(strscpy) {
-   char d[4];
 diff --git a/test/test-thread.c b/test/test-thread.c
 index 8de5a6f0..11e3cf80 100644
 --- a/test/test-thread.c

--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -69,7 +69,7 @@ CSRCS += posix-hrtime.c
 CSRCS += posix-poll.c
 CSRCS += uv-data-getter-setters.c
 CSRCS += version.c
-ifneq ($(CONFIG_LIBUV_UTILS_TEST),)
+ifeq ($(CONFIG_LIBUV_UTILS_TEST),)
 CSRCS += idna.c
 CSRCS += strscpy.c
 endif

--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -71,10 +71,10 @@ CSRCS += uv-data-getter-setters.c
 CSRCS += version.c
 ifneq ($(CONFIG_LIBUV_UTILS_TEST),)
 CSRCS += idna.c
+CSRCS += strscpy.c
 endif
 CSRCS += no-fsevents.c
 CSRCS += uv-common.c
-CSRCS += strscpy.c
 CSRCS += random-devurandom.c
 CSRCS += random.c
 CSRCS += nuttx.c


### PR DESCRIPTION
## Summary

## Impact
fix the linker error when compile libuv test

## Testing
Pass CI
