### PR TITLE
system/uorb: support uorb, include uorb wraper, unit test, uorb_listener, topic definition

### DIFF
--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -18,6 +18,22 @@ config UORB_STACKSIZE
 	int "stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config UORB_LISTENER
+	bool "uorb listener"
+	default n
+
+config UORB_TESTS
+	bool "uorb unit tests"
+	default n
+
+if UORB_TESTS
+
+config UORB_SRORAGE_DIR
+	string "uorb test result storage dir"
+	default "/data/"
+
+endif # UORB_TESTS
+
 config DEBUG_UORB
 	bool "uorb debug output"
 	default n
@@ -45,17 +61,5 @@ config UORB_INFO
 	depends on DEBUG_INFO
 
 endif # DEBUG_UORB
-
-config UORB_TESTS
-	bool "uorb unit tests"
-	default n
-
-if UORB_TESTS
-
-config UORB_SRORAGE_DIR
-	string "uorb test result storage dir"
-	default "/data/"
-
-endif # UORB_TESTS
 
 endif # UORB

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -10,6 +10,14 @@ menuconfig UORB
 
 if UORB
 
+config UORB_PRIORITY
+	int "task priority"
+	default 100
+
+config UORB_STACKSIZE
+	int "stack size"
+	default DEFAULT_TASK_STACKSIZE
+
 config DEBUG_UORB
 	bool "uorb debug output"
 	default n
@@ -37,5 +45,17 @@ config UORB_INFO
 	depends on DEBUG_INFO
 
 endif # DEBUG_UORB
+
+config UORB_TESTS
+	bool "uorb unit tests"
+	default n
+
+if UORB_TESTS
+
+config UORB_SRORAGE_DIR
+	string "uorb test result storage dir"
+	default "/data/"
+
+endif # UORB_TESTS
 
 endif # UORB

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -1,0 +1,41 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig UORB
+	tristate "uorb(micro object request broker)"
+	depends on SENSORS && USENSOR
+	default n
+
+if UORB
+
+config DEBUG_UORB
+	bool "uorb debug output"
+	default n
+
+if DEBUG_UORB
+
+config UORB_ALERT
+	bool "uorb panic output"
+	default n
+	depends on DEBUG_ALERT
+
+config UORB_ERROR
+	bool "uorb error output"
+	default n
+	depends on DEBUG_ERROR
+
+config UORB_WARN
+	bool "uorb warn output"
+	default n
+	depends on DEBUG_WARN
+
+config UORB_INFO
+	bool "uorb info output"
+	default n
+	depends on DEBUG_INFO
+
+endif # DEBUG_UORB
+
+endif # UORB

--- a/system/uorb/Make.defs
+++ b/system/uorb/Make.defs
@@ -22,4 +22,6 @@ ifneq ($(CONFIG_UORB),)
 CONFIGURED_APPS += $(APPDIR)/system/uorb
 CFLAGS          += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
                    $(APPDIR)/system/uorb/}
+CXXFLAGS        += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
+                   $(APPDIR)/system/uorb/}
 endif

--- a/system/uorb/Make.defs
+++ b/system/uorb/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/system/uorb/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_UORB),)
+CONFIGURED_APPS += $(APPDIR)/system/uorb
+CFLAGS          += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
+                   $(APPDIR)/system/uorb/}
+endif

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -21,6 +21,7 @@
 include $(APPDIR)/Make.defs
 
 CSRCS    += uORB/uORB.c
+CSRCS    += $(wildcard sensor/*.c)
 
 ifneq ($(CONFIG_UORB_TESTS),)
 CSRCS    += test/utility.c

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -1,0 +1,25 @@
+############################################################################
+# apps/system/uorb/uORB/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+CSRCS += uORB/uORB.c
+
+include $(APPDIR)/Application.mk

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -20,6 +20,16 @@
 
 include $(APPDIR)/Make.defs
 
-CSRCS += uORB/uORB.c
+CSRCS    += uORB/uORB.c
+
+ifneq ($(CONFIG_UORB_TESTS),)
+CSRCS    += test/utility.c
+MAINSRC   = test/unit_test.c
+PROGNAME  = uorb_unit_test
+endif
+
+PRIORITY  = $(CONFIG_UORB_PRIORITY)
+STACKSIZE = $(CONFIG_UORB_STACKSIZE)
+MODULE    = $(CONFIG_UORB)
 
 include $(APPDIR)/Application.mk

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -23,10 +23,15 @@ include $(APPDIR)/Make.defs
 CSRCS    += uORB/uORB.c
 CSRCS    += $(wildcard sensor/*.c)
 
+ifneq ($(CONFIG_UORB_LISTENER),)
+MAINSRC  += listener.c
+PROGNAME += uorb_listener
+endif
+
 ifneq ($(CONFIG_UORB_TESTS),)
 CSRCS    += test/utility.c
-MAINSRC   = test/unit_test.c
-PROGNAME  = uorb_unit_test
+MAINSRC  += test/unit_test.c
+PROGNAME += uorb_unit_test
 endif
 
 PRIORITY  = $(CONFIG_UORB_PRIORITY)

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -509,7 +509,7 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
       return;
     }
 
-  recv_msgs = malloc(nb_objects * sizeof(int));
+  recv_msgs = calloc(nb_objects, sizeof(int));
   if (!recv_msgs)
     {
       free(fds);
@@ -559,8 +559,6 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
       free(recv_msgs);
       return;
     }
-
-  memset(recv_msgs, 0, sizeof(recv_msgs));
 
   /* Loop poll and print recieved messages */
 

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -1,0 +1,735 @@
+/****************************************************************************
+ * apps/system/uorb/listener.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/list.h>
+
+#include <errno.h>
+#include <dirent.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ORB_MAX_PRINT_NAME 32
+#define ORB_TOP_WAIT_TIME  1000
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct listen_object_s
+{
+  struct list_node  node;         /* Node of object info list */
+  struct orb_object object;       /* Object id */
+  orb_abstime       timestamp;    /* Time of lastest generation  */
+  unsigned long     generation;   /* Latest generation */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int listener_get_state(FAR struct orb_object *object,
+                              FAR struct orb_state *state);
+static int listener_add_object(FAR struct list_node *objlist,
+                               FAR struct orb_object *object);
+static void listener_delete_object_list(FAR struct list_node *objlist);
+static int listener_generate_object_list(FAR struct list_node *objlist,
+                                         FAR const char *filter);
+static int listener_print(FAR const struct orb_metadata *meta, int fd);
+static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
+                             int topic_rate, int nb_msgs, int timeout);
+static int listener_update(FAR struct list_node *objlist,
+                           FAR struct orb_object *object);
+static void listener_top(FAR struct list_node *objlist,
+                         FAR const char *filter,
+                         bool only_once);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static bool g_should_exit = false;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void usage(void)
+{
+  uorbinfo_raw("\n\
+Utility to listen on uORB topics and print the data to the console.\n\
+\n\
+The listener can be exited any time by pressing Ctrl+C, Esc, or Q.\n\
+\n\
+We use cmd 'uorb_listener <t1,t2,...> -n 1' to print once snapshot for\n\
+specify topics if command exists or all the topic objects when command\n\
+doesn't exists. If topic isn't updated, the snapshot for this topic is\n\
+empty.\n\
+\n\
+We use cmd 'uorb_listener t1,t2,... [arguments...]' to print the topics\n\
+specified. The following arguments apply to all topics.\n\
+\n\
+We use cmd 'uorb_listener ... -n num(>1) ...' to print all the topic\n\
+objects message until the number of received is equal to the specified\n\
+number.\n\
+\n\
+We can print the messages all the time when we do not specify the number\n\
+of message.\n\
+\n\
+listener <command> [arguments...]\n\
+ Commands:\n\
+\t<topics_name> Topic name. Multi name are separated by ','\n\
+\t[-h       ]  Listener commands help\n\
+\t[-n <val> ]  Number of messages, default: 0\n\
+\t[-r <val> ]  Subscription rate (unlimited if 0), default: 0\n\
+\t[-t <val> ]  Time of listener, in seconds, default: 5\n\
+\t[-T       ]  Top, continuously print updating objects\n\
+\t[-l       ]  Top only execute once.\n\
+  ");
+}
+
+/****************************************************************************
+ * Name: listener_get_state
+ *
+ * Description:
+ *   Get object's current state.
+ *
+ * Input Parameters:
+ *   object   Given object
+ *   state    Returned state.
+ *
+ * Returned Value:
+ *   0 on success, otherwise negative errno.
+ ****************************************************************************/
+
+static int listener_get_state(FAR struct orb_object *object,
+                              FAR struct orb_state *state)
+{
+  int ret;
+  int fd;
+
+  fd = orb_subscribe_multi(object->meta, object->instance);
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  ret = orb_get_state(fd, state);
+  orb_unsubscribe(fd);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  state->nsubscribers--; /* Ignore temp subscriber */
+  return 0;
+}
+
+/****************************************************************************
+ * Name: listener_add_object
+ *
+ * Description:
+ *   Alloc object node and add to list.
+ *
+ * Input Parameters:
+ *   object     Object to add.
+ *   objlist    List to modify.
+ *
+ * Returned Value:
+ *   0 on success, otherwise return negative errno.
+ ****************************************************************************/
+
+static int listener_add_object(FAR struct list_node *objlist,
+                               FAR struct orb_object *object)
+{
+  FAR struct listen_object_s *tmp;
+  struct orb_state state;
+  int ret;
+
+  tmp = malloc(sizeof(struct listen_object_s));
+  if (tmp == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  ret = listener_get_state(object, &state);
+  if (ret < 0)
+    {
+      free(tmp);
+      return ret;
+    }
+
+  tmp->object.meta     = object->meta;
+  tmp->object.instance = object->instance;
+  tmp->timestamp       = orb_absolute_time();
+  tmp->generation      = state.generation;
+
+  list_add_tail(objlist, &tmp->node);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: listener_update
+ *
+ * Description:
+ *   Update object list, print imformation if given object has new data.
+ *
+ * Input Parameters:
+ *   object     Object to check state.
+ *   objlist    List to update.
+ *
+ * Returned Value:
+ *   0 on success.
+ ****************************************************************************/
+
+static int listener_update(FAR struct list_node *objlist,
+                           FAR struct orb_object *object)
+{
+  FAR struct listen_object_s *old = NULL;
+  FAR struct listen_object_s *tmp;
+  int ret;
+
+  /* Check wether object already exist in old list */
+
+  list_for_every_entry(objlist, tmp, struct listen_object_s, node)
+    {
+      if (tmp->object.meta == object->meta &&
+          tmp->object.instance == object->instance)
+        {
+          old = tmp;
+          break;
+        }
+    }
+
+  if (old)
+    {
+      /* If object existed in old list, print and update. */
+
+      struct orb_state state;
+      orb_abstime now_time;
+      unsigned long delta_time;
+      unsigned long delta_generation;
+
+      now_time = orb_absolute_time();
+      ret = listener_get_state(object, &state);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      delta_time       = now_time - old->timestamp;
+      delta_generation = state.generation - old->generation;
+      if (delta_generation && delta_time)
+        {
+          unsigned long frequency;
+
+          frequency = delta_generation * 1000000 / delta_time;
+          uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
+                       "%2" PRIu32 " %4u",
+                       ORB_MAX_PRINT_NAME,
+                       object->meta->o_name,
+                       object->instance,
+                       state.nsubscribers,
+                       frequency,
+                       state.queue_size,
+                       object->meta->o_size);
+          old->generation = state.generation;
+          old->timestamp  = now_time;
+        }
+    }
+  else
+    {
+      /* If object not existed in old list, alloc one */
+
+      ret = listener_add_object(objlist, object);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: listener_delete_object_list
+ *
+ * Description:
+ *   free object list.
+ *
+ * Input Parameters:
+ *   objlist    List to free.
+ *
+ * Returned Value:
+ *   None.
+ ****************************************************************************/
+
+static void listener_delete_object_list(FAR struct list_node *objlist)
+{
+  FAR struct listen_object_s *tmp;
+  FAR struct listen_object_s *next;
+
+  list_for_every_entry_safe(objlist, tmp, next, struct listen_object_s, node)
+    {
+      list_delete(&tmp->node);
+      free(tmp);
+    }
+
+  list_initialize(objlist);
+}
+
+/****************************************************************************
+ * Name: listener_generate_object_list
+ *
+ * Description:
+ *   Update / alloc object list by scan ORB_SENSOR_PATH.
+ *
+ * Input Parameters:
+ *   objlist    List to update / alloc.
+ *   filter     Specified topic names.
+ *
+ * Returned Value:
+ *   File number under ORB_SENSOR_PATH on success.
+ *   Negative errno on failure.
+ ****************************************************************************/
+
+static int listener_generate_object_list(FAR struct list_node *objlist,
+                                         FAR const char *filter)
+{
+  FAR struct dirent *entry;
+  FAR DIR *dir;
+  int cnt = 0;
+  int ret;
+
+  /* Traverse all objects under ORB_SENSOR_PATH */
+
+  dir = opendir(ORB_SENSOR_PATH);
+  if (!dir)
+    {
+      return ERROR;
+    }
+
+  while ((entry = readdir(dir)))
+    {
+      struct orb_object object;
+      char file_name[PATH_MAX];
+      int len;
+
+      /* Get meta data and instance number through file name */
+
+      if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+        {
+          continue;
+        }
+
+      strlcpy(file_name, entry->d_name, PATH_MAX);
+
+      len = strlen(file_name) - 1;
+      object.instance = file_name[len] - '0';
+      file_name[len] = 0;
+
+      if (filter)
+        {
+          /* Example:
+           *   objects: aaa0, aaa1, aaa2, bbb0, bbb1
+           *   filter:  "aaa bbb1"
+           * Object list we get:
+           *   aaa0, aaa1, aaa2, bbb1.
+           */
+
+          FAR const char *str = strstr(filter, file_name);
+          if (!str || (str[len] && str[len] != ',' &&
+                       str[len] != object.instance + '0'))
+            {
+              continue;
+            }
+        }
+
+      object.meta = orb_get_meta(entry->d_name);
+      if (!object.meta)
+        {
+          continue;
+        }
+
+      /* Update object infomation to list. */
+
+      ret = listener_update(objlist, &object);
+      if (ret < 0)
+        {
+          uorbinfo_raw("listener %s failed", object.meta->o_name);
+          continue;
+        }
+
+      cnt++;
+    }
+
+  closedir(dir);
+  return cnt;
+}
+
+/****************************************************************************
+ * Name: listener_print
+ *
+ * Description:
+ *   Print topic data by its print_message callback.
+ *
+ * Input Parameters:
+ *   meta         The uORB metadata.
+ *   fd           Subscriber handle.
+ *
+ * Returned Value:
+ *   0 on success copy, otherwise -1
+ ****************************************************************************/
+
+static int listener_print(FAR const struct orb_metadata *meta, int fd)
+{
+  char buffer[meta->o_size];
+  int ret;
+
+  ret = orb_copy(meta, fd, buffer);
+#ifdef CONFIG_DEBUG_UORB
+  if (ret == OK && meta->o_cb != NULL)
+    {
+      meta->o_cb(meta, buffer);
+    }
+#else
+  uorbinfo_raw("Enable debug uorb to print message");
+#endif
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: listener_monitor
+ *
+ * Description:
+ *   Moniter objects by subscribe and print data.
+ *
+ * Input Parameters:
+ *   objlist        List of objects to subscribe.
+ *   nb_objects     Length of objects list.
+ *   topic_rate     Subscribe frequency.
+ *   nb_msgs        Subscribe amount of messages.
+ *   timeout        Maximum poll waiting time , ms.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+
+static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
+                             int topic_rate, int nb_msgs, int timeout)
+{
+  struct pollfd fds[nb_objects];
+  int recv_msgs[nb_objects];
+  int nb_recv_msgs = 0;
+  int i = 0;
+
+  struct listen_object_s *tmp;
+
+  /* Prepare pollfd for all objects */
+
+  list_for_every_entry(objlist, tmp, struct listen_object_s, node)
+    {
+      int fd;
+
+      fd = orb_subscribe_multi(tmp->object.meta, tmp->object.instance);
+      if (fd < 0)
+        {
+          fds[i].fd     = -1;
+          fds[i].events = 0;
+          continue;
+        }
+      else
+        {
+          fds[i].fd     = fd;
+          fds[i].events = POLLIN;
+        }
+
+      if (nb_msgs == 1)
+        {
+          listener_print(tmp->object.meta, fd);
+          orb_unsubscribe(fd);
+        }
+      else if (topic_rate != 0)
+        {
+          orb_set_frequency(fd, topic_rate);
+        }
+
+      i++;
+    }
+
+  if (nb_msgs == 1)
+    {
+      return;
+    }
+
+  memset(recv_msgs, 0, sizeof(recv_msgs));
+
+  /* Loop poll and print recieved messages */
+
+  while ((!nb_msgs || nb_recv_msgs < nb_msgs) && !g_should_exit)
+    {
+      if (poll(&fds[0], nb_objects, timeout * 1000) > 0)
+        {
+          i = 0;
+          list_for_every_entry(objlist, tmp, struct listen_object_s, node)
+            {
+              if (fds[i].revents & POLLIN)
+                {
+                  nb_recv_msgs++;
+                  recv_msgs[i]++;
+                  if (listener_print(tmp->object.meta, fds[i].fd) != 0)
+                    {
+                      uorberr("Listener callback failed");
+                    }
+
+                  if (nb_msgs && nb_recv_msgs >= nb_msgs)
+                    {
+                      break;
+                    }
+                }
+
+              i++;
+            }
+        }
+      else if (errno != EINTR)
+        {
+          uorbinfo_raw("Waited for %d seconds without a message. "
+                       "Giving up.", timeout);
+          break;
+        }
+    }
+
+  i = 0;
+  list_for_every_entry(objlist, tmp, struct listen_object_s, node)
+    {
+      if (fds[i].fd < 0)
+        {
+          uorbinfo_raw("Object name:%s%d, subscribe fail",
+                       tmp->object.meta->o_name, tmp->object.instance);
+        }
+      else
+        {
+          orb_unsubscribe(fds[i].fd);
+          uorbinfo_raw("Object name:%s%d, recieved:%d",
+                       tmp->object.meta->o_name, tmp->object.instance,
+                       recv_msgs[i]);
+        }
+
+      i++;
+    }
+
+  uorbinfo_raw("Total number of received Message:%d/%d",
+               nb_recv_msgs, nb_msgs ? nb_msgs : nb_recv_msgs);
+}
+
+/****************************************************************************
+ * Name: listener_top
+ *
+ * Description:
+ *   Continuously print updating objects, like the unix 'top' command.
+ *   Exited when the user presses the enter key.
+ *
+ * Input Parameters:
+ *   objlist    List of objects.
+ *   filter     Specific topic names.
+ *   only_once  Print only once, then exit.
+ *
+ * Returned Value:
+ *   None.
+ ****************************************************************************/
+
+static void listener_top(FAR struct list_node *objlist,
+                         FAR const char *filter,
+                         bool only_once)
+{
+  bool quit = false;
+  struct pollfd fds;
+
+  fds.fd     = STDIN_FILENO;
+  fds.events = POLLIN;
+
+  uorbinfo_raw("\033[2J\n"); /* clear screen */
+
+  do
+    {
+      /* Wait a while, quit if user input some thing */
+
+      if (poll(&fds, 1, ORB_TOP_WAIT_TIME) > 0)
+        {
+          char c;
+
+          if (read(STDIN_FILENO, &c, 1) > 0)
+            {
+              quit = true;
+              break;
+            }
+        }
+
+      /* Then Update object list and print changes. */
+
+      if (!only_once)
+        {
+          uorbinfo_raw("\033[H"); /* move cursor to top left corner */
+        }
+
+      uorbinfo_raw("\033[K" "current objects: %i", list_length(objlist));
+      uorbinfo_raw("\033[K" "%-*s INST #SUB RATE #Q SIZE",
+                   ORB_MAX_PRINT_NAME - 2, "NAME");
+
+      if (listener_generate_object_list(objlist, filter) < 0)
+        {
+          uorberr("Failed to update object list");
+          return;
+        }
+
+      if (!only_once)
+        {
+          uorbinfo_raw("\033[0J"); /* Clear the rest of the screen */
+        }
+    }
+  while (!quit && !only_once);
+}
+
+static void exit_handler(int signo)
+{
+  g_should_exit = true;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct list_node objlist;
+  FAR struct listen_object_s *tmp;
+  int topic_rate    = 0;
+  int nb_msgs       = 0;
+  int timeout       = 5;
+  bool top          = false;
+  bool only_once    = false;
+  FAR char *filter  = NULL;
+  int ret;
+  int ch;
+
+  g_should_exit = false;
+  if (signal(SIGINT, exit_handler) == SIG_ERR)
+    {
+      return 1;
+    }
+
+  /* Pasrse Argument */
+
+  while ((ch = getopt(argc, argv, "r:n:t:Tlh")) != EOF)
+    {
+      switch (ch)
+      {
+        case 'r':
+          topic_rate = strtol(optarg, NULL, 0);
+          if (topic_rate < 0)
+            {
+              goto error;
+            }
+          break;
+
+        case 'n':
+          nb_msgs = strtol(optarg, NULL, 0);
+          if (nb_msgs < 0)
+            {
+              goto error;
+            }
+          break;
+
+        case 't':
+          timeout = strtol(optarg, NULL, 0);
+          if (timeout < 0)
+            {
+              goto error;
+            }
+          break;
+
+        case 'T':
+          top = true;
+          break;
+
+        case 'l':
+          only_once = true;
+          break;
+
+        case 'h':
+        default:
+          goto error;
+        }
+    }
+
+  if (optind < argc)
+    {
+      filter = argv[optind];
+    }
+
+  /* Alloc list and exec command */
+
+  list_initialize(&objlist);
+  ret = listener_generate_object_list(&objlist, filter);
+  if (ret <= 0)
+    {
+      return 0;
+    }
+
+  if (top)
+    {
+      listener_top(&objlist, filter, only_once);
+    }
+  else
+    {
+      uorbinfo_raw("\nMointor objects num:%d", ret);
+      list_for_every_entry(&objlist, tmp, struct listen_object_s, node)
+        {
+          uorbinfo_raw("object_name:%s, object_instance:%d",
+                       tmp->object.meta->o_name,
+                       tmp->object.instance);
+        }
+
+      listener_monitor(&objlist, ret, topic_rate, nb_msgs, timeout);
+    }
+
+  listener_delete_object_list(&objlist);
+  return 0;
+
+error:
+  usage();
+  return 1;
+}

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -499,6 +499,7 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
 {
   FAR struct pollfd *fds;
   FAR int *recv_msgs;
+  int interval = topic_rate ? 1000000 / topic_rate : 0;
   int nb_recv_msgs = 0;
   int i = 0;
 
@@ -541,9 +542,10 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
           listener_print(tmp->object.meta, fd);
           orb_unsubscribe(fd);
         }
-      else if (topic_rate != 0)
+      else if (interval != 0)
         {
-          orb_set_frequency(fd, topic_rate);
+          orb_set_interval(fd, interval);
+
           if (topic_latency != 0)
             {
               orb_set_batch_interval(fd, topic_latency);

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -183,16 +183,10 @@ static int listener_add_object(FAR struct list_node *objlist,
     }
 
   ret = listener_get_state(object, &state);
-  if (ret < 0)
-    {
-      free(tmp);
-      return ret;
-    }
-
   tmp->object.meta     = object->meta;
   tmp->object.instance = object->instance;
   tmp->timestamp       = orb_absolute_time();
-  tmp->generation      = state.generation;
+  tmp->generation      = ret < 0 ? 0 : state.generation;
   list_add_tail(objlist, &tmp->node);
   return 0;
 }
@@ -252,7 +246,8 @@ static int listener_update(FAR struct list_node *objlist,
         {
           unsigned long frequency;
 
-          frequency = delta_generation * 1000000 / delta_time;
+          frequency = (state.max_frequency ? state.max_frequency : 1000000)
+                      * delta_generation / delta_time;
           uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
                        "%2" PRIu32 " %4u",
                        ORB_MAX_PRINT_NAME,

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -492,12 +492,25 @@ static int listener_print(FAR const struct orb_metadata *meta, int fd)
 static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
                              int topic_rate, int nb_msgs, int timeout)
 {
-  struct pollfd fds[nb_objects];
-  int recv_msgs[nb_objects];
+  FAR struct pollfd *fds;
+  FAR int *recv_msgs;
   int nb_recv_msgs = 0;
   int i = 0;
 
   struct listen_object_s *tmp;
+
+  fds = malloc(nb_objects * sizeof(struct pollfd));
+  if (!fds)
+    {
+      return;
+    }
+
+  recv_msgs = malloc(nb_objects * sizeof(int));
+  if (!recv_msgs)
+    {
+      free(fds);
+      return;
+    }
 
   /* Prepare pollfd for all objects */
 
@@ -533,6 +546,8 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
 
   if (nb_msgs == 1)
     {
+      free(fds);
+      free(recv_msgs);
       return;
     }
 
@@ -594,6 +609,8 @@ static void listener_monitor(FAR struct list_node *objlist, int nb_objects,
 
   uorbinfo_raw("Total number of received Message:%d/%d",
                nb_recv_msgs, nb_msgs ? nb_msgs : nb_recv_msgs);
+  free(fds);
+  free(recv_msgs);
 }
 
 /****************************************************************************

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -344,7 +344,7 @@ static int listener_generate_object_list(FAR struct list_node *objlist,
   while ((entry = readdir(dir)))
     {
       struct orb_object object;
-      char file_name[PATH_MAX];
+      char file_name[ORB_PATH_MAX];
       int len;
 
       /* Get meta data and instance number through file name */
@@ -354,7 +354,7 @@ static int listener_generate_object_list(FAR struct list_node *objlist,
           continue;
         }
 
-      strlcpy(file_name, entry->d_name, PATH_MAX);
+      strlcpy(file_name, entry->d_name, ORB_PATH_MAX);
 
       len = strlen(file_name) - 1;
       object.instance = file_name[len] - '0';
@@ -424,8 +424,6 @@ static int listener_print(FAR const struct orb_metadata *meta, int fd)
     {
       meta->o_cb(meta, buffer);
     }
-#else
-  uorbinfo_raw("Enable debug uorb to print message");
 #endif
 
   return ret;

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -173,6 +173,8 @@ static int listener_add_object(FAR struct list_node *objlist,
                                FAR struct orb_object *object)
 {
   FAR struct listen_object_s *tmp;
+  struct orb_state state;
+  int ret;
 
   tmp = malloc(sizeof(struct listen_object_s));
   if (tmp == NULL)
@@ -180,9 +182,17 @@ static int listener_add_object(FAR struct list_node *objlist,
       return -ENOMEM;
     }
 
+  ret = listener_get_state(object, &state);
+  if (ret < 0)
+    {
+      free(tmp);
+      return ret;
+    }
+
   tmp->object.meta     = object->meta;
   tmp->object.instance = object->instance;
-  tmp->timestamp       = 0;
+  tmp->timestamp       = orb_absolute_time();
+  tmp->generation      = state.generation;
   list_add_tail(objlist, &tmp->node);
   return 0;
 }
@@ -234,13 +244,6 @@ static int listener_update(FAR struct list_node *objlist,
       if (ret < 0)
         {
           return ret;
-        }
-
-      if (old->timestamp == 0)
-        {
-          old->timestamp  = orb_absolute_time();
-          old->generation = state.generation;
-          return 0;
         }
 
       delta_time       = now_time - old->timestamp;

--- a/system/uorb/sensor/accel.c
+++ b/system/uorb/sensor/accel.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/accel.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/accel.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_accel_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_accel *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "temperature: %.2f x: %.2f y: %.2f z: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->temperature, message->x, message->y, message->z);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_accel, struct sensor_accel, print_sensor_accel_message);
+ORB_DEFINE(sensor_accel_uncal, struct sensor_accel,
+           print_sensor_accel_message);

--- a/system/uorb/sensor/accel.h
+++ b/system/uorb/sensor/accel.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/accel.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_ACCEL_H
+#define __APPS_SYSTEM_UORB_SENSOR_ACCEL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_accel);
+ORB_DECLARE(sensor_accel_uncal);
+
+#endif

--- a/system/uorb/sensor/baro.c
+++ b/system/uorb/sensor/baro.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/baro.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/baro.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_baro_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_baro *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "temperature: %.2f pressure: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->temperature, message->pressure);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_baro, struct sensor_baro, print_sensor_baro_message);

--- a/system/uorb/sensor/baro.h
+++ b/system/uorb/sensor/baro.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/baro.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_BARO_H
+#define __APPS_SYSTEM_UORB_SENSOR_BARO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_baro);
+
+#endif

--- a/system/uorb/sensor/cap.c
+++ b/system/uorb/sensor/cap.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/cap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/cap.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_cap_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_cap *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "status: %" PRIu32 " rawdata0: %" PRIu32 " rawdata1: "
+               "%" PRIu32 " rawdata2: %" PRIu32 " rawdata3: %" PRIu32 "",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->status, message->rawdata[0], message->rawdata[1],
+               message->rawdata[2], message->rawdata[3]);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_cap, struct sensor_cap, print_sensor_cap_message);

--- a/system/uorb/sensor/cap.h
+++ b/system/uorb/sensor/cap.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/cap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_CAP_H
+#define __APPS_SYSTEM_UORB_SENSOR_CAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_cap);
+
+#endif

--- a/system/uorb/sensor/co2.c
+++ b/system/uorb/sensor/co2.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/co2.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/co2.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_co2_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_co2 *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) co2: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->co2);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_co2, struct sensor_co2, print_sensor_co2_message);

--- a/system/uorb/sensor/co2.h
+++ b/system/uorb/sensor/co2.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/co2.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_CO2_H
+#define __APPS_SYSTEM_UORB_SENSOR_CO2_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_co2);
+
+#endif

--- a/system/uorb/sensor/dust.c
+++ b/system/uorb/sensor/dust.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/dust.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/dust.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_dust_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_dust *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) dust: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->dust);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_dust, struct sensor_dust, print_sensor_dust_message);

--- a/system/uorb/sensor/dust.h
+++ b/system/uorb/sensor/dust.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/dust.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_DUST_H
+#define __APPS_SYSTEM_UORB_SENSOR_DUST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_dust);
+
+#endif

--- a/system/uorb/sensor/ecg.c
+++ b/system/uorb/sensor/ecg.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ecg.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ecg.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ecg_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_ecg *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) ecg: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->ecg);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ecg, struct sensor_ecg, print_sensor_ecg_message);

--- a/system/uorb/sensor/ecg.h
+++ b/system/uorb/sensor/ecg.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ecg.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_ECG_H
+#define __APPS_SYSTEM_UORB_SENSOR_ECG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ecg);
+
+#endif

--- a/system/uorb/sensor/gesture.c
+++ b/system/uorb/sensor/gesture.c
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gesture.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/gesture.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void
+print_sensor_wake_gesture_message(FAR const struct orb_metadata *meta,
+                                  FAR const void *buffer)
+{
+  FAR const struct sensor_wake_gesture *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago)"
+               " event: %" PRIu32 "", meta->o_name, message->timestamp,
+               now - message->timestamp, message->event);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_wake_gesture, struct sensor_wake_gesture,
+           print_sensor_wake_gesture_message);
+ORB_DEFINE(sensor_wake_gesture_uncal, struct sensor_wake_gesture,
+           print_sensor_wake_gesture_message);

--- a/system/uorb/sensor/gesture.h
+++ b/system/uorb/sensor/gesture.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gesture.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_GESTURE_H
+#define __APPS_SYSTEM_UORB_SENSOR_GESTURE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_wake_gesture);
+ORB_DECLARE(sensor_wake_gesture_uncal);
+
+#endif

--- a/system/uorb/sensor/gps.c
+++ b/system/uorb/sensor/gps.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gps.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/gps.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_gps_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_gps *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "time_utc: %" PRIu64 " latitude: %.4f longitude: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->time_utc, message->latitude, message->longitude);
+
+  uorbinfo_raw("%s:\taltitude: %.4f altitude_ellipsoid: %.4f "
+               "ground_speed: %.4f course: %.4f",
+               meta->o_name, message->altitude, message->altitude_ellipsoid,
+               message->ground_speed, message->course);
+
+  uorbinfo_raw("%s:\teph: %.4f epv: %.4f hdop: %.4f vdop: %.4f",
+               meta->o_name, message->eph, message->epv,
+               message->hdop, message->vdop);
+}
+
+static void
+print_sensor_gps_satellite_message(FAR const struct orb_metadata *meta,
+                                   FAR const void *buffer)
+{
+  FAR const struct sensor_gps_satellite *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+  int i;
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago)",
+               meta->o_name, message->timestamp, now - message->timestamp);
+
+  for (i = 0; i < message->count; i++)
+    {
+      uorbinfo_raw("%s:\tnumber:%d svid: %" PRIu32
+                   "elevation: %" PRIu32 "azimuth: %" PRIu32
+                   " snr: %" PRIu32 "",
+                   meta->o_name, i, message->info[i].svid,
+                   message->info[i].elevation, message->info[i].azimuth,
+                   message->info[i].snr);
+    }
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_gps, struct sensor_gps, print_sensor_gps_message);
+ORB_DEFINE(sensor_gps_satellite, struct sensor_gps_satellite,
+           print_sensor_gps_satellite_message);

--- a/system/uorb/sensor/gps.h
+++ b/system/uorb/sensor/gps.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gps.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_GPS_H
+#define __APPS_SYSTEM_UORB_SENSOR_GPS_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_gps);
+ORB_DECLARE(sensor_gps_satellite);
+
+#endif

--- a/system/uorb/sensor/gyro.c
+++ b/system/uorb/sensor/gyro.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gyro.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/gyro.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_gyro_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_gyro *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "temperature: %.2f x: %.2f y: %.2f z: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->temperature, message->x, message->y, message->z);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_gyro, struct sensor_gyro, print_sensor_gyro_message);
+ORB_DEFINE(sensor_gyro_uncal, struct sensor_gyro,
+           print_sensor_gyro_message);

--- a/system/uorb/sensor/gyro.h
+++ b/system/uorb/sensor/gyro.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/gyro.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_GYRO_H
+#define __APPS_SYSTEM_UORB_SENSOR_GYRO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_gyro);
+ORB_DECLARE(sensor_gyro_uncal);
+
+#endif

--- a/system/uorb/sensor/hall.c
+++ b/system/uorb/sensor/hall.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hall.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/hall.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_hall_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_hall *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) hall: %d",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->hall);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_hall, struct sensor_hall, print_sensor_hall_message);

--- a/system/uorb/sensor/hall.h
+++ b/system/uorb/sensor/hall.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hall.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_HALL_H
+#define __APPS_SYSTEM_UORB_SENSOR_HALL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_hall);
+
+#endif

--- a/system/uorb/sensor/hbeat.c
+++ b/system/uorb/sensor/hbeat.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hbeat.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/hbeat.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_hbeat_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_hbeat *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "heart beat: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->beat);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_hbeat, struct sensor_hbeat, print_sensor_hbeat_message);

--- a/system/uorb/sensor/hbeat.h
+++ b/system/uorb/sensor/hbeat.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hbeat.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_HBEAT_H
+#define __APPS_SYSTEM_UORB_SENSOR_HBEAT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_hbeat);
+
+#endif

--- a/system/uorb/sensor/hcho.c
+++ b/system/uorb/sensor/hcho.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hcho.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/hcho.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_hcho_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_hcho *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) hcho: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->hcho);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_hcho, struct sensor_hcho, print_sensor_hcho_message);

--- a/system/uorb/sensor/hcho.h
+++ b/system/uorb/sensor/hcho.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hcho.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_HCHO_H
+#define __APPS_SYSTEM_UORB_SENSOR_HCHO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_hcho);
+
+#endif

--- a/system/uorb/sensor/hrate.c
+++ b/system/uorb/sensor/hrate.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hrate.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/hrate.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_hrate_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_hrate *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "heart rate: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->bpm);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_hrate, struct sensor_hrate, print_sensor_hrate_message);

--- a/system/uorb/sensor/hrate.h
+++ b/system/uorb/sensor/hrate.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/hrate.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_HRATE_H
+#define __APPS_SYSTEM_UORB_SENSOR_HRATE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_hrate);
+
+#endif

--- a/system/uorb/sensor/humi.c
+++ b/system/uorb/sensor/humi.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/humi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/humi.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_humi_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_humi *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) humi: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->humidity);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_humi, struct sensor_humi, print_sensor_humi_message);

--- a/system/uorb/sensor/humi.h
+++ b/system/uorb/sensor/humi.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/humi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_HUMI_H
+#define __APPS_SYSTEM_UORB_SENSOR_HUMI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_humi);
+
+#endif

--- a/system/uorb/sensor/impd.c
+++ b/system/uorb/sensor/impd.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/impd.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/impd.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_impd_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_impd *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "real: %.2f imaginary: %.2f", meta->o_name,
+               message->timestamp, now - message->timestamp,
+               message->real, message->imag);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_impd, struct sensor_impd, print_sensor_impd_message);

--- a/system/uorb/sensor/impd.h
+++ b/system/uorb/sensor/impd.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/impd.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_IMPD_H
+#define __APPS_SYSTEM_UORB_SENSOR_IMPD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_impd);
+
+#endif

--- a/system/uorb/sensor/ir.c
+++ b/system/uorb/sensor/ir.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ir.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ir.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ir_message(FAR const struct orb_metadata *meta,
+                                    FAR const void *buffer)
+{
+  FAR const struct sensor_ir *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) ir: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->ir);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ir, struct sensor_ir, print_sensor_ir_message);

--- a/system/uorb/sensor/ir.h
+++ b/system/uorb/sensor/ir.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ir.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_IR_H
+#define __APPS_SYSTEM_UORB_SENSOR_IR_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ir);
+
+#endif

--- a/system/uorb/sensor/light.c
+++ b/system/uorb/sensor/light.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/light.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/light.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_light_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_light *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "light: %.2f ir: %.2f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->light, message->ir);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_light, struct sensor_light, print_sensor_light_message);
+ORB_DEFINE(sensor_light_uncal, struct sensor_light,
+           print_sensor_light_message);

--- a/system/uorb/sensor/light.h
+++ b/system/uorb/sensor/light.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/light.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_LIGHT_H
+#define __APPS_SYSTEM_UORB_SENSOR_LIGHT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_light);
+ORB_DECLARE(sensor_light_uncal);
+
+#endif

--- a/system/uorb/sensor/mag.c
+++ b/system/uorb/sensor/mag.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/mag.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/mag.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_mag_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_mag *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "temperature: %.2f x: %.2f y: %.2f z: %.2f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->temperature, message->x, message->y, message->z);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_mag, struct sensor_mag, print_sensor_mag_message);
+ORB_DEFINE(sensor_mag_uncal, struct sensor_mag,
+           print_sensor_mag_message);

--- a/system/uorb/sensor/mag.h
+++ b/system/uorb/sensor/mag.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/mag.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_MAG_H
+#define __APPS_SYSTEM_UORB_SENSOR_MAG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_mag);
+ORB_DECLARE(sensor_mag_uncal);
+
+#endif

--- a/system/uorb/sensor/noise.c
+++ b/system/uorb/sensor/noise.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/noise.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/noise.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_noise_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_noise *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "noise: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->db);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_noise, struct sensor_noise, print_sensor_noise_message);

--- a/system/uorb/sensor/noise.h
+++ b/system/uorb/sensor/noise.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/noise.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_NOISE_H
+#define __APPS_SYSTEM_UORB_SENSOR_NOISE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_noise);
+
+#endif

--- a/system/uorb/sensor/ots.c
+++ b/system/uorb/sensor/ots.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ots.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ots.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ots_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_ots *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "x: % " PRIi32 " y: % " PRIi32 "",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->x, message->y);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ots, struct sensor_ots, print_sensor_ots_message);

--- a/system/uorb/sensor/ots.h
+++ b/system/uorb/sensor/ots.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ots.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_OTS_H
+#define __APPS_SYSTEM_UORB_SENSOR_OTS_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ots);
+
+#endif

--- a/system/uorb/sensor/ph.c
+++ b/system/uorb/sensor/ph.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ph.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ph.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ph_message(FAR const struct orb_metadata *meta,
+                                    FAR const void *buffer)
+{
+  FAR const struct sensor_ph *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) ph: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->ph);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ph, struct sensor_ph, print_sensor_ph_message);

--- a/system/uorb/sensor/ph.h
+++ b/system/uorb/sensor/ph.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ph.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PH_H
+#define __APPS_SYSTEM_UORB_SENSOR_PH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ph);
+
+#endif

--- a/system/uorb/sensor/pm10.c
+++ b/system/uorb/sensor/pm10.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm10.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/pm10.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_pm10_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_pm10 *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) pm10: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->pm10);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_pm10, struct sensor_pm10, print_sensor_pm10_message);

--- a/system/uorb/sensor/pm10.h
+++ b/system/uorb/sensor/pm10.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm10.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PM10_H
+#define __APPS_SYSTEM_UORB_SENSOR_PM10_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_pm10);
+
+#endif

--- a/system/uorb/sensor/pm1p0.c
+++ b/system/uorb/sensor/pm1p0.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm1p0.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/pm1p0.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_pm1p0_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_pm1p0 *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "pm1p0: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->pm1p0);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_pm1p0, struct sensor_pm1p0, print_sensor_pm1p0_message);

--- a/system/uorb/sensor/pm1p0.h
+++ b/system/uorb/sensor/pm1p0.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm1p0.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PM1P0_H
+#define __APPS_SYSTEM_UORB_SENSOR_PM1P0_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_pm1p0);
+
+#endif

--- a/system/uorb/sensor/pm25.c
+++ b/system/uorb/sensor/pm25.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm25.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/pm25.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_pm25_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_pm25 *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) pm25: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->pm25);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_pm25, struct sensor_pm25, print_sensor_pm25_message);

--- a/system/uorb/sensor/pm25.h
+++ b/system/uorb/sensor/pm25.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/pm25.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PM25_H
+#define __APPS_SYSTEM_UORB_SENSOR_PM25_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_pm25);
+
+#endif

--- a/system/uorb/sensor/ppgd.c
+++ b/system/uorb/sensor/ppgd.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ppgd.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ppgd.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ppgd_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_ppgd *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "ppg1: %" PRIu32 " ppg2: %" PRIu32 " current: %" PRIu32 " "
+               "gain1: %" PRIu16 " gain2: %" PRIu16 "",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->ppg[0], message->ppg[1], message->current,
+               message->gain[0], message->gain[1]);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ppgd, struct sensor_ppgd, print_sensor_ppgd_message);

--- a/system/uorb/sensor/ppgd.h
+++ b/system/uorb/sensor/ppgd.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ppgd.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PPGD_H
+#define __APPS_SYSTEM_UORB_SENSOR_PPGD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ppgd);
+
+#endif

--- a/system/uorb/sensor/ppgq.c
+++ b/system/uorb/sensor/ppgq.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ppgq.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/ppgq.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_ppgq_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_ppgq *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "ppg1: %" PRIu32 " ppg2: %" PRIu32 " ppg3: %" PRIu32 " "
+               "ppg4: %" PRIu32 "current: %" PRIu32 " gain1: %" PRIu16 " "
+               "gain2: %" PRIu16 " gain3: %" PRIu16 " gain4: %" PRIu16 "",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->ppg[0], message->ppg[1], message->ppg[2],
+               message->ppg[3], message->current, message->gain[0],
+               message->gain[1], message->gain[2], message->gain[3]);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_ppgq, struct sensor_ppgq, print_sensor_ppgq_message);

--- a/system/uorb/sensor/ppgq.h
+++ b/system/uorb/sensor/ppgq.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/ppgq.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PPGQ_H
+#define __APPS_SYSTEM_UORB_SENSOR_PPGQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_ppgq);
+
+#endif

--- a/system/uorb/sensor/prox.c
+++ b/system/uorb/sensor/prox.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/prox.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/prox.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_prox_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_prox *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "proximity: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->proximity);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_prox, struct sensor_prox, print_sensor_prox_message);

--- a/system/uorb/sensor/prox.h
+++ b/system/uorb/sensor/prox.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/prox.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_PROX_H
+#define __APPS_SYSTEM_UORB_SENSOR_PROX_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_prox);
+
+#endif

--- a/system/uorb/sensor/rgb.c
+++ b/system/uorb/sensor/rgb.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/rgb.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/rgb.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_rgb_message(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct sensor_rgb *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) red: %.2f"
+               " green: %.2f blue: %.2f\n", meta->o_name, message->timestamp,
+               now - message->timestamp, message->r, message->g, message->b);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_rgb, struct sensor_rgb, print_sensor_rgb_message);

--- a/system/uorb/sensor/rgb.h
+++ b/system/uorb/sensor/rgb.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/rgb.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_RGB_H
+#define __APPS_SYSTEM_UORB_SENSOR_RGB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_rgb);
+
+#endif

--- a/system/uorb/sensor/temp.c
+++ b/system/uorb/sensor/temp.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/temp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/temp.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_temp_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_temp *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "temperature: %.4f", meta->o_name, message->timestamp,
+               now - message->timestamp, message->temperature);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_temp, struct sensor_temp, print_sensor_temp_message);

--- a/system/uorb/sensor/temp.h
+++ b/system/uorb/sensor/temp.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/temp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_TEMP_H
+#define __APPS_SYSTEM_UORB_SENSOR_TEMP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_temp);
+
+#endif

--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -113,7 +113,7 @@ static FAR const struct orb_metadata *g_sensor_list[] =
 FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
 {
   struct sensor_state_s state;
-  char path[PATH_MAX];
+  char path[ORB_PATH_MAX];
   int idx = -1;
   int ret;
   int fd;
@@ -141,11 +141,11 @@ FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
 
   /* Then open node to get meta */
 
-  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s", name);
+  snprintf(path, ORB_PATH_MAX, ORB_SENSOR_PATH"%s", name);
   fd = open(path, O_RDONLY);
   if (fd < 0)
     {
-      snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", name, 0);
+      snprintf(path, ORB_PATH_MAX, ORB_SENSOR_PATH"%s%d", name, 0);
       fd = open(path, O_RDONLY);
       if (fd < 0)
         {

--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -1,0 +1,164 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/topics.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+#include <sensor/accel.h>
+#include <sensor/baro.h>
+#include <sensor/cap.h>
+#include <sensor/co2.h>
+#include <sensor/dust.h>
+#include <sensor/ecg.h>
+#include <sensor/gps.h>
+#include <sensor/gyro.h>
+#include <sensor/gesture.h>
+#include <sensor/hall.h>
+#include <sensor/hbeat.h>
+#include <sensor/hcho.h>
+#include <sensor/hrate.h>
+#include <sensor/humi.h>
+#include <sensor/impd.h>
+#include <sensor/ir.h>
+#include <sensor/light.h>
+#include <sensor/mag.h>
+#include <sensor/noise.h>
+#include <sensor/ots.h>
+#include <sensor/ph.h>
+#include <sensor/pm25.h>
+#include <sensor/pm1p0.h>
+#include <sensor/pm10.h>
+#include <sensor/ppgd.h>
+#include <sensor/ppgq.h>
+#include <sensor/prox.h>
+#include <sensor/rgb.h>
+#include <sensor/temp.h>
+#include <sensor/tvoc.h>
+#include <sensor/uv.h>
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static FAR const struct orb_metadata *g_sensor_list[] =
+{
+  ORB_ID(sensor_accel),
+  ORB_ID(sensor_accel_uncal),
+  ORB_ID(sensor_baro),
+  ORB_ID(sensor_cap),
+  ORB_ID(sensor_co2),
+  ORB_ID(sensor_dust),
+  ORB_ID(sensor_ecg),
+  ORB_ID(sensor_gps),
+  ORB_ID(sensor_gps_satellite),
+  ORB_ID(sensor_gyro),
+  ORB_ID(sensor_gyro_uncal),
+  ORB_ID(sensor_hall),
+  ORB_ID(sensor_hbeat),
+  ORB_ID(sensor_hcho),
+  ORB_ID(sensor_humi),
+  ORB_ID(sensor_hrate),
+  ORB_ID(sensor_impd),
+  ORB_ID(sensor_ir),
+  ORB_ID(sensor_light),
+  ORB_ID(sensor_light_uncal),
+  ORB_ID(sensor_mag),
+  ORB_ID(sensor_mag_uncal),
+  ORB_ID(sensor_noise),
+  ORB_ID(sensor_ots),
+  ORB_ID(sensor_ph),
+  ORB_ID(sensor_pm10),
+  ORB_ID(sensor_pm1p0),
+  ORB_ID(sensor_pm25),
+  ORB_ID(sensor_ppgd),
+  ORB_ID(sensor_ppgq),
+  ORB_ID(sensor_prox),
+  ORB_ID(sensor_rgb),
+  ORB_ID(sensor_temp),
+  ORB_ID(sensor_tvoc),
+  ORB_ID(sensor_uv),
+  ORB_ID(sensor_wake_gesture),
+  ORB_ID(sensor_wake_gesture_uncal),
+  NULL,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
+{
+  struct sensor_state_s state;
+  char path[PATH_MAX];
+  int idx = -1;
+  int ret;
+  int fd;
+  int i;
+
+  /* Fisrt search built-in topics */
+
+  for (i = 0; g_sensor_list[i]; i++)
+    {
+      if (!strncmp(g_sensor_list[i]->o_name, name,
+          strlen(g_sensor_list[i]->o_name)))
+        {
+          if (idx == -1 || strlen(g_sensor_list[idx]->o_name) <
+                           strlen(g_sensor_list[i]->o_name))
+            {
+              idx = i;
+            }
+        }
+    }
+
+  if (idx != -1)
+    {
+      return g_sensor_list[idx];
+    }
+
+  /* Then open node to get meta */
+
+  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s", name);
+  fd = open(path, O_RDONLY);
+  if (fd < 0)
+    {
+      snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", name, 0);
+      fd = open(path, O_RDONLY);
+      if (fd < 0)
+        {
+          return NULL;
+        }
+    }
+
+  ret = ioctl(fd, SNIOC_GET_STATE, (unsigned long)(uintptr_t)&state);
+  close(fd);
+  if (ret < 0)
+    {
+      return NULL;
+    }
+
+  return state.priv;
+}

--- a/system/uorb/sensor/tvoc.c
+++ b/system/uorb/sensor/tvoc.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/tvoc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/tvoc.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_tvoc_message(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct sensor_tvoc *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) tvoc: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->tvoc);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_tvoc, struct sensor_tvoc, print_sensor_tvoc_message);

--- a/system/uorb/sensor/tvoc.h
+++ b/system/uorb/sensor/tvoc.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/tvoc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_TVOC_H
+#define __APPS_SYSTEM_UORB_SENSOR_TVOC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_tvoc);
+
+#endif

--- a/system/uorb/sensor/uv.c
+++ b/system/uorb/sensor/uv.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/uv.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/uv.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_uv_message(FAR const struct orb_metadata *meta,
+                                    FAR const void *buffer)
+{
+  FAR const struct sensor_uv *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) uvi: %.4f",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->uvi);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_uv, struct sensor_uv, print_sensor_uv_message);

--- a/system/uorb/sensor/uv.h
+++ b/system/uorb/sensor/uv.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/uv.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_UV_H
+#define __APPS_SYSTEM_UORB_SENSOR_UV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_uv);
+
+#endif

--- a/system/uorb/test/unit_test.c
+++ b/system/uorb/test/unit_test.c
@@ -61,10 +61,16 @@ static int pubsubtest_thread_entry(int argc, FAR char *argv[])
   int current_value;
   int num_missed = 0;
   unsigned timingsgroup = 0;
-  unsigned timings[MAX_RUNS];
+  FAR unsigned *timings;
   unsigned timing_min = 9999999;
   unsigned timing_max = 0;
   unsigned i;
+
+  timings = malloc(MAX_RUNS * sizeof(unsigned));
+  if (timings == NULL)
+    {
+      return -ENOMEM;
+    }
 
   /* clear all ready flags */
 
@@ -128,6 +134,7 @@ static int pubsubtest_thread_entry(int argc, FAR char *argv[])
       if (f == NULL)
         {
           snerr("Error opening file!");
+          free(timings);
           return ERROR;
         }
 
@@ -167,6 +174,7 @@ static int pubsubtest_thread_entry(int argc, FAR char *argv[])
       g_pubsubtest_res = OK;
     }
 
+  free(timings);
   return g_pubsubtest_res;
 }
 

--- a/system/uorb/test/unit_test.c
+++ b/system/uorb/test/unit_test.c
@@ -1,0 +1,1076 @@
+/****************************************************************************
+ * apps/system/uorb/test/unit_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <math.h>
+#include <poll.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "utility.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static volatile bool g_thread_should_exit;
+static volatile int  g_num_messages_sent;
+static bool          g_pubsubtest_passed;
+static bool          g_pubsubtest_print;
+static int           g_pubsubtest_res;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int pubsubtest_thread_entry(int argc, FAR char *argv[])
+{
+  /* poll on test topic and output latency */
+
+  struct pollfd fds[1];
+  struct orb_test_medium_s t;
+
+  static const unsigned MAX_RUNS = 1000;
+  float latency_integral = 0.0f;
+  float std_dev = 0.f;
+  float mean;
+  int test_multi_sub;
+  int current_value;
+  int num_missed = 0;
+  unsigned timingsgroup = 0;
+  unsigned timings[MAX_RUNS];
+  unsigned timing_min = 9999999;
+  unsigned timing_max = 0;
+  unsigned i;
+
+  /* clear all ready flags */
+
+  test_multi_sub = orb_subscribe_multi(ORB_ID(orb_test_medium), 0);
+
+  orb_copy(ORB_ID(orb_test_medium), test_multi_sub, &t);
+
+  fds[0].fd     = test_multi_sub;
+  fds[0].events = POLLIN;
+  current_value = t.val;
+
+  for (i = 0; i < MAX_RUNS; i++)
+    {
+      int pret;
+
+      /* wait for up to 500ms for data */
+
+      pret = poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 500);
+      if (fds[0].revents & POLLIN)
+        {
+          unsigned elt;
+
+          orb_copy(ORB_ID(orb_test_medium), test_multi_sub, &t);
+          elt = (unsigned)orb_elapsed_time(&t.timestamp);
+          latency_integral += elt;
+          timings[i] = elt;
+
+          if (elt > timing_max)
+            {
+              timing_max = elt;
+            }
+
+          if (elt < timing_min)
+            {
+              timing_min = elt;
+            }
+
+          timingsgroup  = 0;
+          num_missed   += t.val - current_value - 1;
+          current_value = t.val;
+        }
+
+      if (pret < 0)
+        {
+          snerr("poll error %d, %d", pret, errno);
+          continue;
+        }
+    }
+
+  orb_unsubscribe(test_multi_sub);
+
+  if (g_pubsubtest_print)
+    {
+      char fname[32];
+      FAR FILE *f;
+
+      sprintf(fname, CONFIG_UORB_SRORAGE_DIR"/uorb_timings%u.txt",
+              timingsgroup);
+
+      f = fopen(fname, "w");
+      if (f == NULL)
+        {
+          snerr("Error opening file!");
+          return ERROR;
+        }
+
+      for (i = 0; i < MAX_RUNS; i++)
+        {
+          fprintf(f, "%u\n", timings[i]);
+        }
+
+      fclose(f);
+    }
+
+  std_dev = 0.f;
+  mean    = latency_integral / MAX_RUNS;
+
+  for (i = 0; i < MAX_RUNS; i++)
+    {
+      float diff;
+
+      diff     = (float)timings[i] - mean;
+      std_dev += diff * diff;
+    }
+
+  printf("mean:    %u us\n", (unsigned)(mean));
+  printf("std dev: %u us\n", (unsigned)(sqrtf(std_dev / (MAX_RUNS - 1))));
+  printf("min:     %u us\n", timing_min);
+  printf("max:     %u us\n", timing_max);
+  printf("missed topic updates: %i\n", num_missed);
+
+  g_pubsubtest_passed = true;
+
+  if (latency_integral / MAX_RUNS > 100.0f)
+    {
+      g_pubsubtest_res = ERROR;
+    }
+  else
+    {
+      g_pubsubtest_res = OK;
+    }
+
+  return g_pubsubtest_res;
+}
+
+static int latency_test(bool print)
+{
+  FAR char *const args[1];
+  struct orb_test_medium_s sample;
+  int pubsub_task;
+  int fd;
+
+  test_note("---------------- LATENCY TEST ------------------");
+
+  sample.val       = 308;
+  sample.timestamp = orb_absolute_time();
+
+  fd = orb_advertise(ORB_ID(orb_test_medium), &sample);
+  if (fd < 0)
+    {
+      return test_fail("orb_advertise failed (%i)", errno);
+    }
+
+  g_pubsubtest_print  = print;
+  g_pubsubtest_passed = false;
+
+  /* test pub / sub latency
+   * Can't pass a pointer in args, must be a null terminated
+   * array of strings because the strings are copied to
+   * prevent access if the caller data goes out of scope
+   */
+
+  args[0] = NULL;
+  pubsub_task = task_create("uorb_latency",
+                            SCHED_PRIORITY_DEFAULT,
+                            CONFIG_UORB_STACKSIZE,
+                            pubsubtest_thread_entry,
+                            args);
+
+  /* give the test task some data */
+
+  while (!g_pubsubtest_passed)
+    {
+      ++sample.val;
+      sample.timestamp = orb_absolute_time();
+      if (OK != orb_publish(ORB_ID(orb_test_medium), fd, &sample))
+        {
+          return test_fail("mult. pub0 timing fail");
+        }
+
+      usleep(1000); /* simulate >800 Hz system operation */
+    }
+
+  if (pubsub_task < 0)
+    {
+      return test_fail("failed launching task");
+    }
+
+  orb_unadvertise(fd);
+  return g_pubsubtest_res;
+}
+
+static int test_single(void)
+{
+  struct orb_test_s sample;
+  struct orb_test_s sub_sample;
+  bool updated;
+  int afd;
+  int sfd;
+  int ret;
+
+  test_note("try single-topic support");
+
+  /* advertise, then subscribe */
+
+  sample.val = 0;
+
+  afd = orb_advertise(ORB_ID(orb_test), &sample);
+  if (afd < 0)
+    {
+      return test_fail("advertise failed: %d", errno);
+    }
+
+  sfd = orb_subscribe(ORB_ID(orb_test));
+  if (sfd < 0)
+    {
+      return test_fail("subscribe failed: %d", errno);
+    }
+
+  /* check first publish */
+
+  sub_sample.val = 1;
+
+  if (OK != orb_copy(ORB_ID(orb_test), sfd, &sub_sample))
+    {
+      return test_fail("copy(1) failed: %d", errno);
+    }
+
+  if (sample.val != sub_sample.val)
+    {
+      return test_fail("copy(1) mismatch: %d expected %d",
+                       sub_sample.val, sample.val);
+    }
+
+  if (OK != orb_check(sfd, &updated))
+    {
+      return test_fail("check(1) failed");
+    }
+
+  if (updated)
+    {
+      return test_fail("spurious updated flag");
+    }
+
+  /* check second publish */
+
+  sample.val = 2;
+
+  if (OK != orb_publish(ORB_ID(orb_test), afd, &sample))
+    {
+      return test_fail("publish failed");
+    }
+
+  if (OK != orb_check(sfd, &updated))
+    {
+      return test_fail("check(2) failed");
+    }
+
+  if (!updated)
+    {
+      return test_fail("missing updated flag");
+    }
+
+  if (OK != orb_copy(ORB_ID(orb_test), sfd, &sub_sample))
+    {
+      return test_fail("copy(2) failed: %d", errno);
+    }
+
+  if (sample.val != sub_sample.val)
+    {
+      return test_fail("copy(2) mismatch: %d expected %d",
+                       sub_sample.val, sample.val);
+    }
+
+  /* unadvertise and out */
+
+  ret = orb_unadvertise(afd);
+  if (ret != OK)
+    {
+      return test_fail("orb_unadvertise failed: %i", ret);
+    }
+
+  ret = orb_unsubscribe(sfd);
+  if (ret != OK)
+    {
+      return test_fail("orb_unsubscribe failed: %i", ret);
+    }
+
+  return test_note("PASS single-topic test");
+}
+
+static int test_multi_inst10(void)
+{
+  const int max_inst = 10;
+  int sfd[max_inst];
+  int afd[max_inst];
+  int i;
+  int j;
+
+  for (i = 0; i < max_inst; i++)
+    {
+      sfd[i] = orb_subscribe_multi(ORB_ID(orb_test), i);
+    }
+
+  /* verify not advertised yet */
+
+  for (i = 0; i < max_inst; i++)
+    {
+      if (OK == orb_exists(ORB_ID(orb_test), i))
+        {
+          return test_fail("sub %d is advertised", i);
+        }
+    }
+
+  /* advertise one at a time and verify instance */
+
+  for (i = 0; i < max_inst; i++)
+    {
+      afd[i] = orb_advertise_multi_queue(ORB_ID(orb_test), NULL, &i, 1);
+      if (OK != orb_exists(ORB_ID(orb_test), i))
+        {
+          return test_fail("sub %d advertise failed", i);
+        }
+    }
+
+  /* publish one at a time and verify */
+
+  for (i = 0; i < 2; i++)
+    {
+      for (j = 0; j < 10; j++)
+        {
+          int instance;
+          int sub_instance;
+
+          for (instance = 0; instance < max_inst; instance++)
+            {
+              struct orb_test_s sample;
+
+              sample.val       = j * instance + i;
+              sample.timestamp = orb_absolute_time();
+
+              orb_publish(ORB_ID(orb_test), afd[instance], &sample);
+            }
+
+          for (sub_instance = 0; sub_instance < max_inst; sub_instance++)
+            {
+              bool updated = false;
+
+              orb_check(sfd[sub_instance], &updated);
+              if (!updated)
+                {
+                  return test_fail("sub %d not updated", sub_instance);
+                }
+              else
+                {
+                  struct orb_test_s sample;
+
+                  if (orb_copy(ORB_ID(orb_test), sfd[sub_instance], &sample))
+                    {
+                      return test_fail("sub %d copy failed", sub_instance);
+                    }
+                  else
+                    {
+                      if (sample.val != (j * sub_instance + i))
+                        {
+                          return test_fail("sub %d invalid value %d",
+                                           sub_instance, sample.val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+  /* force unsubscribe all, then repeat */
+
+  for (i = 0; i < max_inst; i++)
+    {
+      orb_unsubscribe(sfd[i]);
+    }
+
+  return test_note("PASS orb 10-instances");
+}
+
+static int test_multi(int *afds, int *sfds)
+{
+  struct orb_test_s sample;
+  struct orb_test_s sub_sample;
+  int instance0 = 0;
+  int instance1 = 1;
+
+  /* this routine tests the multi-topic support */
+
+  test_note("try multi-topic support");
+
+  afds[0] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance0);
+
+  if (instance0 != 0)
+    {
+      return test_fail("mult. id0: %d", instance0);
+    }
+
+  afds[1] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance1);
+
+  if (instance1 != 1)
+    {
+      return test_fail("mult. id1: %d", instance1);
+    }
+
+  sample.val = 103;
+
+  if (OK != orb_publish(ORB_ID(orb_multitest), afds[0], &sample))
+    {
+      return test_fail("mult. pub0 fail");
+    }
+
+  sample.val = 203;
+
+  if (OK != orb_publish(ORB_ID(orb_multitest), afds[1], &sample))
+    {
+      return test_fail("mult. pub1 fail");
+    }
+
+  /* subscribe to both topics and ensure valid data is received */
+
+  sfds[0] = orb_subscribe_multi(ORB_ID(orb_multitest), 0);
+
+  if (OK != orb_copy(ORB_ID(orb_multitest), sfds[0], &sub_sample))
+    {
+      return test_fail("sub #0 copy failed: %d", errno);
+    }
+
+  if (sub_sample.val != 103)
+    {
+      return test_fail("sub #0 val. mismatch: %d", sub_sample.val);
+    }
+
+  sfds[1] = orb_subscribe_multi(ORB_ID(orb_multitest), 1);
+
+  if (OK != orb_copy(ORB_ID(orb_multitest), sfds[1], &sub_sample))
+    {
+      return test_fail("sub #1 copy failed: %d", errno);
+    }
+
+  if (sub_sample.val != 203)
+    {
+      return test_fail("sub #1 val. mismatch: %d", sub_sample.val);
+    }
+
+  if (OK != latency_test(false))
+    {
+      return test_fail("latency test failed");
+    }
+
+  orb_unsubscribe(sfds[0]);
+  orb_unsubscribe(sfds[1]);
+
+  return test_note("PASS multi-topic test");
+}
+
+static int test_multi_reversed(int *afds, int *sfds)
+{
+  struct orb_test_s sample;
+  struct orb_test_s sub_sample;
+  int instance2 = 2;
+  int instance3 = 3;
+
+  test_note("try multi-topic support subscribing before publishing");
+
+  /* For these tests 0 and 1 instances are taken from before,
+   * therefore continue with 2 and 3,
+   * subscribe first and advertise afterwards.
+   */
+
+  sfds[2] = orb_subscribe_multi(ORB_ID(orb_multitest), 2);
+
+  if (sfds[2] < 0)
+    {
+      return test_fail("sub. id2: ret: %d", sfds[2]);
+    }
+
+  afds[2] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance2);
+
+  if (instance2 != 2)
+    {
+      return test_fail("mult. id2: %d", instance2);
+    }
+
+  afds[3] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance3);
+
+  if (instance3 != 3)
+    {
+      return test_fail("mult. id3: %d", instance3);
+    }
+
+  sample.val = 204;
+
+  if (OK != orb_publish(ORB_ID(orb_multitest), afds[2], &sample))
+    {
+      return test_fail("mult. pub2 fail");
+    }
+
+  sample.val = 304;
+
+  if (OK != orb_publish(ORB_ID(orb_multitest), afds[3], &sample))
+    {
+      return test_fail("mult. pub3 fail");
+    }
+
+  /* subscribe to both topics and ensure valid data is received */
+
+  sfds[2] = orb_subscribe_multi(ORB_ID(orb_multitest), 2);
+
+  if (OK != orb_copy(ORB_ID(orb_multitest), sfds[2], &sub_sample))
+    {
+      return test_fail("sub #2 copy failed: %d", errno);
+    }
+
+  if (sub_sample.val != 204)
+    {
+      return test_fail("sub #2 val. mismatch: %d", sub_sample.val);
+    }
+
+  sfds[3] = orb_subscribe_multi(ORB_ID(orb_multitest), 3);
+
+  if (OK != orb_copy(ORB_ID(orb_multitest), sfds[3], &sub_sample))
+    {
+      return test_fail("sub #3 copy failed: %d", errno);
+    }
+
+  if (sub_sample.val != 304)
+    {
+      return test_fail("sub #3 val. mismatch: %d", sub_sample.val);
+    }
+
+  return test_note("PASS multi-topic reversed");
+}
+
+static int test_unadvertise(int *afds)
+{
+  int ret;
+  int i;
+
+  test_note("Testing unadvertise");
+
+  /* we still have the advertisements from the previous test_multi calls. */
+
+  for (i = 0; i < 4; ++i)
+    {
+      ret = orb_unadvertise(afds[i]);
+      if (ret != OK)
+        {
+          return test_fail("orb_unadvertise failed (%i)", ret);
+        }
+    }
+
+  return OK;
+}
+
+static int pub_test_multi2_entry(int argc, char *argv[])
+{
+  struct orb_test_medium_s data_topic;
+  const int num_instances = 3;
+  int data_next_idx = 0;
+  int orb_pub[num_instances];
+  int message_counter = 0;
+  int num_messages = 50 * num_instances;
+  int i;
+
+  memset(&data_topic, '\0', sizeof(data_topic));
+  for (i = 0; i < num_instances; ++i)
+    {
+      orb_pub[i] = orb_advertise_multi(ORB_ID(orb_test_medium_multi),
+                                       &data_topic, &i);
+    }
+
+  usleep(100 * 1000);
+
+  while (message_counter++ < num_messages)
+    {
+      usleep(2); /* make sure the timestamps are different */
+
+      data_topic.timestamp = orb_absolute_time();
+      data_topic.val       = data_next_idx;
+
+      orb_publish(ORB_ID(orb_test_medium_multi), orb_pub[data_next_idx],
+                  &data_topic);
+
+      data_next_idx = (data_next_idx + 1) % num_instances;
+      if (data_next_idx == 0)
+        {
+          usleep(50 * 1000);
+        }
+    }
+
+  usleep(100 * 1000);
+
+  g_thread_should_exit = true;
+
+  for (i = 0; i < num_instances; ++i)
+    {
+      orb_unadvertise(orb_pub[i]);
+    }
+
+  return OK;
+}
+
+static int test_multi2(void)
+{
+  const int num_instances = 3;
+  int orb_data_fd[num_instances];
+  int orb_data_next     = 0;
+  orb_abstime last_time = 0;
+  FAR char *const args[1];
+  int pubsub_task;
+  int i;
+
+  test_note("Testing multi-topic 2 test (queue simulation)");
+
+  g_thread_should_exit = false;
+
+  /* test: first subscribe, then advertise */
+
+  for (i = 0; i < num_instances; ++i)
+    {
+      orb_data_fd[i] = orb_subscribe_multi(ORB_ID(orb_test_medium_multi), i);
+    }
+
+  /* launch the publisher thread */
+
+  args[0] = NULL;
+  pubsub_task = task_create("uorb_test_multi",
+                            SCHED_PRIORITY_MAX - 5,
+                            CONFIG_UORB_STACKSIZE,
+                            (main_t)&pub_test_multi2_entry,
+                            args);
+  if (pubsub_task < 0)
+    {
+      return test_fail("failed launching task");
+    }
+
+  /* loop check update and copy new data */
+
+  while (!g_thread_should_exit)
+    {
+      bool updated        = false;
+      int orb_data_cur_fd = orb_data_fd[orb_data_next];
+
+      usleep(1000);
+
+      orb_check(orb_data_cur_fd, &updated);
+      if (updated)
+        {
+          struct orb_test_medium_s msg =
+            {
+              0, 0
+            };
+
+          orb_copy(ORB_ID(orb_test_medium_multi), orb_data_cur_fd, &msg);
+          if (last_time >= msg.timestamp && last_time != 0)
+            {
+              return test_fail("Timestamp not increasing! (%" PRIu64
+                               " >= %" PRIu64 ")", last_time, msg.timestamp);
+            }
+
+          last_time     = msg.timestamp;
+          orb_data_next = (orb_data_next + 1) % num_instances;
+        }
+    }
+
+  for (i = 0; i < num_instances; ++i)
+    {
+      orb_unsubscribe(orb_data_fd[i]);
+    }
+
+  return test_note("PASS multi-topic 2 test (queue simulation)");
+}
+
+int test_queue(void)
+{
+  const int queue_size  = 16;
+  const int overflow_by = 3;
+  struct orb_test_medium_s sample;
+  struct orb_test_medium_s sub_sample;
+  bool updated;
+  int ptopic;
+  int sfd;
+  int i;
+
+  test_note("Testing orb queuing");
+
+  sfd = orb_subscribe(ORB_ID(orb_test_medium_queue));
+
+  if (sfd < 0)
+    {
+      return test_fail("subscribe failed: %d", errno);
+    }
+
+  /* Get all published messages,
+   * ensure that publish and subscribe message match
+   */
+
+  do
+    {
+      orb_check(sfd, &updated);
+      if (updated)
+        {
+          orb_copy(ORB_ID(orb_test_medium_queue), sfd, &sub_sample);
+        }
+    }
+  while (updated);
+
+  ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue),
+                               &sample, queue_size);
+  if (ptopic < 0)
+    {
+      return test_fail("advertise failed: %d", errno);
+    }
+
+  orb_check(sfd, &updated);
+  if (!updated)
+    {
+      return test_fail("update flag not set");
+    }
+
+  if (OK != orb_copy(ORB_ID(orb_test_medium_queue), sfd, &sub_sample))
+    {
+      return test_fail("copy(1) failed: %d", errno);
+    }
+
+  if (sub_sample.val != sample.val)
+    {
+      return test_fail("copy(1) mismatch: %d expected %d",
+                       sub_sample.val, sample.val);
+    }
+
+  orb_check(sfd, &updated);
+  if (updated)
+    {
+      return test_fail("spurious updated flag");
+    }
+
+#define CHECK_UPDATED(element) \
+  orb_check(sfd, &updated); \
+  if (!updated) \
+    { \
+      return test_fail("update flag not set, element %i", element); \
+    }
+
+#define CHECK_NOT_UPDATED(element) \
+  orb_check(sfd, &updated); \
+  if (updated) \
+    { \
+      return test_fail("update flag set, element %i", element); \
+    }
+
+#define CHECK_COPY(i_got, i_correct) \
+  orb_copy(ORB_ID(orb_test_medium_queue), sfd, &sub_sample); \
+  if (i_got != i_correct) \
+    { \
+      return test_fail("got wrong element from the queue (got %i," \
+                       "should be %i)", i_got, i_correct); \
+    }
+
+  /* no messages in the queue anymore */
+
+  test_note("  Testing to write some elements...");
+
+  for (i = 0; i < queue_size - 2; ++i)
+    {
+      sample.val = i;
+      orb_publish(ORB_ID(orb_test_medium_queue), ptopic, &sample);
+    }
+
+  for (i = 0; i < queue_size - 2; ++i)
+    {
+      CHECK_UPDATED(i);
+      CHECK_COPY(sub_sample.val, i);
+    }
+
+  CHECK_NOT_UPDATED(queue_size);
+
+  test_note("  Testing overflow...");
+
+  for (i = 0; i < queue_size + overflow_by; ++i)
+    {
+      sample.val = i;
+      orb_publish(ORB_ID(orb_test_medium_queue), ptopic, &sample);
+    }
+
+  for (i = 0; i < queue_size; ++i)
+    {
+      CHECK_UPDATED(i);
+      CHECK_COPY(sub_sample.val, i + overflow_by);
+    }
+
+  CHECK_NOT_UPDATED(queue_size);
+
+  test_note("  Testing underflow...");
+
+  for (i = 0; i < queue_size; ++i)
+    {
+      CHECK_NOT_UPDATED(i);
+      CHECK_COPY(sub_sample.val, queue_size + overflow_by - 1);
+    }
+
+  sample.val = 943;
+
+  orb_publish(ORB_ID(orb_test_medium_queue), ptopic, &sample);
+
+  CHECK_UPDATED(-1);
+  CHECK_COPY(sub_sample.val, sample.val);
+
+#undef CHECK_COPY
+#undef CHECK_UPDATED
+#undef CHECK_NOT_UPDATED
+
+  orb_unadvertise(ptopic);
+  orb_unsubscribe(sfd);
+
+  return test_note("PASS orb queuing");
+}
+
+static int pub_test_queue_entry(int argc, char *argv[])
+{
+  const int queue_size = 50;
+  struct orb_test_medium_s t;
+  int num_messages = 20 * queue_size;
+  int message_counter = 0;
+  int ptopic;
+
+  memset(&t, '\0', sizeof(t));
+  ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue_poll),
+                               &t, queue_size);
+  if (ptopic < 0)
+    {
+      g_thread_should_exit = true;
+      return test_fail("advertise failed: %d", errno);
+    }
+
+  ++t.val;
+
+  while (message_counter < num_messages)
+    {
+      /* simulate burst */
+
+      int burst_counter = 0;
+
+      while (burst_counter++ < queue_size / 2 + 7)
+        {
+          /* make interval non-boundary aligned */
+
+          orb_publish(ORB_ID(orb_test_medium_queue_poll), ptopic, &t);
+          ++t.val;
+        }
+
+      message_counter += burst_counter;
+      usleep(20 * 1000); /* give subscriber a chance to catch up */
+    }
+
+  g_num_messages_sent = t.val;
+  usleep(100 * 1000);
+  g_thread_should_exit = true;
+  orb_unadvertise(ptopic);
+
+  return 0;
+}
+
+static int test_queue_poll_notify(void)
+{
+  FAR char *const args[1];
+  struct pollfd fds[1];
+  struct orb_test_medium_s t;
+  bool updated;
+  int next_expected_val = 0;
+  int pubsub_task;
+  int sfd;
+
+  test_note("Testing orb queuing (poll & notify)");
+
+  if ((sfd = orb_subscribe(ORB_ID(orb_test_medium_queue_poll))) < 0)
+    {
+      return test_fail("subscribe failed: %d", errno);
+    }
+
+  /* Get all published messages,
+   * ensure that publish and subscribe message match
+   */
+
+  do
+    {
+      orb_check(sfd, &updated);
+      if (updated)
+        {
+          orb_copy(ORB_ID(orb_test_medium_queue_poll), sfd, &t);
+        }
+    }
+  while (updated);
+
+  g_thread_should_exit = false;
+
+  args[0] = NULL;
+  pubsub_task = task_create("uorb_test_queue",
+                            SCHED_PRIORITY_MIN + 5,
+                            CONFIG_UORB_STACKSIZE,
+                            (main_t)&pub_test_queue_entry,
+                            args);
+
+  if (pubsub_task < 0)
+    {
+      return test_fail("failed launching task");
+    }
+
+  fds[0].fd     = sfd;
+  fds[0].events = POLLIN;
+
+  while (!g_thread_should_exit)
+    {
+      int poll_ret;
+
+      poll_ret = poll(fds, 1, 500);
+      if (poll_ret == 0)
+        {
+          if (g_thread_should_exit)
+            {
+              break;
+            }
+
+          return test_fail("poll timeout");
+        }
+      else if (poll_ret < 0 && errno != EINTR)
+        {
+          return test_fail("poll error (%d, %d)", poll_ret, errno);
+        }
+
+      if (fds[0].revents & POLLIN)
+        {
+          orb_copy(ORB_ID(orb_test_medium_queue_poll), sfd, &t);
+          if (next_expected_val != t.val)
+            {
+              return test_fail("copy mismatch: %d expected %d",
+                               t.val, next_expected_val);
+            }
+
+          ++next_expected_val;
+        }
+    }
+
+  if (g_num_messages_sent != next_expected_val)
+    {
+      return test_fail("number of sent and received messages mismatch"
+                       " (sent: %i, received: %i)",
+                       g_num_messages_sent, next_expected_val);
+    }
+
+  orb_unsubscribe(sfd);
+
+  return OK;
+}
+
+static int test(void)
+{
+  int afds[4];
+  int sfds[4];
+  int ret;
+
+  ret = test_single();
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_multi_inst10();
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_multi(afds, sfds);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_multi_reversed(afds, sfds);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_unadvertise(afds);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_multi2();
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  ret = test_queue();
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  return test_queue_poll_notify();
+}
+
+int main(int argc, FAR char *argv[])
+{
+  /* Test the driver/device. */
+
+  if (argc == 1)
+    {
+      if (test() == OK)
+        {
+          printf("PASS\n");
+          return 0;
+        }
+      else
+        {
+          printf("FAIL\n");
+          return -1;
+        }
+    }
+
+  /* Test the latency. */
+
+  if (argc > 1 && !strcmp(argv[1], "latency_test"))
+    {
+      return latency_test(true);
+    }
+
+  printf("Usage: uorb_tests [latency_test]\n");
+  return -EINVAL;
+}

--- a/system/uorb/test/unit_test.c
+++ b/system/uorb/test/unit_test.c
@@ -183,6 +183,7 @@ static int latency_test(bool print)
   FAR char *const args[1];
   struct orb_test_medium_s sample;
   int pubsub_task;
+  int instance = 0;
   int fd;
 
   test_note("---------------- LATENCY TEST ------------------");
@@ -190,7 +191,8 @@ static int latency_test(bool print)
   sample.val       = 308;
   sample.timestamp = orb_absolute_time();
 
-  fd = orb_advertise(ORB_ID(orb_test_medium), &sample);
+  fd = orb_advertise_multi_queue_persist(ORB_ID(orb_test_medium),
+                                         &sample, &instance, 1);
   if (fd < 0)
     {
       return test_fail("orb_advertise failed (%i)", errno);
@@ -239,6 +241,7 @@ static int test_single(void)
 {
   struct orb_test_s sample;
   struct orb_test_s sub_sample;
+  int instance = 0;
   bool updated;
   int afd;
   int sfd;
@@ -250,7 +253,8 @@ static int test_single(void)
 
   sample.val = 0;
 
-  afd = orb_advertise(ORB_ID(orb_test), &sample);
+  afd = orb_advertise_multi_queue_persist(ORB_ID(orb_test),
+                                          &sample, &instance, 1);
   if (afd < 0)
     {
       return test_fail("advertise failed: %d", errno);
@@ -361,7 +365,8 @@ static int test_multi_inst10(void)
 
   for (i = 0; i < max_inst; i++)
     {
-      afd[i] = orb_advertise_multi_queue(ORB_ID(orb_test), NULL, &i, 1);
+      afd[i] = orb_advertise_multi_queue_persist(ORB_ID(orb_test),
+                                                 NULL, &i, 1);
       if (OK != orb_exists(ORB_ID(orb_test), i))
         {
           return test_fail("sub %d advertise failed", i);
@@ -438,14 +443,16 @@ static int test_multi(int *afds, int *sfds)
 
   test_note("try multi-topic support");
 
-  afds[0] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance0);
+  afds[0] = orb_advertise_multi_queue_persist(ORB_ID(orb_multitest),
+                                              &sample, &instance0, 1);
 
   if (instance0 != 0)
     {
       return test_fail("mult. id0: %d", instance0);
     }
 
-  afds[1] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance1);
+  afds[1] = orb_advertise_multi_queue_persist(ORB_ID(orb_multitest),
+                                              &sample, &instance1, 1);
 
   if (instance1 != 1)
     {
@@ -524,14 +531,16 @@ static int test_multi_reversed(int *afds, int *sfds)
       return test_fail("sub. id2: ret: %d", sfds[2]);
     }
 
-  afds[2] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance2);
+  afds[2] = orb_advertise_multi_queue_persist(ORB_ID(orb_multitest),
+                                              &sample, &instance2, 1);
 
   if (instance2 != 2)
     {
       return test_fail("mult. id2: %d", instance2);
     }
 
-  afds[3] = orb_advertise_multi(ORB_ID(orb_multitest), &sample, &instance3);
+  afds[3] = orb_advertise_multi_queue_persist(ORB_ID(orb_multitest),
+                                              &sample, &instance3, 1);
 
   if (instance3 != 3)
     {
@@ -615,8 +624,8 @@ static int pub_test_multi2_entry(int argc, char *argv[])
   memset(&data_topic, '\0', sizeof(data_topic));
   for (i = 0; i < num_instances; ++i)
     {
-      orb_pub[i] = orb_advertise_multi(ORB_ID(orb_test_medium_multi),
-                                       &data_topic, &i);
+      orb_pub[i] = orb_advertise_multi_queue_persist(
+        ORB_ID(orb_test_medium_multi), &data_topic, &i, 1);
     }
 
   usleep(100 * 1000);
@@ -728,6 +737,7 @@ int test_queue(void)
   struct orb_test_medium_s sample;
   struct orb_test_medium_s sub_sample;
   bool updated;
+  int instance = 0;
   int ptopic;
   int sfd;
   int i;
@@ -755,8 +765,8 @@ int test_queue(void)
     }
   while (updated);
 
-  ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue),
-                               &sample, queue_size);
+  ptopic = orb_advertise_multi_queue_persist(
+    ORB_ID(orb_test_medium_queue), &sample, &instance, queue_size);
   if (ptopic < 0)
     {
       return test_fail("advertise failed: %d", errno);
@@ -872,11 +882,12 @@ static int pub_test_queue_entry(int argc, char *argv[])
   struct orb_test_medium_s t;
   int num_messages = 20 * queue_size;
   int message_counter = 0;
+  int instance = 0;
   int ptopic;
 
   memset(&t, '\0', sizeof(t));
-  ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue_poll),
-                               &t, queue_size);
+  ptopic = orb_advertise_multi_queue_persist(
+    ORB_ID(orb_test_medium_queue_poll), &t, &instance, queue_size);
   if (ptopic < 0)
     {
       g_thread_should_exit = true;

--- a/system/uorb/test/utility.c
+++ b/system/uorb/test/utility.c
@@ -1,0 +1,122 @@
+/****************************************************************************
+ * apps/system/uorb/test/utility.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "utility.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_orb_test_msg(FAR const struct orb_metadata *meta,
+                               FAR const void *buffer)
+{
+  FAR const struct orb_test_s *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %"PRIu64" (%"PRIu64" us ago) val: %"PRId32"",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->val);
+}
+
+static void print_orb_test_medium_msg(FAR const struct orb_metadata *meta,
+                                      FAR const void *buffer)
+{
+  FAR const struct orb_test_medium_s *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %"PRIu64" (%"PRIu64" us ago) val: %"PRId32"",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->val);
+}
+
+static void print_orb_test_large_msg(FAR const struct orb_metadata *meta,
+                                     FAR const void *buffer)
+{
+  FAR const struct orb_test_large_s *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %"PRIu64" (%"PRIu64" us ago) val: %"PRId32"",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->val);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(orb_test, struct orb_test_s, print_orb_test_msg);
+ORB_DEFINE(orb_multitest, struct orb_test_s, print_orb_test_msg);
+ORB_DEFINE(orb_test_medium, struct orb_test_medium_s,
+           print_orb_test_medium_msg);
+ORB_DEFINE(orb_test_medium_multi, struct orb_test_medium_s,
+           print_orb_test_medium_msg);
+ORB_DEFINE(orb_test_medium_wrap_around, struct orb_test_medium_s,
+           print_orb_test_medium_msg);
+ORB_DEFINE(orb_test_medium_queue, struct orb_test_medium_s,
+           print_orb_test_medium_msg);
+ORB_DEFINE(orb_test_medium_queue_poll, struct orb_test_medium_s,
+           print_orb_test_medium_msg);
+ORB_DEFINE(orb_test_large, struct orb_test_large_s,
+           print_orb_test_large_msg);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int test_note(FAR const char *fmt, ...)
+{
+  va_list ap;
+
+  fprintf(stderr, "uORB note: ");
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+
+  va_end(ap);
+
+  fprintf(stderr, "\n");
+  fflush(stderr);
+
+  return OK;
+}
+
+int test_fail(FAR const char *fmt, ...)
+{
+  va_list ap;
+
+  fprintf(stderr, "uORB fail: ");
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+
+  va_end(ap);
+
+  fprintf(stderr, "\n");
+  fflush(stderr);
+
+  return ERROR;
+}

--- a/system/uorb/test/utility.h
+++ b/system/uorb/test/utility.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/system/uorb/test/utility.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APP_SYSTEM_UORB_UORB_TEST_UTILITY_H
+#define __APP_SYSTEM_UORB_UORB_TEST_UTILITY_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "uORB/uORB.h"
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct orb_test_s
+{
+  uint64_t timestamp;
+  int32_t val;
+};
+
+struct orb_test_medium_s
+{
+  uint64_t timestamp;
+  int32_t val;
+};
+
+struct orb_test_large_s
+{
+  uint64_t timestamp;
+  int32_t val;
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(orb_test);
+ORB_DECLARE(orb_multitest);
+ORB_DECLARE(orb_test_large);
+ORB_DECLARE(orb_test_medium);
+ORB_DECLARE(orb_test_medium_multi);
+ORB_DECLARE(orb_test_medium_wrap_around);
+ORB_DECLARE(orb_test_medium_queue);
+ORB_DECLARE(orb_test_medium_queue_poll);
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int test_note(FAR const char *fmt, ...);
+int test_fail(FAR const char *fmt, ...);
+
+#endif /* __APP_SYSTEM_UORB_TEST_UTILITY_H */

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -1,0 +1,314 @@
+/****************************************************************************
+ * apps/system/uorb/uORB/uORB.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: orb_open
+ *
+ * Description:
+ *   Open device node as advertiser / subscriber, regist node and save meta
+ *   in driver for first user, set buffer number for advertisers.
+ *
+ * Input Parameters:
+ *   meta         The uORB metadata (usually from the ORB_ID() macro)
+ *   advertiser   Whether advertiser or subscriber.
+ *   instance     Instance number to open.
+ *   queue_size   Maximum number of buffered elements.
+ *
+ * Returned Value:
+ *   fd on success, otherwise returns negative value and set errno.
+ ****************************************************************************/
+
+static int orb_open(FAR const struct orb_metadata *meta, bool advertiser,
+                    int instance, unsigned int queue_size)
+{
+  char path[PATH_MAX];
+  bool first_open = false;
+  int fd;
+  int ret;
+
+  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name, instance);
+
+  /* Check existance before open */
+
+  ret = access(path, F_OK);
+  if (ret < 0)
+    {
+      struct sensor_reginfo_s reginfo;
+
+      reginfo.path    = path;
+      reginfo.esize   = meta->o_size;
+      reginfo.nbuffer = queue_size;
+
+      fd = open(ORB_USENSOR_PATH, O_WRONLY);
+      if (fd < 0)
+        {
+          return fd;
+        }
+
+      /* Register new device node */
+
+      ret = ioctl(fd, SNIOC_REGISTER, (unsigned long)(uintptr_t)&reginfo);
+      close(fd);
+      if (ret < 0 && ret != -EEXIST)
+        {
+          return ret;
+        }
+
+      first_open = true;
+    }
+
+  fd = open(path, O_CLOEXEC | (advertiser ? O_WRONLY : O_RDONLY));
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  if (first_open)
+    {
+      ioctl(fd, SNIOC_SET_USERPRIV, (unsigned long)(uintptr_t)meta);
+    }
+
+  /* Only first advertiser can successfully set buffer number */
+
+  if (queue_size)
+    {
+      ioctl(fd, SNIOC_SET_BUFFER_NUMBER, (unsigned long)queue_size);
+    }
+
+  return fd;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int orb_advertise_multi_queue(FAR const struct orb_metadata *meta,
+                              FAR const void *data, FAR int *instance,
+                              unsigned int queue_size)
+{
+  int inst;
+  int fd;
+
+  /* Open the node as an advertiser */
+
+  inst = instance ? *instance : orb_group_count(meta);
+
+  fd = orb_open(meta, true, inst, queue_size);
+  if (fd < 0)
+    {
+      uorberr("%s advertise failed (%i)", meta->o_name, fd);
+      return -1;
+    }
+
+  /* The advertiser may perform an initial publish to initialise the object */
+
+  if (data != NULL)
+    {
+      int ret;
+
+      ret = orb_publish_multi(fd, data, meta->o_size);
+      if (ret != meta->o_size)
+        {
+          uorberr("%s publish %d, expect %d",
+                  meta->o_name, ret, meta->o_size);
+          close(fd);
+          return -1;
+        }
+    }
+
+  return fd;
+}
+
+int orb_unadvertise(int fd)
+{
+  return close(fd);
+}
+
+ssize_t orb_publish_multi(int fd, const void *data, size_t len)
+{
+  return write(fd, data, len);
+}
+
+int orb_subscribe_multi(FAR const struct orb_metadata *meta,
+                        unsigned instance)
+{
+  return orb_open(meta, false, instance, 0);
+}
+
+int orb_unsubscribe(int fd)
+{
+  return close(fd);
+}
+
+ssize_t orb_copy_multi(int fd, FAR void *buffer, size_t len)
+{
+  return read(fd, buffer, len);
+}
+
+int orb_get_state(int fd, FAR struct orb_state *state)
+{
+  struct sensor_state_s tmp;
+  int ret;
+
+  if (!state)
+    {
+      return -EINVAL;
+    }
+
+  ret = ioctl(fd, SNIOC_GET_STATE, (unsigned long)(uintptr_t)&tmp);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  state->max_frequency      = tmp.min_interval ?
+                              1000000 / tmp.min_interval : 0;
+  state->min_batch_interval = tmp.min_latency;
+  state->queue_size         = tmp.nbuffer;
+  state->enable             = tmp.nsubscribers > 0;
+
+  return ret;
+}
+
+int orb_check(int fd, FAR bool *updated)
+{
+  struct pollfd fds[1];
+  int ret;
+
+  fds[0].fd     = fd;
+  fds[0].events = POLLIN;
+
+  ret = poll(fds, 1, 0);
+  if (ret < 0)
+    {
+      return -1;
+    }
+
+  *updated = (fds[0].revents & POLLIN) > 0;
+  return 0;
+}
+
+int orb_ioctl(int handle, int cmd, unsigned long arg)
+{
+  return ioctl(handle, cmd, arg);
+}
+
+int orb_set_interval(int fd, unsigned interval)
+{
+  return ioctl(fd, SNIOC_SET_INTERVAL, (unsigned long)interval);
+}
+
+int orb_get_interval(int fd, FAR unsigned *interval)
+{
+  struct sensor_state_s tmp;
+  int ret;
+
+  ret = ioctl(fd, SNIOC_GET_STATE, (unsigned long)(uintptr_t)&tmp);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *interval = tmp.min_interval;
+  return ret;
+}
+
+int orb_set_batch_interval(int fd, unsigned batch_interval)
+{
+  return ioctl(fd, SNIOC_BATCH, (unsigned long)batch_interval);
+}
+
+int orb_get_batch_interval(int fd, FAR unsigned *batch_interval)
+{
+  struct sensor_state_s tmp;
+  int ret;
+
+  ret = ioctl(fd, SNIOC_GET_STATE, (unsigned long)(uintptr_t)&tmp);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *batch_interval = tmp.min_latency;
+  return ret;
+}
+
+orb_abstime orb_absolute_time(void)
+{
+  struct timespec ts;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  return 1000000ull * ts.tv_sec + ts.tv_nsec / 1000;
+}
+
+int orb_exists(FAR const struct orb_metadata *meta, int instance)
+{
+  struct sensor_state_s state;
+  char path[PATH_MAX];
+  int ret;
+  int fd;
+
+  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name, instance);
+  fd = open(path, 0);
+  if (fd < 0)
+    {
+      return -1;
+    }
+
+  ret = ioctl(fd, SNIOC_GET_STATE, (unsigned long)(uintptr_t)&state);
+  close(fd);
+  if (ret < 0)
+    {
+      return -1;
+    }
+
+  return state.nadvertisers > 0 ? 0 : -1;
+}
+
+int orb_group_count(FAR const struct orb_metadata *meta)
+{
+  unsigned instance = 0;
+
+  while (orb_exists(meta, instance) == 0)
+    {
+      ++instance;
+    }
+
+  return instance;
+}

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -56,12 +56,13 @@
 static int orb_open(FAR const struct orb_metadata *meta, bool advertiser,
                     int instance, unsigned int queue_size)
 {
-  char path[PATH_MAX];
+  char path[ORB_PATH_MAX];
   bool first_open = false;
   int fd;
   int ret;
 
-  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name, instance);
+  snprintf(path, ORB_PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name,
+           instance);
 
   /* Check existance before open */
 
@@ -281,11 +282,12 @@ orb_abstime orb_absolute_time(void)
 int orb_exists(FAR const struct orb_metadata *meta, int instance)
 {
   struct sensor_state_s state;
-  char path[PATH_MAX];
+  char path[ORB_PATH_MAX];
   int ret;
   int fd;
 
-  snprintf(path, PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name, instance);
+  snprintf(path, ORB_PATH_MAX, ORB_SENSOR_PATH"%s%d", meta->o_name,
+           instance);
   fd = open(path, 0);
   if (fd < 0)
     {

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <poll.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -228,20 +227,7 @@ int orb_get_state(int fd, FAR struct orb_state *state)
 
 int orb_check(int fd, FAR bool *updated)
 {
-  struct pollfd fds[1];
-  int ret;
-
-  fds[0].fd     = fd;
-  fds[0].events = POLLIN;
-
-  ret = poll(fds, 1, 0);
-  if (ret < 0)
-    {
-      return -1;
-    }
-
-  *updated = (fds[0].revents & POLLIN) > 0;
-  return 0;
+  return ioctl(fd, SNIOC_UPDATED, (unsigned long)(uintptr_t)updated);
 }
 
 int orb_ioctl(int fd, int cmd, unsigned long arg)

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -200,7 +200,8 @@ int orb_get_state(int fd, FAR struct orb_state *state)
                               1000000 / tmp.min_interval : 0;
   state->min_batch_interval = tmp.min_latency;
   state->queue_size         = tmp.nbuffer;
-  state->enable             = tmp.nsubscribers > 0;
+  state->nsubscribers       = tmp.nsubscribers;
+  state->generation         = tmp.generation;
 
   return ret;
 }

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -235,14 +235,18 @@ int orb_advertise_multi_queue(FAR const struct orb_metadata *meta,
 static inline int orb_advertise(FAR const struct orb_metadata *meta,
                                 FAR const void *data)
 {
-  return orb_advertise_multi_queue(meta, data, NULL, 1);
+  int instance = 0;
+
+  return orb_advertise_multi_queue(meta, data, &instance, 1);
 }
 
 static inline int orb_advertise_queue(FAR const struct orb_metadata *meta,
                                       FAR const void *data,
                                       unsigned int queue_size)
 {
-  return orb_advertise_multi_queue(meta, data, NULL, queue_size);
+  int instance = 0;
+
+  return orb_advertise_multi_queue(meta, data, &instance, queue_size);
 }
 
 static inline int orb_advertise_multi(FAR const struct orb_metadata *meta,

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -257,6 +257,33 @@ static inline int orb_advertise_multi(FAR const struct orb_metadata *meta,
 }
 
 /****************************************************************************
+ * Name: orb_advertise_multi_queue_persist
+ *
+ * Description:
+ *   orb_advertise_multi_queue_persist is similar to orb_advertise_mult and
+ *   it can ensures that every subscriber has access to current and
+ *   future data.
+ *
+ * Input Parameters:
+ *   meta         The uORB metadata (usually from the ORB_ID() macro)
+ *   data         A pointer to the initial data to be published.
+ *   instance     Pointer to an integer which yield the instance ID,
+ *                (has default 0 if pointer is NULL).
+ *
+ * Returned Value:
+ *   -1 on error, otherwise returns an file descriptor
+ *   that can be used to publish to the topic.
+ *   If the topic in question is not known (due to an
+ *   ORB_DEFINE with no corresponding ORB_DECLARE)
+ *   this function will return -1 and set errno to ENOENT.
+ ****************************************************************************/
+
+int orb_advertise_multi_queue_persist(FAR const struct orb_metadata *meta,
+                                      FAR const void *data,
+                                      FAR int *instance,
+                                      unsigned int queue_size);
+
+/****************************************************************************
  * Name: orb_unadvertise
  *
  * Description:
@@ -316,7 +343,7 @@ static inline int orb_publish_auto(FAR const struct orb_metadata *meta,
     {
       int tmp;
 
-      tmp = orb_advertise_multi(meta, data, instance);
+      tmp = orb_advertise_multi_queue_persist(meta, data, instance, 1);
       if (tmp < 0)
         {
           return tmp;

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -638,6 +638,21 @@ int orb_exists(FAR const struct orb_metadata *meta, int instance);
 
 int orb_group_count(FAR const struct orb_metadata *meta);
 
+/****************************************************************************
+ * Name: orb_get_meta
+ *
+ * Description:
+ *   Get the metadata of topic object by name string.
+ *
+ * Input Parameters:
+ *   name       The name of topic, ex: sensor_accel, sensor_accel0.
+ *
+ * Returned Value:
+ *   The metadata on success. NULL on failure.
+ ****************************************************************************/
+
+FAR const struct orb_metadata *orb_get_meta(FAR const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -1,0 +1,645 @@
+/****************************************************************************
+ * apps/system/uorb/uORB/uORB.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APP_SYSTEM_UORB_UORB_UORB_H
+#define __APP_SYSTEM_UORB_UORB_UORB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/sensors/ioctl.h>
+#include <nuttx/sensors/sensor.h>
+
+#include <sys/time.h>
+#include <debug.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <syslog.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct orb_metadata;
+typedef void (*orb_print_message)(FAR const struct orb_metadata *meta,
+                                  FAR const void *buffer);
+
+struct orb_metadata
+{
+  FAR const char   *o_name;     /* Unique object name */
+  uint16_t          o_size;     /* Object size */
+#ifdef CONFIG_DEBUG_UORB
+  orb_print_message o_cb;       /* Function pointer of output topic message */
+#endif
+};
+
+typedef FAR const struct orb_metadata *orb_id_t;
+
+struct orb_state
+{
+  uint32_t max_frequency;       /* Object maximum frequency, Hz */
+  uint32_t min_batch_interval;  /* Object minimum batch interval, us */
+  uint32_t queue_size;          /* The maximum number of buffered elements,
+                                 * if 1, no queuing is is used
+                                 */
+  bool     enable;              /* Indicates whether the current node is
+                                 * subscribed or activated
+                                 */
+};
+
+struct orb_object
+{
+  orb_id_t meta;                /* The metadata of topic object */
+  int      instance;            /* The instance of topic object */
+};
+
+typedef uint64_t orb_abstime;
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ORB_SENSOR_PATH        "/dev/sensor/"
+#define ORB_USENSOR_PATH       "/dev/usensor"
+
+#ifdef CONFIG_UORB_ALERT
+#  define uorbpanic(fmt, ...)  _alert(fmt "\n", ##__VA_ARGS__)
+#else
+#  define uorbpanic            _none
+#endif
+
+#ifdef CONFIG_UORB_ERROR
+#  define uorberr(fmt, ...)    _err(fmt "\n", ##__VA_ARGS__)
+#else
+#  define uorberr              _none
+#endif
+
+#ifdef CONFIG_UORB_WARN
+#  define uorbwarn(fmt, ...)   _warn(fmt "\n", ##__VA_ARGS__)
+#else
+#  define uorbwarn             _none
+#endif
+
+#ifdef CONFIG_UORB_INFO
+#  define uorbinfo(fmt, ...)   _info(fmt "\n", ##__VA_ARGS__)
+#else
+#  define uorbinfo             _none
+#endif
+
+#ifdef CONFIG_DEBUG_UORB
+#  define uorbdebug(fmt, ...)  syslog(LOG_INFO, fmt "\n", ##__VA_ARGS__)
+#else
+#  define uorbdebug            _none
+#endif
+
+#define uorbinfo_raw(fmt, ...) syslog(LOG_INFO, fmt "\n", ##__VA_ARGS__)
+
+/**
+ * Generates a pointer to the uORB metadata structure for
+ * a given topic.
+ *
+ * The topic must have been declared previously in scope
+ * with ORB_DECLARE().
+ *
+ * @param name    The name of the topic.
+ */
+#define ORB_ID(name)  &g_orb_##name
+
+/**
+ * Declare the uORB metadata for a topic (used by code generators).
+ *
+ * @param name      The name of the topic.
+ */
+#if defined(__cplusplus)
+# define ORB_DECLARE(name) extern "C" const struct orb_metadata g_orb_##name
+#else
+# define ORB_DECLARE(name) extern const struct orb_metadata g_orb_##name
+#endif
+
+/**
+ * Define (instantiate) the uORB metadata for a topic.
+ *
+ * The uORB metadata is used to help ensure that updates and
+ * copies are accessing the right data.
+ *
+ * Note that there must be no more than one instance of this macro
+ * for each topic.
+ *
+ * @param name    The name of the topic.
+ * @param struct  The structure the topic provides.
+ * @param cb      The function pointer of output topic message.
+ */
+#ifdef CONFIG_DEBUG_UORB
+#define ORB_DEFINE(name, structure, cb) \
+  const struct orb_metadata g_orb_##name = \
+  { \
+    #name, \
+    sizeof(structure), \
+    cb, \
+  };
+#else
+#define ORB_DEFINE(name, structure, cb) \
+  const struct orb_metadata g_orb_##name = \
+  { \
+    #name, \
+    sizeof(structure), \
+  };
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: orb_advertise_multi_queue
+ *
+ * Description:
+ *   This performs the initial advertisement of a topic; it creates the topic
+ *   node in /dev/sensor and publishes the initial data.
+ *
+ * Input Parameters:
+ *   meta         The uORB metadata (usually from the ORB_ID() macro)
+ *   data         A pointer to the initial data to be published.
+ *   instance     Pointer to an integer which yield the instance ID,
+ *                (has default 0 if pointer is NULL).
+ *   queue_size   Maximum number of buffered elements.
+ *
+ * Returned Value:
+ *   -1 on error, otherwise returns an file descriptor
+ *   that can be used to publish to the topic.
+ *   If the topic in question is not known (due to an
+ *   ORB_DEFINE with no corresponding ORB_DECLARE)
+ *   this function will return -1 and set errno to ENOENT.
+ ****************************************************************************/
+
+int orb_advertise_multi_queue(FAR const struct orb_metadata *meta,
+                              FAR const void *data,
+                              FAR int *instance,
+                              unsigned int queue_size);
+
+static inline int orb_advertise(FAR const struct orb_metadata *meta,
+                                FAR const void *data)
+{
+  return orb_advertise_multi_queue(meta, data, NULL, 1);
+}
+
+static inline int orb_advertise_queue(FAR const struct orb_metadata *meta,
+                                      FAR const void *data,
+                                      unsigned int queue_size)
+{
+  return orb_advertise_multi_queue(meta, data, NULL, queue_size);
+}
+
+static inline int orb_advertise_multi(FAR const struct orb_metadata *meta,
+                                      FAR const void *data,
+                                      FAR int *instance)
+{
+  return orb_advertise_multi_queue(meta, data, instance, 1);
+}
+
+/****************************************************************************
+ * Name: orb_unadvertise
+ *
+ * Description:
+ *   Unadvertise a topic.
+ *
+ * Input Parameters:
+ *   handle   A handle returned by orb_advertise or orb_advertise_multi.
+ *
+ * Returned Value:
+ *   0 on success.
+ ****************************************************************************/
+
+int orb_unadvertise(int handle);
+
+/****************************************************************************
+ * Name: orb_publish_multi
+ *
+ * Description:
+ *   Publish the specified length of new data to a topic.
+ *
+ *   The data is published to the topic and any waiting subscribers will be
+ *   notified. Subscribers that are not waiting can check the topic for
+ *   updates using orb_check.
+ *
+ * Input Parameters:
+ *   handle   The handle returned from orb_advertise.
+ *   data     A pointer to the data to be published.
+ *   len      The length of the data to be published.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with errno set accordingly.
+ ****************************************************************************/
+
+ssize_t orb_publish_multi(int handle, FAR const void *data, size_t len);
+
+static inline int orb_publish(FAR const struct orb_metadata *meta,
+                              int handle, FAR const void *data)
+{
+  int ret;
+
+  ret = orb_publish_multi(handle, data, meta->o_size);
+  return ret == meta->o_size ? 0 : -1;
+}
+
+static inline int orb_publish_auto(FAR const struct orb_metadata *meta,
+                                   FAR int *handle, FAR const void *data,
+                                   FAR int *instance)
+{
+  if (handle && *handle)
+    {
+      return orb_publish(meta, *handle, data);
+    }
+  else
+    {
+      int tmp;
+
+      tmp = orb_advertise_multi(meta, data, instance);
+      if (tmp < 0)
+        {
+          return tmp;
+        }
+
+      if (handle)
+        {
+          *handle = tmp;
+          return tmp;
+        }
+      else
+        {
+          return orb_unadvertise(tmp);
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: orb_subscribe_multi
+ *
+ * Description:
+ *   Subscribe to a topic.
+ *
+ *   The data is published to the topic and any waiting subscribers will be
+ *   notified. Subscribers that are not waiting can check the topic for
+ *   updates using orb_check.
+ *
+ *   If there were any publications of the topic prior to the subscription,
+ *   an orb_check right after orb_subscribe_multi will return true.
+ *
+ *   Subscription will succeed even if the topic has not been advertised;
+ *   in this case, the topic will have a timestamp of zero, it will never
+ *   signal a poll() event, checking will always return false and it cannot
+ *   be copied, until the topic is subsequently advertised.
+ *
+ * Input Parameters:
+ *   meta       The uORB metadata (usually from the ORB_ID() macro)
+ *   instance   The instance of the topic. Instance 0 matches the topic of
+ *              the orb_subscribe() call.
+ *
+ * Returned Value:
+ *   -1 on error, otherwise returns a handle
+ *   that can be used to read and update the topic.
+ *   If the topic in question is not known (due to an
+ *   ORB_DEFINE_OPTIONAL with no corresponding ORB_DECLARE)
+ *   this function will return -1 and set errno to ENOENT.
+ ****************************************************************************/
+
+int orb_subscribe_multi(FAR const struct orb_metadata *meta,
+                        unsigned instance);
+
+static inline int orb_subscribe(FAR const struct orb_metadata *meta)
+{
+  return orb_subscribe_multi(meta, 0);
+}
+
+/****************************************************************************
+ * Name: orb_unsubscribe
+ *
+ * Description:
+ *   Unsubscribe from a topic.
+ *
+ * Input Parameters:
+ *   handle   A handle returned from orb_subscribe.
+ *
+ * Returned Value:
+ *   0 on success.
+ ****************************************************************************/
+
+int orb_unsubscribe(int handle);
+
+/****************************************************************************
+ * Name: orb_copy_multi
+ *
+ * Description:
+ *   Fetch the specified length of data from a topic.
+ *
+ *   This is the only operation that will reset the internal marker that
+ *   indicates that a topic has been updated for a subscriber. Once poll
+ *   or check return indicating that an updaet is available, this call
+ *   must be used to update the subscription.
+ *
+ * Input Parameters:
+ *   handle   A handle returned from orb_subscribe.
+ *   buffer   Pointer to the buffer receiving the data, or NULL if the
+ *            caller wants to clear the updated flag without.
+ *   len      The length to the buffer receiving the data.
+ *
+ * Returned Value:
+ *   The positive non-zero number of bytes read on success.
+ *   0 on if an end-of-file condition,
+ *   -1 otherwise with errno set accordingly.
+ ****************************************************************************/
+
+ssize_t orb_copy_multi(int handle, FAR void *buffer, size_t len);
+
+static inline int orb_copy(FAR const struct orb_metadata *meta,
+                           int handle, FAR void *buffer)
+{
+  int ret;
+
+  ret = orb_copy_multi(handle, buffer, meta->o_size);
+  return ret == meta->o_size ? 0 : -1;
+}
+
+/****************************************************************************
+ * Name: orb_get_state
+ *
+ * Description:
+ *   Get some state about all subscriber of topic.
+ *
+ *   This state contains the maximum frequency and minimum batch interval
+ *   in all subscriber, and it also contanis enable to indicate whether
+ *   the current node is subscribed or activated.
+ *
+ *   If no one subscribes this topic, the state is set:
+ *     max_frequency to 0. min_batch_interval to 0, enable to false.
+ *
+ * Input Parameters:
+ *   handle   The handle returned from orb_advertise / orb_subscribe.
+ *   state    Pointer to an state of struct orb_state type. This is an
+ *            output parameter and will be set to the current state of topic.
+ *
+ * Returned Value:
+ *   -1 on error.
+ ****************************************************************************/
+
+int orb_get_state(int handle, FAR struct orb_state *state);
+
+/****************************************************************************
+ * Name: orb_check
+ *
+ * Description:
+ *   Check whether a topic has been published to since the last orb_copy.
+ *
+ *   This check can be used to determine whether to copy the topic when
+ *   not using poll(), or to avoid the overhead of calling poll() when the
+ *   topic is likely to have updated.
+ *
+ *   Updates are tracked on a per-handle basis; this call will continue to
+ *   return true until orb_copy is called using the same handle.
+ *
+ * Input Parameters:
+ *   handle   A handle returned from orb_subscribe.
+ *   update   Set to true if the topic has been updated since the
+ *            last time it was copied using this handle.
+ *
+ * Returned Value:
+ *   0 if the check was successful,
+ *   -1 otherwise with errno set accordingly.
+ ****************************************************************************/
+
+int orb_check(int handle, FAR bool *updated);
+
+/****************************************************************************
+ * Name: orb_ioctl
+ *
+ * Description:
+ *   Ioctl control for the subscriber, the same as ioctl().
+ *
+ * Input Parameters:
+ *   handle   A handle returned from orb_advertise / orb_subscribe.
+ *   cmd      Ioctl command.
+ *   arg      Ioctl argument.
+ *
+ * Returned Value:
+ *   0 on success.
+ ****************************************************************************/
+
+int orb_ioctl(int handle, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Name: orb_set_batch_interval
+ *
+ * Description:
+ *   The batch interval set through api is just the value user wants,
+ *   and the final value depends on the hardware FIFO capability.
+ *   This API will send POLLPRI event to notify publisher and
+ *   publisher determine the final batch interval.
+ *
+ *   This API is only for topics with hardware fifo, such as sensor with
+ *   hardware fifo, otherwise it's meaningless.
+ *
+ * Input Parameters:
+ *   handle         A handle returned from orb_subscribe.
+ *   batch_interval An batch interval in us.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+int orb_set_batch_interval(int handle, unsigned batch_interval);
+
+/****************************************************************************
+ * Name: orb_get_batch_interval
+ *
+ * Description:
+ *   Get the batch interval in batch mode.
+ *
+ *   This API is only for topics with hardware fifo, such as sensor with
+ *   hardware fifo, otherwise it's meaningless.
+ *
+ *   @see orb_set_batch_interval()
+ *
+ * Input Parameters:
+ *   handle          A handle returned from orb_subscribe.
+ *   batch_interval  The returned batch interval in us.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+int orb_get_batch_interval(int handle, FAR unsigned *batch_interval);
+
+/****************************************************************************
+ * Name:
+ *
+ * Description:
+ *   Set the minimum interval between which updates seen for a subscription.
+ *
+ * Input Parameters:
+ *   handle     A handle returned from orb_subscribe.
+ *   interval   An interval period in us.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+int orb_set_interval(int handle, unsigned interval);
+
+/****************************************************************************
+ * Name:
+ *
+ * Description:
+ *   Get the minimum interval between which updates seen for a subscription.
+ *
+ * Input Parameters:
+ *   handle     A handle returned from orb_subscribe.
+ *   interval   The returned interval period in us.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+int orb_get_interval(int handle, FAR unsigned *interval);
+
+/****************************************************************************
+ * Name:
+ *   orb_set_frequency
+ *
+ * Description:
+ *   Set the maximum frequency for a subscription.
+ *
+ * Input Parameters:
+ *   handle     A handle returned from orb_subscribe.
+ *   frequency  A frequency in hz.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+static inline int orb_set_frequency(int handle, unsigned frequency)
+{
+  return orb_set_interval(handle, frequency ? 1000000 / frequency : 0);
+}
+
+/****************************************************************************
+ * Name:
+ *   orb_get_frequency
+ *
+ * Description:
+ *   Get the maximum frequency for a subscription.
+ *
+ * Input Parameters:
+ *   handle     A handle returned from orb_subscribe.
+ *   frequency  The returned frequency in hz.
+ *
+ * Returned Value:
+ *   0 on success, -1 otherwise with ERRNO set accordingly.
+ ****************************************************************************/
+
+static inline int orb_get_frequency(int handle, FAR unsigned *frequency)
+{
+  unsigned interval;
+  int ret;
+
+  ret = orb_get_interval(handle, &interval);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *frequency = interval ? 1000000 / interval : 0;
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: orb_elapsed_time
+ *
+ * Description:
+ *   Get current value of system time in us.
+ *
+ * Returned Value:
+ *   Absolute time.
+ ****************************************************************************/
+
+orb_abstime orb_absolute_time(void);
+
+/****************************************************************************
+ * Name: orb_elapsed_time
+ *
+ * Description:
+ *   Compute the delta between a timestamp taken in the past and now.
+ *
+ *   This function is not interrupt save.
+ *
+ * Input Parameters:
+ *   then   Past system time.
+ *
+ * Returned Value:
+ *   Bewteen time.
+ ****************************************************************************/
+
+static inline orb_abstime orb_elapsed_time(FAR const orb_abstime *then)
+{
+  return orb_absolute_time() - *then;
+}
+
+/****************************************************************************
+ * Name: orb_exists
+ *
+ * Description:
+ *   Check if a topic instance has already been advertised.
+ *
+ * Input Parameters:
+ *   meta       ORB topic metadata.
+ *   instance   ORB instance
+ *
+ * Returned Value:
+ *   0 if the topic exists, -1 otherwise.
+ ****************************************************************************/
+
+int orb_exists(FAR const struct orb_metadata *meta, int instance);
+
+/****************************************************************************
+ * Name: orb_group_count
+ *
+ * Description:
+ *   Get instance amount of advertised topic instances.
+ *
+ * Input Parameters:
+ *   meta       ORB topic metadata.
+ *
+ * Returned Value:
+ *   0 if none
+ ****************************************************************************/
+
+int orb_group_count(FAR const struct orb_metadata *meta);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APP_SYSTEM_UORB_UORB_UORB_H */

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -60,9 +60,8 @@ struct orb_state
   uint32_t queue_size;          /* The maximum number of buffered elements,
                                  * if 1, no queuing is is used
                                  */
-  bool     enable;              /* Indicates whether the current node is
-                                 * subscribed or activated
-                                 */
+  uint32_t nsubscribers;        /* Number of subscribers */
+  uint64_t generation;          /* Mainline generation */
 };
 
 struct orb_object

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -78,6 +78,7 @@ typedef uint64_t orb_abstime;
 
 #define ORB_SENSOR_PATH        "/dev/sensor/"
 #define ORB_USENSOR_PATH       "/dev/usensor"
+#define ORB_PATH_MAX           (NAME_MAX + 16)
 
 #ifdef CONFIG_UORB_ALERT
 #  define uorbpanic(fmt, ...)  _alert(fmt "\n", ##__VA_ARGS__)


### PR DESCRIPTION
## Summary
system/uorb: support uorb, include uorb wraper, unit test, uorb_listener, topic definition

refer to: https://docs.px4.io/v1.12/en/middleware/uorb.html
uORB  comes from the open source flight control PX4, is the internal pub-sub messaging system, used for communication between modules. 

About original uORB implementation:
* No thread or work queue is needed, the module start only makes sure to initialize the shared global state.
* Communication is done via shared memory.
* The implementation is asynchronous and lock-free, ie. a publisher does not wait for a subscriber and vice versa.
* This is achieved by having a separate buffer between a publisher and a subscriber.
* The code is optimized to minimize the memory footprint and the latency to exchange messages.

About uORB shortcoming:
* The internal driver of uorb is implemented in user space and cannot run in kernel mode.
* Uorb is developed in C++ language, and the integration needs to rely on libc++, which is not good for embedded devices with limited resources.
* There is no relationship between the subscriber and the publisher, and it is impossible to control the publisher according to the status of the subscriber, which is required in many cases.For example, to control whether to open it according to the subscription of the sensor.
* For weaker sampling support, there is a cumulative error.

For the original design, vela has been enhanced：
* Enhanced nuttx sensor driver framework, adapted to uorb cdev function.
* Use c language to implement uorb upper wrapper.
* The interaction between subscribers and publishers is completed through event POLLPRI, making the whole framework more intelligent.
* By working with sensor rpmsg, you can subscribe to multi-core topics transparently and without any sense, make the whole system configuration more flexible.
* Change all interfaces of uorb to file descriptor operations to simplify usage.
* Keep most of the test cases and test tools with the original uorb.

## Impact
Support uorb middleware
## Testing
Vela CI
