### PR TITLE
Address #1190 -- EXAMPLES_ELF_CXX broken w/o exceptions

### DIFF
--- a/examples/elf/tests/helloxx/Makefile
+++ b/examples/elf/tests/helloxx/Makefile
@@ -114,7 +114,7 @@ $(BIN3): $(OBJS3)
 # NOTE:  libstdc++ is not available for NuttX as of this writing
 #
 ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
-ifeq ($(CXX_EXCEPTION),y) 
+ifeq ($(CONFIG_CXX_EXCEPTION),y)
 $(BIN4): $(OBJS4)
 	@echo "LD: $<"
 	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $@ $(ARCHCRT0OBJ) $^ $(LDLIBS)

--- a/examples/elf/tests/helloxx/Makefile
+++ b/examples/elf/tests/helloxx/Makefile
@@ -110,16 +110,18 @@ $(BIN3): $(OBJS3)
 	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $@ $(ARCHCRT0OBJ) $^ $(LDLIBS)
 
 # BIN4 is similar to BIN3 except that it uses the streams code from libstdc++
-#
+# Both BIN4 and BIN5 use exceptions
 # NOTE:  libstdc++ is not available for NuttX as of this writing
 #
 ifeq ($(CONFIG_EXAMPLES_ELF_CXX),y)
+ifeq ($(CXX_EXCEPTION),y) 
 $(BIN4): $(OBJS4)
 	@echo "LD: $<"
 	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $@ $(ARCHCRT0OBJ) $^ $(LDLIBS)
 $(BIN5): $(OBJS5)
 	@echo "LD: $<"
 	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $@ $(ARCHCRT0OBJ) $^ $(LDLIBS)
+endif
 endif
 endif
 


### PR DESCRIPTION
Should guard against these being included if exception support isn't there. Fixes https://github.com/apache/incubator-nuttx-apps/issues/1190

## Summary
https://github.com/apache/incubator-nuttx-apps/issues/1190 these two require exception support
## Impact
Broken example
## Testing
Works on my machine (tm)
