### PR TITLE
cu: fix cu hang when meet ctrl + C

### DIFF
--- a/system/cu/cu.h
+++ b/system/cu/cu.h
@@ -73,6 +73,7 @@ struct cu_globals_s
   int infd;            /* Incoming data from serial port */
   int outfd;           /* Outgoing data to serial port */
   pthread_t listener;  /* Terminal listener thread */
+  bool force_exit;     /* Force exit */
 };
 
 /****************************************************************************

--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -129,11 +129,7 @@ static FAR void *cu_listener(FAR void *parameter)
 
 static void sigint(int sig)
 {
-  pthread_cancel(g_cu.listener);
-  tcflush(g_cu.outfd, TCIOFLUSH);
-  close(g_cu.outfd);
-  close(g_cu.infd);
-  exit(0);
+  g_cu.force_exit = true;
 }
 
 #ifdef CONFIG_SERIAL_TERMIOS
@@ -459,7 +455,7 @@ int main(int argc, FAR char *argv[])
 
   /* Send messages and get responses -- forever */
 
-  for (; ; )
+  while (!g_cu.force_exit)
     {
       int ch = getc(stdin);
 


### PR DESCRIPTION

## Summary
cu: fix cu hang when meet ctrl + C

We can't do sem_wait in sigaction

hang backtrace:
[<0x2c5a6958>] arm_switchcontext+0xc/0x10
[<0x2c579eba>] nxsem_wait+0x6e/0xa8
[<0x3c9a8cb5>] pb_field_iter_find+0xffde8cb/0xd3635c15
[<0x2c58d164>] uart_tcdrain.constprop.0+0x10/0xf8
[<0x2c58d5c6>] uart_close+0x10e/0x180
[<0x2c579f38>] nxsem_wait_uninterruptible+0x44/0xb8
[<0x2c95f87a>] file_close+0x12/0x44
[<0x2c95e5a8>] close+0x80/0xb4
[<0x2c5c6396>] sigint+0x1a/0x28
[<0x2c57b1b0>] nxsig_deliver+0x54/0xb8
[<0x2c5a549a>] arm_sigdeliver+0x1a/0x44
[<0x2c579eb6>] nxsem_wait+0x6a/0xa8
[<0x2c579eb6>] nxsem_wait+0x6a/0xa8
[<0x2c579eb6>] nxsem_wait+0x6a/0xa8
[<0x2c58aa1a>] pm_lock+0x1a/0x28
[<0x2c58a656>] pm_stay+0xa/0x60
[<0x2c58bb14>] rptun_notify+0x4c/0x58
[<0x2c97b8fc>] virtqueue_kick+0x54/0x7c
[<0x2c97ac82>] rpmsg_virtio_send_offchannel_nocopy+0x9a/0xcc
[<0x2c58df7c>] uart_rpmsg_dmasend+0x8c/0xe0
[<0x2c5771be>] leave_critical_section+0x2e/0x54
[<0x2c58d124>] uart_write+0x11c/0x14c
[<0x2c9620c6>] write+0x32/0x50
[<0x2c5c665e>] cu_main+0x2ba/0x484
[<0x2c5957be>] nxtask_startup+0x12/0x24
[<0x2c57b9d2>] nxtask_start+0x46/0x60

Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

## Testing

