### PR TITLE
netutils/iperf: fix string for iperf test interface option

### DIFF
--- a/netutils/iperf/Kconfig
+++ b/netutils/iperf/Kconfig
@@ -31,7 +31,7 @@ config NETUTILS_IPERF_STACKSIZE
 	default DEFAULT_TASK_STACKSIZE
 
 config NETUTILS_IPERFTEST_DEVNAME
-	string "Wi-Fi Network device"
+	string "iperf Network device"
 	default "wlan0"
 
 endif


### PR DESCRIPTION
## Summary
Fix description as iperf can run not only with Wi-Fi network interface

## Impact
None

## Testing
Pass CI