### PR TITLE
mkfats make g_bootcodeblob const to save on .data section usage

### DIFF
--- a/fsutils/mkfatfs/configfat.c
+++ b/fsutils/mkfatfs/configfat.c
@@ -74,7 +74,7 @@ struct fat_config_s
  * offset 3.
  */
 
-static uint8_t g_bootcodeblob[] =
+const static uint8_t g_bootcodeblob[] =
 {
   0x0e, 0x1f, 0xbe, 0x00, 0x7c, 0xac, 0x22, 0xc0, 0x74, 0x0b, 0x56,
   0xb4, 0x0e, 0xbb, 0x07, 0x00, 0xcd, 0x10, 0x5e, 0xeb, 0xf0, 0x32,
@@ -794,7 +794,7 @@ mkfatfs_clustersearch(FAR struct fat_format_s *fmt,
         {
           if ((!var->fv_fattype &&
                fatconfig16.fc_nclusters > fatconfig12.fc_nclusters) ||
-              (var ->fv_fattype == 16))
+              (var->fv_fattype == 16))
             {
               /* The caller has selected FAT16 -OR- no FAT type has been
                * selected, but the FAT16 selection has more clusters.
@@ -923,7 +923,7 @@ int mkfatfs_configfatfs(FAR struct fat_format_s *fmt,
 
   var->fv_jump[0]      = OPCODE_JMP_REL8;
   var->fv_jump[2]      = OPCODE_NOP;
-  var->fv_bootcode     = g_bootcodeblob;
+  var->fv_bootcodeblob = g_bootcodeblob;
   var->fv_bootcodesize = sizeof(g_bootcodeblob);
 
   if (var->fv_fattype != 32)
@@ -932,15 +932,15 @@ int mkfatfs_configfatfs(FAR struct fat_format_s *fmt,
 
       /* Patch in the correct offset to the boot code */
 
-      var->fv_jump[1]   = MBR16_BOOTCODE - 2;
-      g_bootcodeblob[3] = MBR16_BOOTCODE + BOOTCODE_MSGOFFSET;
+      var->fv_jump[1]       = MBR16_BOOTCODE - 2;
+      var->fv_bootcodepatch = MBR16_BOOTCODE + BOOTCODE_MSGOFFSET;
     }
   else
     {
       /* Patch in the correct offset to the boot code */
 
-      var->fv_jump[1]   = MBR32_BOOTCODE - 2;
-      g_bootcodeblob[3] = MBR32_BOOTCODE + BOOTCODE_MSGOFFSET;
+      var->fv_jump[1]       = MBR32_BOOTCODE - 2;
+      var->fv_bootcodepatch = MBR32_BOOTCODE + BOOTCODE_MSGOFFSET;
 
       /* The root directory is a cluster chain... its is initialize size is
        * one cluster

--- a/fsutils/mkfatfs/mkfatfs.h
+++ b/fsutils/mkfatfs/mkfatfs.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/futils/mkfatfs/mkfatfs.h
+ * apps/fsutils/mkfatfs/mkfatfs.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -72,7 +72,8 @@ struct fat_var_s
   uint32_t       fv_nfatsects;      /* Number of sectors in each FAT */
   uint32_t       fv_nclusters;      /* Number of clusters */
   uint8_t       *fv_sect;           /* Allocated working sector buffer */
-  const uint8_t *fv_bootcode;       /* Points to boot code to put into MBR */
+  uint8_t        fv_bootcodepatch;  /* FAT16/FAT32 Bootcode offset patch */
+  const uint8_t *fv_bootcodeblob;   /* Points to boot code to put into MBR */
 };
 
 /****************************************************************************

--- a/fsutils/mkfatfs/writefat.c
+++ b/fsutils/mkfatfs/writefat.c
@@ -232,8 +232,12 @@ static inline void mkfatfs_initmbr(FAR struct fat_format_s *fmt,
 
       /* Boot code may be placed in the remainder of the sector */
 
-      memcpy(&var->fv_sect[MBR16_BOOTCODE], var->fv_bootcode,
+      memcpy(&var->fv_sect[MBR16_BOOTCODE], var->fv_bootcodeblob,
              var->fv_bootcodesize);
+
+      /* Patch in the correct offset to the boot code */
+
+      var->fv_sect[MBR16_BOOTCODE + 3] = var->fv_bootcodepatch;
     }
   else
     {
@@ -283,8 +287,12 @@ static inline void mkfatfs_initmbr(FAR struct fat_format_s *fmt,
 
       /* Boot code may be placed in the remainder of the sector */
 
-      memcpy(&var->fv_sect[MBR32_BOOTCODE], var->fv_bootcode,
+      memcpy(&var->fv_sect[MBR32_BOOTCODE], var->fv_bootcodeblob,
              var->fv_bootcodesize);
+
+      /* Patch in the correct offset to the boot code */
+
+      var->fv_sect[MBR32_BOOTCODE + 3] = var->fv_bootcodepatch;
     }
 
   /* The magic bytes at the end of the MBR are common to FAT12/16/32 */


### PR DESCRIPTION
## Summary
g_bootcodeblob was allocated in RAM, to be able to patch the offset logic.
This patch makes g_bootcodeblob a constant and patches the offset afterwards to save on ram usage

## Impact
Saves 132 bytes on .data section and moves it to the .rodata section.

## Testing
Tested on MR-CANHUBK3 formatting SD cards as FAT16/FAT32 and checking partition table

