### PR TITLE
dhcpc: Rename timeout Kconfig

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -17,7 +17,7 @@ config NETUTILS_DHCPC_HOST_NAME
 	string "DHCP client host name"
 	default "nuttx"
 
-config NETUTILS_DHCPC_RECV_TIMEOUT
+config NETUTILS_DHCPC_RECV_TIMEOUT_MS
 	int "Number of receive timeout in millisecond"
 	default 3000
 	---help---

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -552,8 +552,8 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
 
       /* Configure for read timeouts */
 
-      tv.tv_sec  = CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT / 1000;
-      tv.tv_usec = (CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT % 1000) * 1000;
+      tv.tv_sec  = CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT_MS / 1000;
+      tv.tv_usec = (CONFIG_NETUTILS_DHCPC_RECV_TIMEOUT_MS % 1000) * 1000;
 
       ret = setsockopt(pdhcpc->sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv,
                        sizeof(struct timeval));


### PR DESCRIPTION
## Summary

NETUTILS_DHCPC_RECV_TIMEOUT -> NETUTILS_DHCPC_RECV_TIMEOUT_MS

Recently its unit has been changed from second to millisecond. [1]
Using the same Kconfig name for a different meaning is a pitfall
for an upgrade. I was using 3ms timeout because of this.

This commit renames it so that at least the default value
is used for a careless user like me.

[1]
```
commit 8fd4b6105be2a535ecea2312858602d9ffa4e670
Author: zrrong <zrrong@bouffalolab.com>
Date:   Fri May 27 11:35:23 2022 +0800

    netutils/dhcpc: Change the timeout unit to milliseconds
```



## Impact

## Testing

