### PR TITLE
testing/sensortest: fix cmd argument mismatch(follow new sensor driver)

### DIFF
--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -325,7 +325,7 @@ int main(int argc, FAR char *argv[])
       goto open_err;
     }
 
-  ret = ioctl(fd, SNIOC_SET_INTERVAL, &interval);
+  ret = ioctl(fd, SNIOC_SET_INTERVAL, interval);
   if (ret < 0)
     {
       ret = -errno;
@@ -337,7 +337,7 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-  ret = ioctl(fd, SNIOC_BATCH, &latency);
+  ret = ioctl(fd, SNIOC_BATCH, latency);
   if (ret < 0)
     {
       ret = -errno;


### PR DESCRIPTION


## Summary
testing/sensortest: fix cmd argument mismatch(follow new sensor driver)

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

