### PR TITLE
driver/sensor: rename /dev/sensor -> /dev/uorb

### DIFF
--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -76,7 +76,7 @@ typedef uint64_t orb_abstime;
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ORB_SENSOR_PATH        "/dev/sensor/"
+#define ORB_SENSOR_PATH        "/dev/uorb/"
 #define ORB_USENSOR_PATH       "/dev/usensor"
 #define ORB_PATH_MAX           (NAME_MAX + 16)
 
@@ -210,7 +210,7 @@ int orb_close(int fd);
  *
  * Description:
  *   This performs the initial advertisement of a topic; it creates the topic
- *   node in /dev/sensor and publishes the initial data.
+ *   node in /dev/uorb and publishes the initial data.
  *
  * Input Parameters:
  *   meta         The uORB metadata (usually from the ORB_ID() macro)

--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -37,7 +37,7 @@
  ****************************************************************************/
 
 #define ARRAYSIZE(a)       (sizeof(a) / sizeof(a)[0])
-#define DEVNAME_FMT        "/dev/sensor/sensor_%s"
+#define DEVNAME_FMT        "/dev/uorb/sensor_%s"
 #define DEVNAME_MAX        64
 
 /****************************************************************************
@@ -214,7 +214,7 @@ static void usage(void)
   printf("\t            default: 0\n");
 
   printf(" Commands:\n");
-  printf("\t<sensor_node_name> ex, accel0(/dev/sensor/accel0)\n");
+  printf("\t<sensor_node_name> ex, accel0(/dev/uorb/sensor_accel0)\n");
 }
 
 static void exit_handler(int signo)


### PR DESCRIPTION

## Summary
driver/sensor: rename /dev/sensor -> /dev/uorb

because this directory contains all topics, not just sensors.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
rename  directory for sensor device
## Testing
Local test
