### PR TITLE
Fix find: '/github/workspace/sources/nuttx/libs/libxx/uClibc++/tests' No such file or directory

### DIFF
--- a/testing/uclibcxx_test/Makefile
+++ b/testing/uclibcxx_test/Makefile
@@ -21,8 +21,7 @@
 include $(APPDIR)/Make.defs
 
 CXXEXT := .cpp
-TESTDIR = $(TOPDIR)/libs/libxx/uClibc++/tests
-ORIGS  := $(shell find $(TESTDIR) -name *.cpp)
+ORIGS  := $(wildcard $(TOPDIR)/libs/libxx/uClibc++/tests/*.cpp)
 
 BLACKSRCS := wchartest.cpp
 BLACKSRCS += excepttest.cpp


### PR DESCRIPTION
## Summary
Fix the warning

## Impact
uclibcxx_test

## Testing
Pass CI
