### PR TITLE
nshlib/nsh_ddcmd: calculate time difference with microsecond precision

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -353,14 +353,15 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   elapsed  = (((uint64_t)ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec);
   elapsed -= (((uint64_t)ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec);
-  elapsed /= NSEC_PER_MSEC; /* msec */
+  elapsed /= NSEC_PER_USEC; /* usec */
 
   total = ((uint64_t)dd.sector * (uint64_t)dd.sectsize);
 
-  nsh_output(vtbl, "%llu bytes copied, %u msec, ",
+  nsh_output(vtbl, "%llu bytes copied, %u usec, ",
              total, (unsigned int)elapsed);
   nsh_output(vtbl, "%u KB/s\n" ,
-             (unsigned int)((double)total / (double)elapsed));
+             (unsigned int)(((double)total / 1024)
+             / ((double)elapsed / USEC_PER_SEC)));
 #endif
 
 errout_with_outf:


### PR DESCRIPTION
## Summary
Improve calculation accuracy.

## Impact
None

## Testing
Daily test
