### PR TITLE
.github/workflows: Add nuttx/source to the safe directory 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
             mkdir $CCACHE_DIR
             export ARTIFACTDIR=`pwd`/buildartifacts
             git config --global --add safe.directory /github/workspace/sources/nuttx
+            git config --global --add safe.directory /github/workspace/sources/apps
             cd sources/nuttx/tools/ci
             ./cibuild.sh -A -c testlist/${{matrix.boards}}.dat
             ccache -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
             export CCACHE_DIR=`pwd`/ccache
             mkdir $CCACHE_DIR
             export ARTIFACTDIR=`pwd`/buildartifacts
+            git config --global --add safe.directory /github/workspace/sources/nuttx
             cd sources/nuttx/tools/ci
             ./cibuild.sh -A -c testlist/${{matrix.boards}}.dat
             ccache -s


### PR DESCRIPTION
## Summary
Follow the nuttx side change: https://github.com/apache/incubator-nuttx/pull/6509

## Impact
Fix the ci broken

## Testing
Pass CI
