### PR TITLE
system: popen: Fix to build with CONFIG_BUILD_KERNEL=y

### DIFF
--- a/system/popen/Kconfig
+++ b/system/popen/Kconfig
@@ -18,7 +18,7 @@ if SYSTEM_POPEN
 config SYSTEM_POPEN_SHPATH
 	string "Path to shell command"
 	default "/bin/sh"
-	depends on SYSTEM_NSH=m
+	depends on SYSTEM_NSH=m || BUILD_KERNEL
 	---help---
 		This is the full path to the program in a mounted file system that
 		implements the system() command.  That is, a program that starts the

--- a/system/popen/popen.c
+++ b/system/popen/popen.c
@@ -197,12 +197,14 @@ FILE *popen(FAR const char *command, FAR const char *mode)
       goto errout_with_actions;
     }
 
+#ifndef CONFIG_SYSTEM_POPEN_SHPATH
   errcode = task_spawnattr_setstacksize(&attr,
                                         CONFIG_SYSTEM_POPEN_STACKSIZE);
   if (errcode != 0)
     {
       goto errout_with_actions;
     }
+#endif
 
   /* If robin robin scheduling is enabled, then set the scheduling policy
    * of the new task to SCHED_RR before it has a chance to run.


### PR DESCRIPTION
## Summary

- This commit fixes to build with CONFIG_BUILD_KERNEL=y

## Impact

- None

## Testing

- Tested with sabre-6quad:knsh (not merged yet)
