### PR TITLE
nshlib/netcmds: Decouple nslookup() from NETDB_DNSCLIENT

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -401,7 +401,7 @@ config NSH_DISABLE_NSFMOUNT
 config NSH_DISABLE_NSLOOKUP
 	bool "Disable nslookup"
 	default DEFAULT_SMALL
-	depends on LIBC_NETDB && NETDB_DNSCLIENT
+	depends on LIBC_NETDB
 
 config NSH_DISABLE_PASSWD
 	bool "Disable passwd"


### PR DESCRIPTION
## Summary

Allow disabling nslookup even when not using dnsclient.

#151 touched cmd_nslookup, replacing `gethostbyname()` with `getaddrinfo()` for IPv6 compatibility. 
It also touched the macro conditions, effectively dropping the dependency on activated NETDB_DNSCLIENT. 
`nshlib/Kconfig` was not updated accordingly. See 8da81578b0e5822719ca764416ebb6a74e568fa4
Now we're forced to use nslookup with or without dnsclient. That pulls some functions into the build, according to System.map 
(derived from `diff -NarU0 <(cut -d' ' -f3 ../build-10.3.0/nucleo-h743zi2/System.map) <(cut -d' ' -f3 System.map)`
and Puncover utility:
```
cmd_nslookup	160
getaddrinfo	496
getnameinfo	368
lib_numeric_address	228
getservbyname_r	180
lib_localhost	168
getservbyport_r	164
gethostentbyname_r	86
```
and possibly others. Sizes for armv7e-m build on -Og optlevel.

The proposed change saves 2436 bytes of .text on nucleo-h743zi2:jumbo slightly stripped config, 
and something similar on my mdr32 config. 
Other consumers of getaddrinfo()/getnameinfo() were webclient and dhcpc_renew.

## Impact

Boards with minimal networking configurations without using NETDB_DNSCLIENT.
Keep in mind `nslookup` can still use a static `/etc/hosts` file, it doesn't strictly require dns functionality.

## Testing

Milandr mdr32 builds and runs, reduced flash footprint.
nucleo-h743zi2 (slightly stripped :jumbo) builds with reduced footprint and no linker errors.
Before:
```
   text    data     bss     dec     hex filename
 288850     488   32832  322170   4ea7a nuttx
```
After:
```
   text    data     bss     dec     hex filename
 286414     488   32832  319734   4e0f6 nuttx
```
