### PR TITLE
webclient.h: Avoid relying on indirect inclusion

### DIFF
--- a/include/netutils/webclient.h
+++ b/include/netutils/webclient.h
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Include stdint.h for uint16_t explicitly.

This was necessary when I was trying to build this natively
on Ubuntu.  It seems some other headers happen to pull
the uint16_t definition by luck on NuttX and macOS.

## Impact

## Testing

