### PR TITLE
cmd_reset_cause:remove extra space in text ouput

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -351,7 +351,7 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
       return ERROR;
     }
 
-  nsh_output(vtbl, "cause:0x%x, flag:0x%" PRIx32 "\n",
+  nsh_output(vtbl, "cause:0x%x,flag:0x%" PRIx32 "\n",
              cause.cause, cause.flag);
   return OK;
 }


### PR DESCRIPTION
can use ouput string set a env to argv
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact
in a nsh script:
```set flag "cause:0x9,flag:0x4"
set rel `resetcause`
if [ $flag == $rel ]
then 
  echo "do something"
fi
```
but,if `resetcause` output have `space`,  `if [ $flag == $rel ]` will parse error

## Testing

