### PR TITLE
ifconfig support set IPv6 DNS server

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -337,6 +337,10 @@ int netlib_ifdown(FAR const char *ifname);
 int netlib_set_ipv4dnsaddr(FAR const struct in_addr *inaddr);
 #endif
 
+#if defined(CONFIG_NET_IPv6) && defined(CONFIG_NETDB_DNSCLIENT)
+int netlib_set_ipv6dnsaddr(FAR const struct in6_addr *inaddr);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -60,6 +60,9 @@ CSRCS += netlib_ipv6adaptor.c
 ifeq ($(CONFIG_NET_ICMPv6_AUTOCONF),y)
 CSRCS += netlib_autoconfig.c
 endif
+ifeq ($(CONFIG_NETDB_DNSCLIENT),y)
+CSRCS += netlib_setipv6dnsaddr.c
+endif
 ifeq ($(CONFIG_NET_ROUTE),y)
 CSRCS += netlib_ipv6route.c netlib_ipv6router.c
 endif

--- a/netutils/netlib/netlib_setipv6dnsaddr.c
+++ b/netutils/netlib/netlib_setipv6dnsaddr.c
@@ -1,0 +1,79 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_setipv6dnsaddr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/socket.h>
+
+#include <string.h>
+#include <errno.h>
+
+#include <netinet/in.h>
+
+#include <nuttx/net/dns.h>
+
+#include "netutils/netlib.h"
+
+#if defined(CONFIG_NET_IPv6) && defined(CONFIG_NETDB_DNSCLIENT)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_set_ipv6dnsaddr
+ *
+ * Description:
+ *   Set the DNS server IPv6 address
+ *
+ * Parameters:
+ *   inaddr   The address to set
+ *
+ * Return:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+int netlib_set_ipv6dnsaddr(FAR const struct in6_addr *inaddr)
+{
+  struct sockaddr_in6 addr;
+  int ret = -EINVAL;
+
+  if (inaddr)
+    {
+      /* Set the IPv6 DNS server address */
+
+      addr.sin6_family = AF_INET6;
+      addr.sin6_port   = 0;
+      memcpy(&addr.sin6_addr, inaddr, sizeof(struct in6_addr));
+
+      ret = dns_add_nameserver((FAR const struct sockaddr *)&addr,
+                               sizeof(struct sockaddr_in6));
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_NET_IPv6 && CONFIG_NETDB_DNSCLIENT */

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -559,6 +559,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #endif
 #ifdef CONFIG_NET_IPv6
   struct in6_addr addr6;
+  struct in6_addr gip6 = IN6ADDR_ANY_INIT;
 #endif
   int i;
   FAR char *ifname = NULL;
@@ -801,6 +802,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
           inet_pton(AF_INET6, gwip, &addr6);
 
           netlib_set_dripv6addr(ifname, &addr6);
+          gip6 = addr6;
         }
     }
 #endif /* CONFIG_NET_IPv6 */
@@ -883,7 +885,18 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
   if (inet6)
 #endif
     {
-#warning Missing Logic
+      if (dns != NULL)
+        {
+          ninfo("DNS: %s\n", dns);
+          inet_pton(AF_INET6, dns, &addr6);
+        }
+      else
+        {
+          ninfo("DNS: Default\n");
+          addr6 = gip6;
+        }
+
+      netlib_set_ipv6dnsaddr(&addr6);
     }
 #endif /* CONFIG_NET_IPv6 */
 
@@ -958,6 +971,9 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #endif
 #ifdef CONFIG_NET_IPv4
   UNUSED(gip);
+#endif
+#ifdef CONFIG_NET_IPv6
+  UNUSED(gip6);
 #endif
 
   return OK;


### PR DESCRIPTION
Signed-off-by: liyi <liyi25@xiaomi.com>

## Summary
ifconfig support set IPv6 DNS server
 
## Impact
ifconfig can be used to set IPv6 DNS server with the command format below:
ifconfig [dev_name] [ipv6_addr] gw [ipv6_gw] dns [ipv6_dns] inet6 

## Testing
Testing cases has been done with nuttx sim:nsh program
![image](https://user-images.githubusercontent.com/38680504/182595559-3a946257-5879-4543-b833-5577ddc9fde3.png)
![image](https://user-images.githubusercontent.com/38680504/182596347-73e8dbf4-647b-4369-9e64-d71c7ccd5491.png)

