### PR TITLE
testing/sensortest: Update device path

### DIFF
--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -37,7 +37,7 @@
  ****************************************************************************/
 
 #define ARRAYSIZE(a)       (sizeof(a) / sizeof(a)[0])
-#define DEVNAME_FMT        "/dev/sensor/%s"
+#define DEVNAME_FMT        "/dev/sensor/sensor_%s"
 #define DEVNAME_MAX        64
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Device Paths for NuttX Sensors are now named `/dev/sensor/sensor_...` according to [drivers/sensors/sensor.c](https://github.com/apache/incubator-nuttx/blob/3fdd036ba6eee2ffd76cfba561ab1b044e3275e2/drivers/sensors/sensor.c#L49):

```c
#define DEVNAME_FMT        "/dev/sensor/sensor_%s%s%d"
```

`sensortest` fails to open any sensor because it's using the old Device Path:

```text
nsh> sensortest -n 1 baro0
Failed to open device:/dev/sensor/baro0, ret:No such file or directory

nsh> sensortest -n 1 sensor_baro0
The sensor node name:sensor_baro0 is invalid

nsh> ls /dev/sensor
/dev/sensor:
 sensor_baro0
 sensor_humi0
```

This patch updates the Device Path in `sensortest` so that it can open the sensor correctly.

Hi @Donny9 I hope this patch is correct? Thanks!

## Impact

After applying the patch, `sensortest` can access the sensor correctly at `/dev/sensor/sensor_...`

## Testing

Tested with [BME280 Driver](https://github.com/lupyuen/bme280-nuttx) on BL602:

```text
nsh> sensortest -n 1 baro0
SensorTest: Test /dev/sensor/sensor_baro0 with interval(1000000us), latency(0us)
baro0: timestamp:14060000 value1:1007.14 value2:29.73
SensorTest: Received message: baro0, number:1/1

nsh> sensortest -n 1 humi0
SensorTest: Test /dev/sensor/sensor_humi0 with interval(1000000us), latency(0us)
humi0: timestamp:20940000 value:74.96
SensorTest: Received message: humi0, number:1/1
```
