### PR TITLE
testing/irtest: Fix issue of failure to open multiple IR devices

### DIFF
--- a/testing/irtest/cmd.cxx
+++ b/testing/irtest/cmd.cxx
@@ -189,11 +189,13 @@ CMD1(open_device, const char *, file_name)
     }
 
   int index = 0;
-  for (; index < CONFIG_TESTING_IRTEST_MAX_NIRDEV &&
-       g_irdevs[index] == -1; index++)
+  for (; index < CONFIG_TESTING_IRTEST_MAX_NIRDEV; index++)
     {
-      g_irdevs[index] = irdev;
-      break;
+      if (g_irdevs[index] == -1)
+        {
+          g_irdevs[index] = irdev;
+          break;
+        }
     }
 
   if (index == CONFIG_TESTING_IRTEST_MAX_NIRDEV)


### PR DESCRIPTION
## Summary

Fix issue of failure to open multiple IR devices.

## Impact

## Testing

`irtest`