### PR TITLE
Modify telnetd

### DIFF
--- a/include/netutils/telnetd.h
+++ b/include/netutils/telnetd.h
@@ -65,6 +65,20 @@ struct telnetd_config_s
                             * connection is accepted. */
 };
 
+/* This structure represents the overall state of one telnet daemon instance
+ * (Yes, multiple telnet daemons are supported).
+ */
+
+struct telnetd_s
+{
+  uint16_t              port;      /* The port to listen on (in network byte order) */
+  sa_family_t           family;    /* Address family */
+  uint8_t               priority;  /* The execution priority of the spawned task, */
+  size_t                stacksize; /* The stack size needed by the spawned task */
+  main_t                entry;     /* The entrypoint of the task to spawn when a new
+                                    * connection is accepted. */
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -76,6 +90,23 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
+
+/****************************************************************************
+ * Name: telnetd_daemon
+ *
+ * Description:
+ *   This function is the Telnet daemon.  It does not return (unless an
+ *   error occurs).
+ *
+ * Parameters:
+ *   Standard task start up arguments.
+ *
+ * Return:
+ *   Does not return unless an error occurs.
+ *
+ ****************************************************************************/
+
+int telnetd_daemon(int argc, FAR char *argv[]);
 
 /****************************************************************************
  * Name: telnetd_start

--- a/include/nshlib/nshlib.h
+++ b/include/nshlib/nshlib.h
@@ -127,6 +127,27 @@ void nsh_initialize(void);
 int nsh_consolemain(int argc, FAR char *argv[]);
 
 /****************************************************************************
+ * Name: nsh_telnetmain
+ *
+ * Description:
+ *   This interface may be called or started with task_start to start a
+ *   single NSH instance that operates on stdin and stdout for telnet daemon.
+ *   This function does not return.
+ *
+ * Input Parameters:
+ *   Standard task start-up arguments.  These are not used.  argc may be
+ *   zero and argv may be NULL.
+ *
+ * Returned Values:
+ *   This function does not normally return.  exit() is usually called to
+ *   terminate the NSH session.  This function will return in the event of
+ *   an error.  In that case, a non-zero value is returned (EXIT_FAILURE=1).
+
+ ****************************************************************************/
+
+int nsh_telnetmain(int argc, FAR char *argv[]);
+
+/****************************************************************************
  * Name: nsh_telnetstart
  *
  * Description:

--- a/netutils/telnetd/Kconfig
+++ b/netutils/telnetd/Kconfig
@@ -11,5 +11,24 @@ config NETUTILS_TELNETD
 	---help---
 		Enable support for the Telnet daemon.
 
-if NETUTILS_TELNETD
-endif
+config NETUTILS_TELNETD_USE_POSIX_SPAWNP
+	bool "Telnet daemon uses posix_spawnp"
+	default y if BUILD_KERNEL
+	default n if !BUILD_KERNEL
+	depends on NETUTILS_TELNETD
+	---help---
+		Enable to use posix_spawnp instead of tak_create
+
+config NETUTILS_TELNETD_PATH
+	string "Telnetd path"
+	default "/bin/telnetd"
+	depends on NETUTILS_TELNETD_USE_POSIX_SPAWNP
+	---help---
+		The path to the telnetd.
+
+config NETUTILS_TELNETD_SHELL_PATH
+	string "Telnetd shell path"
+	default "/bin/sh"
+	depends on NETUTILS_TELNETD_USE_POSIX_SPAWNP
+	---help---
+		The path to the shell executable.

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -1157,6 +1157,12 @@ config NSH_IOBUFFER_SIZE
 		Determines the size of the I/O buffer to use for sending/
 		receiving TELNET commands/responses.  Default: 512
 
+config NSH_DISABLE_TELNETSTART
+	bool "Disable to start telnetd"
+	default false
+	---help---
+		Determines if the nsh starts telnetd automatically
+
 endif # NSH_TELNET
 endmenu # Telnet Configuration
 

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -59,14 +59,14 @@ enum telnetd_state_e
 };
 
 /****************************************************************************
- * Private Functions
+ * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
  * Name: nsh_telnetmain
  ****************************************************************************/
 
-static int nsh_telnetmain(int argc, char *argv[])
+int nsh_telnetmain(int argc, FAR char *argv[])
 {
   FAR struct console_stdio_s *pstate = nsh_newconsole(true);
   FAR struct nsh_vtbl_s *vtbl;
@@ -193,10 +193,6 @@ static int nsh_telnetmain(int argc, char *argv[])
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: nsh_telnetstart
  *
  * Description:
@@ -218,6 +214,7 @@ static int nsh_telnetmain(int argc, char *argv[])
  *
  ****************************************************************************/
 
+#ifndef CONFIG_NSH_DISABLE_TELNETSTART
 int nsh_telnetstart(sa_family_t family)
 {
   static enum telnetd_state_e state = TELNETD_NOTRUNNING;
@@ -325,6 +322,7 @@ int nsh_telnetstart(sa_family_t family)
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: cmd_telnetd

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -127,7 +127,8 @@ int main(int argc, FAR char *argv[])
 
   nsh_initialize();
 
-#if defined(CONFIG_NSH_TELNET) && !defined(CONFIG_NETINIT_NETLOCAL)
+#if defined(CONFIG_NSH_TELNET) && !defined(CONFIG_NSH_DISABLE_TELNETSTART) && \
+  !defined(CONFIG_NETINIT_NETLOCAL)
   /* If the Telnet console is selected as a front-end, then start the
    * Telnet daemon UNLESS network initialization is deferred via
    * CONFIG_NETINIT_NETLOCAL.  In that case, the telnet daemon must be

--- a/system/telnetd/Kconfig
+++ b/system/telnetd/Kconfig
@@ -1,0 +1,39 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_TELNETD
+	tristate "Telnet daemon application"
+	default n
+	depends on NETUTILS_TELNETD
+	---help---
+		Enable the Telnet daemon application
+
+config SYSTEM_TELNETD_PROGNAME
+	string "Telnetd program name"
+	default "telnetd"
+	depends on SYSTEM_TELNETD
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config SYSTEM_TELNETD_PRIORITY
+	int "Telnetd task priority"
+	default 100
+	depends on SYSTEM_TELNETD
+
+config SYSTEM_TELNETD_STACKSIZE
+	int "Telnetd task stack size"
+	default DEFAULT_TASK_STACKSIZE
+	depends on SYSTEM_TELNETD
+
+config SYSTEM_TELNETD_SESSION_PRIORITY
+	int "Telnetd session task priority"
+	default 100
+	depends on SYSTEM_TELNETD
+
+config SYSTEM_TELNETD_SESSION_STACKSIZE
+	int "Telnetd session task stack size"
+	default 3072
+	depends on SYSTEM_TELNETD

--- a/system/telnetd/Make.defs
+++ b/system/telnetd/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/telnetd/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_TELNETD),)
+CONFIGURED_APPS += $(APPDIR)/system/telnetd
+endif

--- a/system/telnetd/Makefile
+++ b/system/telnetd/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/system/telnetd/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# telnetd
+
+PROGNAME  := $(CONFIG_SYSTEM_TELNETD_PROGNAME)
+PRIORITY  := $(CONFIG_SYSTEM_TELNETD_PRIORITY)
+STACKSIZE := $(CONFIG_SYSTEM_TELNETD_STACKSIZE)
+MODULE    := $(CONFIG_SYSTEM_TELNETD)
+
+# Files
+
+MAINSRC := telnetd.c
+
+include $(APPDIR)/Application.mk

--- a/system/telnetd/telnetd.c
+++ b/system/telnetd/telnetd.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * apps/system/telnetd/telnetd.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netutils/telnetd.h"
+#include "netutils/netlib.h"
+#include "nshlib/nshlib.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  FAR char *argv1[3];
+  char arg0[sizeof("0x1234567812345678")];
+  struct telnetd_s daemon;
+
+  /* Initialize the daemon structure */
+
+  daemon.port      = HTONS(23);
+  daemon.family    = AF_INET;
+  daemon.entry     = nsh_telnetmain;
+
+  /* NOTE: Settings for telnet session task */
+
+  daemon.priority  = CONFIG_SYSTEM_TELNETD_SESSION_PRIORITY;
+  daemon.stacksize = CONFIG_SYSTEM_TELNETD_SESSION_STACKSIZE;
+
+  snprintf(arg0, sizeof(arg0), "0x%" PRIxPTR, (uintptr_t)&daemon);
+  argv1[0] = "telnetd";
+  argv1[1] = arg0;
+  argv1[2] = NULL;
+
+  telnetd_daemon(2, argv1);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- This PR contains the following commits
- commit1: netutils: Make telnetd_daemon() in public
   - This commit makes telnetd_daemon() in public so that we
      can call it from applications.
  - Also, adds new configs to support posix_spawnp()
- commit2: nshlib: Make nsh_telnetmain() in public
  - This commit makes nsh_telnetmain() in public so that we can
      call it from applications.
  - Also, CONFIG_NSH_DISABLE_TELNETSTART is introduced so that
      we can disable nsh_telnetstart()

## Impact

- nsh with telnet daemon

## Testing

- Tested with sabre-6quad:netnsh (will be updated later)
