### PR TITLE
apps: Fix make distclean for CONFIG_BUILD_KERNEL=y

### DIFF
--- a/Directory.mk
+++ b/Directory.mk
@@ -26,6 +26,7 @@ SUBDIRS       := $(dir $(wildcard *$(DELIM)Makefile))
 CONFIGSUBDIRS := $(filter-out $(dir $(wildcard *$(DELIM)Kconfig)),$(SUBDIRS))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).depend))
 CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).kconfig))
+CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).context))
 CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))
 
 all: nothing

--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -84,9 +84,11 @@ $(MCUBOOT_UNPACK): $(MCUBOOT_TARBALL)
 	$(Q) touch $(MCUBOOT_UNPACK)
 
 context:: $(MCUBOOT_UNPACK)
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, $(MCUBOOT_TARBALL))
 	$(call DELDIR, $(MCUBOOT_UNPACK))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/canutils/libcanard/Makefile
+++ b/canutils/libcanard/Makefile
@@ -58,6 +58,7 @@ $(APPS_INCDIR)$(DELIM)canard_nuttx.h: $(LIBCANARD_DRVDIR)$(DELIM)canard_nuttx.h
 	$(Q) cp $< $@
 
 context:: $(APPS_INCDIR)$(DELIM)canard.h $(APPS_INCDIR)$(DELIM)canard_nuttx.h
+	$(Q) touch .context
 
 clean::
 	$(foreach OBJ, $(OBJS), $(call DELFILE, $(OBJ)))
@@ -67,5 +68,6 @@ distclean::
 	$(call DELFILE, $(APPS_INCDIR)$(DELIM)canard_nuttx.h)
 	$(call DELDIR, $(LIBCANARD_UNPACKNAME))
 	$(call DELFILE, $(LIBCANARD_PACKNAME))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/crypto/libtomcrypt/Makefile
+++ b/crypto/libtomcrypt/Makefile
@@ -477,9 +477,11 @@ $(LIBTOMCRYPT_UNPACKNAME): $(LIBTOMCRYPT_ZIP)
 	$(Q) touch $(LIBTOMCRYPT_UNPACKNAME)
 
 context:: $(LIBTOMCRYPT_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(LIBTOMCRYPT_UNPACKNAME))
 	$(call DELFILE, $(LIBTOMCRYPT_ZIP))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -51,10 +51,12 @@ $(MBEDTLS_UNPACKNAME): $(MBEDTLS_ZIP)
 	$(Q) touch $(MBEDTLS_UNPACKNAME)
 
 context:: $(MBEDTLS_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(MBEDTLS_UNPACKNAME))
 	$(call DELFILE, $(MBEDTLS_ZIP))
+	$(call DELFILE, .context)
 
 # Configuration Applications
 

--- a/examples/bastest/Makefile
+++ b/examples/bastest/Makefile
@@ -49,9 +49,11 @@ $(ROMFS_HDR) : $(ROMFS_IMG)
 # Add the BASTEST object to the archive
 
 context:: $(ROMFS_HDR)
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, $(ROMFS_HDR))
 	$(call DELFILE, $(ROMFS_IMG))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/bridge/Makefile
+++ b/examples/bridge/Makefile
@@ -62,6 +62,7 @@ $(HOST_BIN2): $(HOST_OBJS2)
 	$(Q) $(HOSTCC) $(HOSTLDFLAGS) $(HOST_OBJS2) -o $@
 
 context:: $(HOST_BIN1) $(HOST_BIN2)
+	$(Q) touch .context
 
 clean::
 	$(call DELFILE, $(HOST_BIN1))
@@ -69,5 +70,6 @@ clean::
 
 distclean::
 	$(call DELFILE, bridge_config.h)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/cromfs/Makefile
+++ b/examples/cromfs/Makefile
@@ -37,8 +37,10 @@ cromfs.c: $(NXTOOLDIR)$(DELIM)$(GENCROMFSEXE)
 	$(Q) $(NXTOOLDIR)$(DELIM)$(GENCROMFSEXE) cromfs cromfs.c
 
 context:: cromfs.c
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, cromfs.c)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/flowc/Makefile
+++ b/examples/flowc/Makefile
@@ -89,6 +89,7 @@ $(HOST_BIN): $(HOST_OBJS)
 endif
 
 context:: config.h $(HOST_BIN)
+	$(Q) touch .context
 
 clean::
 ifneq ($(CONFIG_EXAMPLES_FLOWC_TARGET2),y)
@@ -97,6 +98,7 @@ ifneq ($(CONFIG_EXAMPLES_FLOWC_TARGET2),y)
 	$(call DELFILE, *.dSYM)
 endif
 	$(call DELFILE, config.h)
+	$(call DELFILE, .context)
 
 MODULE = $(CONFIG_EXAMPLES_FLOWC)
 

--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -88,9 +88,11 @@ $(LVGL_EXAMPLES_UNPACKNAME): $(LVGL_EXAMPLES_TARBALL)
 	$(Q) touch $(LVGL_EXAMPLES_UNPACKNAME)
 
 context:: $(LVGL_EXAMPLES_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(LVGL_EXAMPLES_UNPACKNAME))
 	$(call DELFILE, $(LVGL_EXAMPLES_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/nettest/Makefile
+++ b/examples/nettest/Makefile
@@ -114,6 +114,7 @@ endif
 endif
 
 context:: config.h $(HOST_BIN)
+	$(Q) touch .context
 
 clean::
 ifneq ($(CONFIG_EXAMPLES_NETTEST_TARGET2),y)
@@ -124,6 +125,7 @@ ifneq ($(CONFIG_EXAMPLES_NETTEST_LOOPBACK),y)
 endif
 endif
 	$(call DELFILE, config.h)
+	$(call DELFILE, .context)
 
 MODULE = $(CONFIG_EXAMPLES_NETTEST)
 

--- a/examples/romfs/Makefile
+++ b/examples/romfs/Makefile
@@ -50,10 +50,12 @@ romfs_testdir.h : testdir.img
 	@xxd -i $< >$@ || { echo "xxd of $< failed" ; exit 1 ; }
 
 context:: romfs_testdir.h
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, testdir.img)
 	$(call DELFILE, romfs_testdir.h)
 	$(call DELDIR, testdir)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/tcpblaster/Makefile
+++ b/examples/tcpblaster/Makefile
@@ -111,6 +111,7 @@ endif
 endif
 
 context:: config.h $(HOST_BIN)
+	$(Q) touch .context
 
 clean::
 ifneq ($(CONFIG_EXAMPLES_TCPBLASTER_TARGET2),y)
@@ -121,6 +122,7 @@ ifneq ($(CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK),y)
 endif
 endif
 	$(call DELFILE, config.h)
+	$(call DELFILE, .context)
 
 MODULE = $(CONFIG_EXAMPLES_TCPBLASTER)
 

--- a/examples/thttpd/Makefile
+++ b/examples/thttpd/Makefile
@@ -56,11 +56,13 @@ build:
 
 context::
 	+$(Q) $(CONTENT_MAKE) context TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) touch .context
 
 clean::
 	+$(Q) $(CONTENT_MAKE) clean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
 
 distclean::
 	+$(Q) $(CONTENT_MAKE) distclean TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" CROSSDEV=$(CROSSDEV)
+	+$(Q) $(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/examples/udp/Makefile
+++ b/examples/udp/Makefile
@@ -97,6 +97,7 @@ $(HOST_BIN): $(HOST_OBJS)
 endif
 
 context:: config.h $(HOST_BIN)
+	$(Q) touch .context
 
 clean::
 ifneq ($(CONFIG_EXAMPLES_UDP_TARGET2),y)
@@ -105,6 +106,7 @@ ifneq ($(CONFIG_EXAMPLES_UDP_TARGET2),y)
 	$(call DELFILE, *.dSYM)
 endif
 	$(call DELFILE, config.h)
+	$(call DELFILE, .context)
 
 MODULE = $(CONFIG_EXAMPLES_UDP)
 

--- a/examples/udpblaster/Makefile
+++ b/examples/udpblaster/Makefile
@@ -60,6 +60,7 @@ $(HOST_BIN): $(HOST_OBJS)
 endif
 
 context:: config.h $(HOST_BIN)
+	$(Q) touch .context
 
 clean::
 ifneq ($(CONFIG_EXAMPLES_UDPBLASTER_LOOPBACK),y)
@@ -68,6 +69,7 @@ ifneq ($(CONFIG_EXAMPLES_UDPBLASTER_LOOPBACK),y)
 	$(call DELFILE, *.dSYM)
 endif
 	$(call DELFILE, config.h)
+	$(call DELFILE, .context)
 
 MODULE = $(CONFIG_EXAMPLES_UDPBLASTER)
 

--- a/examples/unionfs/Makefile
+++ b/examples/unionfs/Makefile
@@ -53,11 +53,13 @@ romfs_btestdir.h : btestdir.img
 	@xxd -i $< >$@ || { echo "xxd of $< failed" ; exit 1 ; }
 
 context:: romfs_atestdir.h romfs_btestdir.h
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, atestdir.img)
 	$(call DELFILE, btestdir.img)
 	$(call DELFILE, romfs_atestdir.h)
 	$(call DELFILE, romfs_btestdir.h)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/fsutils/inih/Makefile
+++ b/fsutils/inih/Makefile
@@ -79,6 +79,7 @@ create_includes:
 
 context:: $(INIH_SOURCES)
 	$(Q) $(MAKE) create_includes
+	$(Q) touch .context
 
 clean::
 	$(Q) $(call DELFILE, $(APPDIR)/include/fsutils/ini.h)
@@ -87,5 +88,6 @@ clean::
 distclean::
 	$(Q) $(call DELDIR, $(INIH_SOURCES))
 	$(Q) $(call DELDIR, $(INIH_TARBALL))
+	$(Q) $(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -71,9 +71,11 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
 context:: $(LVGL_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(LVGL_UNPACKNAME))
 	$(call DELFILE, $(LVGL_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -63,9 +63,11 @@ $(DUKTAPE_UNPACK)/.patch: $(DUKTAPE_UNPACK)
 	$(Q) touch $(DUKTAPE_UNPACK)/.patch
 
 context:: $(DUKTAPE_UNPACK)/.patch
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(DUKTAPE_UNPACK))
 	$(call DELFILE, $(DUKTAPE_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/interpreters/lua/Makefile
+++ b/interpreters/lua/Makefile
@@ -76,6 +76,7 @@ $(LUA_UNPACK): $(LUA_TARBALL)
 	$(Q) tar -xvzf $(LUA_TARBALL)
 
 context:: $(LUA_UNPACK)
+	$(Q) touch .context
 
 # Register core modules
 
@@ -131,5 +132,6 @@ distclean:: clean_context clean
 	$(call DELFILE, registry$(DELIM).updated)
 	$(call DELDIR, $(LUA_UNPACK))
 	$(call DELFILE, $(LUA_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/interpreters/quickjs/Makefile
+++ b/interpreters/quickjs/Makefile
@@ -82,6 +82,7 @@ build_host: $(QUICKJS_UNPACK)/.patch
 		CONFIG_BIGNUM=$(CONFIG_INTERPRETERS_QUICKJS_BIGNUM)
 
 context:: build_host
+	$(Q) touch .context
 
 clean::
 	$(Q) test ! -d $(QUICKJS_UNPACK) || make -C $(QUICKJS_UNPACK) clean
@@ -89,5 +90,6 @@ clean::
 distclean::
 	$(call DELDIR, $(QUICKJS_UNPACK))
 	$(call DELFILE, $(QUICKJS_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -51,9 +51,11 @@ $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) touch $(WAMR_UNPACK)
 
 context:: $(WAMR_UNPACK)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(WAMR_UNPACK))
 	$(call DELFILE, $(WAMR_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/interpreters/wasm3/Makefile
+++ b/interpreters/wasm3/Makefile
@@ -72,9 +72,11 @@ $(WASM3_UNPACK)/.patch: $(WASM3_UNPACK)
 	$(Q) touch $(WASM3_UNPACK)/.patch
 
 context:: $(WASM3_UNPACK)/.patch
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(WASM3_UNPACK))
 	$(call DELFILE, $(WASM3_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/math/libtommath/Makefile
+++ b/math/libtommath/Makefile
@@ -104,9 +104,11 @@ $(LIBTOMMATH_UNPACKNAME): $(LIBTOMMATH_ZIP)
 	$(Q) touch $(LIBTOMMATH_UNPACKNAME)
 
 context:: $(LIBTOMMATH_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(LIBTOMMATH_UNPACKNAME))
 	$(call DELFILE, $(LIBTOMMATH_ZIP))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/mlearning/cmsis/Makefile
+++ b/mlearning/cmsis/Makefile
@@ -27,9 +27,11 @@ cmsis.zip:
 	$(Q) patch -p0 < cmsis-nn-support_nnabla.patch
 
 context:: cmsis.zip
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, CMSIS_5)
 	$(call DELFILE, cmsis.zip)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/mlearning/darknet/Makefile
+++ b/mlearning/darknet/Makefile
@@ -80,10 +80,12 @@ darknet.zip:
 	$(Q) mv darknet-$(DARKNET_YOLO_VER) darknet
 
 context:: darknet.zip
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, darknet)
 	$(call DELFILE, darknet.zip)
+	$(call DELFILE, .context)
 
 endif
 

--- a/mlearning/libnnablart/Makefile
+++ b/mlearning/libnnablart/Makefile
@@ -116,10 +116,12 @@ nnabla.zip:
 	$(Q) mv nnabla-c-runtime-$(CONFIG_NNABLA_RT_VER) nnabla-c-runtime
 
 context:: nnabla.zip
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, nnabla-c-runtime)
 	$(call DELFILE, nnabla.zip)
+	$(call DELFILE, .context)
 
 endif
 

--- a/netutils/cjson/Makefile
+++ b/netutils/cjson/Makefile
@@ -66,11 +66,13 @@ $(APPS_INCDIR)$(DELIM)cJSON_Utils.h: $(CJSON_SRCDIR)$(DELIM)cJSON_Utils.h
 	$(Q) cp $< $@
 
 context:: $(APPS_INCDIR)$(DELIM)cJSON.h $(APPS_INCDIR)$(DELIM)cJSON_Utils.h
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(CJSON_UNPACKNAME))
 	$(call DELFILE, $(CJSON_TARBALL))
 	$(call DELFILE, $(APPDIR)/include/netutils/cJSON.h)
 	$(call DELFILE, $(APPDIR)/include/netutils/cJSON_Utils.h)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/netutils/mqttc/Makefile
+++ b/netutils/mqttc/Makefile
@@ -40,9 +40,11 @@ $(MQTTC_UNPACK): $(MQTTC_TARBALL)
 	$(Q) touch $(MQTTC_UNPACK)
 
 context:: $(MQTTC_UNPACK)
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, $(MQTTC_TARBALL))
 	$(call DELDIR, $(MQTTC_UNPACK))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/platform/Makefile
+++ b/platform/Makefile
@@ -54,11 +54,13 @@ $(PLATFORMDIR): $(TOPDIR)$(DELIM).config
 dirlinks: $(PLATFORMDIR)
 
 context:: dirlinks
+	$(Q) touch .context
 
 clean_context:
 	$(Q) $(DIRUNLINK) $(PLATFORMDIR)
 
 clean::
 	$(Q) $(MAKE) -C bin TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" clean
+	$(Q) $(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -83,11 +83,13 @@ CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_socket.c
 endif
 
 context:: $(ADB_UNPACKDIR)
+	$(Q) touch .context
 
 clean::
 	$(call DELFILE, $(OBJS))
 
 distclean::
 	$(call DELDIR, $(ADB_UNPACKDIR))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/system/argtable3/Makefile
+++ b/system/argtable3/Makefile
@@ -53,9 +53,11 @@ $(ARGTABLE3_UNPACK): $(ARGTABLE3_TARBALL)
 	$(Q) mv argtable3-$(ARGTABLE3_VERSION) $(ARGTABLE3_UNPACK)
 
 context:: $(ARGTABLE3_UNPACK)
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE, $(ARGTABLE3_TARBALL))
 	$(call DELDIR, $(ARGTABLE3_UNPACK))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/system/embedlog/Makefile
+++ b/system/embedlog/Makefile
@@ -235,6 +235,7 @@ create_includes: $(EMBEDLOG_SOURCES)/include/embedlog.h
 
 context:: $(EMBEDLOG_SOURCES)
 	$(Q) $(MAKE) create_includes
+	$(Q) touch .context
 
 clean::
 	$(Q) $(call DELFILE, $(APPDIR)/include/system/embedlog.h)
@@ -243,5 +244,6 @@ clean::
 distclean::
 	$(Q) $(call DELDIR, $(EMBEDLOG_SOURCES))
 	$(Q) $(call DELDIR, $(EMBEDLOG_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -319,9 +319,11 @@ CSRCS += echo-server.c
 endif
 
 context:: $(LIBUV_UNPACK)/.patch
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(LIBUV_UNPACK))
 	$(call DELFILE, $(LIBUV_TARBALL))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/system/psmq/Makefile
+++ b/system/psmq/Makefile
@@ -106,6 +106,7 @@ create_includes: $(PSMQ_SOURCES)/inc/psmq.h
 
 context:: $(PSMQ_SOURCES)
 	$(Q) $(MAKE) create_includes
+	$(Q) touch .context
 
 clean::
 	$(Q) $(call DELFILE, $(APPDIR)/include/system/psmq.h)
@@ -114,6 +115,7 @@ clean::
 distclean::
 	$(Q) $(call DELDIR, $(PSMQ_SOURCES))
 	$(Q) $(call DELDIR, $(PSMQ_TARBALL))
+	$(Q) $(call DELFILE, .context)
 
 MODULE = $(CONFIG_SYSTEM_PSMQ)
 

--- a/testing/iozone/Makefile
+++ b/testing/iozone/Makefile
@@ -56,9 +56,11 @@ $(IOZONE_UNPACKNAME): $(IOZONE_ZIP)
 	$(Q) touch $(IOZONE_UNPACKNAME)
 
 context:: $(IOZONE_UNPACKNAME)
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(IOZONE_UNPACKNAME))
 	$(call DELFILE, $(IOZONE_ZIP))
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -133,8 +133,10 @@ $(LTP_UNPACK):
 	$(Q) git -C $(LTP_UNPACK) am < 0002-Use-ifdef-instead-of-if-for-__linux__.patch
 
 context:: $(LTP_UNPACK)
+	$(Q) touch .context
 
 distclean::
 	$(Q) rm -rf $(LTP_UNPACK)
+	$(Q) $(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/testing/unity/Makefile
+++ b/testing/unity/Makefile
@@ -65,11 +65,13 @@ $(APPS_INCDIR)$(DELIM)unity_internals.h: $(UNITY_SRCDIR)$(DELIM)unity_internals.
 	$(Q) cp $< $@
 
 context:: $(APPS_INCDIR)$(DELIM)unity.h $(APPS_INCDIR)$(DELIM)unity_internals.h
+	$(Q) touch .context
 
 distclean::
 	$(call DELDIR, $(UNITY_UNPACKNAME))
 	$(call DELFILE, $(UNITY_TARBALL))
 	$(call DELFILE, $(APPDIR)/include/testing/unity.h)
 	$(call DELFILE, $(APPDIR)/include/testing/unity_internals.h)
+	$(call DELFILE, .context)
 
 include $(APPDIR)/Application.mk

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -41,10 +41,12 @@ $(NIMBLE_UNPACKDIR): $(NIMBLE_TAR)
 	$(Q) touch $(NIMBLE_UNPACKDIR)
 
 context:: $(NIMBLE_UNPACKDIR)
+	$(Q) touch .context
 
 distclean::
 	$(call DELFILE,$(NIMBLE_TAR))
 	$(call DELDIR,$(NIMBLE_UNPACKDIR))
+	$(call DELFILE, .context)
 
 # nimBLE assumes this flag since it expects undefined macros to be zero value
 


### PR DESCRIPTION
## Summary

- I noticed that some files (e.g. xxx.tar.gz) which are generated
   by 'make context' are not deleted when we build the kernel only
    then we do 'make distclean' because .depend is not generated.
- This commit fixes this issue by adding the .context file and
    also adding directories that contain the file to be cleaned.

## Impact

- None

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)
