### PR TITLE
wireless/wapi: fix wapi wpa_wconfig_s sta_mode data type error

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -271,7 +271,7 @@ enum wpa_alg_e
 
 struct wpa_wconfig_s
 {
-  uint8_t sta_mode;              /* Mode of operation, e.g. IW_MODE_INFRA */
+  enum wapi_mode_e sta_mode;     /* Mode of operation, e.g. IW_MODE_INFRA */
   uint8_t auth_wpa;              /* IW_AUTH_WPA_VERSION values, e.g.
                                   * IW_AUTH_WPA_VERSION_WPA2 */
   uint8_t cipher_mode;           /* IW_AUTH_PAIRWISE_CIPHER and


### PR DESCRIPTION
## Summary
Similar to #1134: This fixes the sta_mode field data type which causes:
```c
src/wapi.c: In function 'wapi_save_config_cmd':
src/wapi.c:866:38: warning: passing argument 3 of 'wapi_get_mode' from incompatible pointer type [-Wincompatible-pointer-types]
  866 |   ret = wapi_get_mode(sock, argv[0], &conf.sta_mode);
      |                                      ^~~~~~~~~~~~~~
      |                                      |
      |                                      uint8_t * {aka unsigned char *}
In file included from src/wapi.c:55:
../apps/include/wireless/wapi.h:508:41: note: expected 'enum wapi_mode_e *' but argument is of type 'uint8_t *' {aka 'unsigned char *'}
  508 |                   FAR enum wapi_mode_e *mode);
      |                       ~~~~~~~~~~~~~~~~~~^~~~
```

## Impact
Make `wireless/wapi` compile without warnings.

## Testing
Built wapi, and used it to save_config (which was broken without the fix from #1134 and continues to work with this fix)