### PR TITLE
apps:fix reset cause warning

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -344,7 +344,7 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   struct boardioc_reset_cause_s cause;
 
   memset(&cause, 0, sizeof(cause));
-  ret = boardctl(BOARDIOC_RESET_CAUSE, &cause);
+  ret = boardctl(BOARDIOC_RESET_CAUSE, (uintptr_t)&cause);
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);


### PR DESCRIPTION
nsh_syscmds.c:352:40: error: passing argument 2 of 'boardctl' makes integer from pointer without a cast [-Werror=int-conversion]
352 |   ret = boardctl(BOARDIOC_RESET_CAUSE, &cause);
    |                                        ^~~~~~
    |                                        |
    |                                        struct boardioc_reset_cause_s *
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact

## Testing

