### PR TITLE
wamr: Add a new option to enable semaphore support

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -89,6 +89,11 @@ config INTERPRETERS_WAMR_LIB_PTHREAD
 	bool "Enable lib pthread"
 	default n
 
+config INTERPRETERS_WAMR_LIB_PTHREAD_SEMAPHORE
+	bool "Enable semaphore"
+	depends on INTERPRETERS_WAMR_LIB_PTHREAD
+	default n
+
 config INTERPRETERS_WAMR_SHARED_MEMORY
 	bool "Enable shared memory"
 	default n


### PR DESCRIPTION
## Summary
Add a new option to enable semaphore support, see : https://github.com/bytecodealliance/wasm-micro-runtime/pull/1345
## Impact
New feature
## Testing
Custom boards
