### PR TITLE
zmodem: Move crc16.h and crc32.h from host to host/nuttx

### DIFF
--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -33,9 +33,9 @@
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
-#include <crc32.h>
 #include <debug.h>
 
+#include <nuttx/crc32.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/mtd/configdata.h>
 #include <nuttx/fs/ioctl.h>

--- a/fsutils/mkgpt/mkgpt.c
+++ b/fsutils/mkgpt/mkgpt.c
@@ -22,7 +22,6 @@
  * Included Files
  ****************************************************************************/
 
-#include <crc32.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -34,6 +33,8 @@
 
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+
+#include <nuttx/crc32.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/system/zmodem/host/nuttx/crc16.h
+++ b/system/zmodem/host/nuttx/crc16.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/zmodem/host/crc32.h
+ * apps/system/zmodem/host/nuttx/crc16.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_SYSTEM_ZMODEM_HOST_CRC32_H
-#define __APPS_SYSTEM_ZMODEM_HOST_CRC32_H
+#ifndef __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC16_H
+#define __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC16_H
 
 /****************************************************************************
  * Included Files
@@ -41,28 +41,28 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: crc32part
+ * Name: crc16part
  *
  * Description:
  *   Continue CRC calculation on a part of the buffer.
  *
  ****************************************************************************/
 
-uint32_t crc32part(const uint8_t *src, size_t len, uint32_t crc32val);
+uint16_t crc16part(const uint8_t *src, size_t len, uint16_t crc16val);
 
 /****************************************************************************
- * Name: crc32
+ * Name: crc16
  *
  * Description:
- *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
  *
  ****************************************************************************/
 
-uint32_t crc32(const uint8_t *src, size_t len);
+uint16_t crc16(const uint8_t *src, size_t len);
 
 #undef EXTERN
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __APPS_SYSTEM_ZMODEM_HOST_CRC32_H */
+#endif /* __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC16_H */

--- a/system/zmodem/host/nuttx/crc32.h
+++ b/system/zmodem/host/nuttx/crc32.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/zmodem/host/crc16.h
+ * apps/system/zmodem/host/nuttx/crc32.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_SYSTEM_ZMODEM_HOST_CRC16_H
-#define __APPS_SYSTEM_ZMODEM_HOST_CRC16_H
+#ifndef __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC32_H
+#define __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC32_H
 
 /****************************************************************************
  * Included Files
@@ -41,28 +41,28 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: crc16part
+ * Name: crc32part
  *
  * Description:
  *   Continue CRC calculation on a part of the buffer.
  *
  ****************************************************************************/
 
-uint16_t crc16part(const uint8_t *src, size_t len, uint16_t crc16val);
+uint32_t crc32part(const uint8_t *src, size_t len, uint32_t crc32val);
 
 /****************************************************************************
- * Name: crc16
+ * Name: crc32
  *
  * Description:
- *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
  *
  ****************************************************************************/
 
-uint16_t crc16(const uint8_t *src, size_t len);
+uint32_t crc32(const uint8_t *src, size_t len);
 
 #undef EXTERN
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __APPS_SYSTEM_ZMODEM_HOST_CRC16_H */
+#endif /* __APPS_SYSTEM_ZMODEM_HOST_NUTTX_CRC32_H */

--- a/system/zmodem/zm_proto.c
+++ b/system/zmodem/zm_proto.c
@@ -30,8 +30,9 @@
 #include <nuttx/config.h>
 
 #include <stdio.h>
-#include <crc16.h>
-#include <crc32.h>
+
+#include <nuttx/crc16.h>
+#include <nuttx/crc32.h>
 
 #include "zm.h"
 

--- a/system/zmodem/zm_send.c
+++ b/system/zmodem/zm_send.c
@@ -45,11 +45,12 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
-#include <crc16.h>
-#include <crc32.h>
 
+#include <nuttx/crc16.h>
+#include <nuttx/crc32.h>
 #include <nuttx/ascii.h>
-#include "system/zmodem.h"
+
+#include <system/zmodem.h>
 
 #include "zm.h"
 

--- a/system/zmodem/zm_state.c
+++ b/system/zmodem/zm_state.c
@@ -47,9 +47,9 @@
 #include <sched.h>
 #include <assert.h>
 #include <errno.h>
-#include <crc16.h>
-#include <crc32.h>
 
+#include <nuttx/crc16.h>
+#include <nuttx/crc32.h>
 #include <nuttx/ascii.h>
 
 #include "zm.h"

--- a/system/zmodem/zm_utils.c
+++ b/system/zmodem/zm_utils.c
@@ -30,7 +30,8 @@
 #include <termios.h>
 #include <assert.h>
 #include <errno.h>
-#include <crc32.h>
+
+#include <nuttx/crc32.h>
 
 #include "zm.h"
 

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -37,9 +37,10 @@
 #include <dirent.h>
 #include <string.h>
 #include <errno.h>
-#include <crc32.h>
 #include <debug.h>
 #include <assert.h>
+
+#include <nuttx/crc32.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/testing/nxffs/nxffs_main.c
+++ b/testing/nxffs/nxffs_main.c
@@ -35,9 +35,9 @@
 #include <dirent.h>
 #include <string.h>
 #include <errno.h>
-#include <crc32.h>
 #include <debug.h>
 
+#include <nuttx/crc32.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/nxffs.h>
 

--- a/testing/smart/smart_main.c
+++ b/testing/smart/smart_main.c
@@ -35,9 +35,9 @@
 #include <dirent.h>
 #include <string.h>
 #include <errno.h>
-#include <crc32.h>
 #include <debug.h>
 
+#include <nuttx/crc32.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/smart.h>
 #include <nuttx/fs/ioctl.h>


### PR DESCRIPTION
## Summary
to avoid the conflict with the 3rd party library.
note: all major libc provider doesn't put crc8.h, crc16.h and crc32.h directly under include folder.
depends on https://github.com/apache/incubator-nuttx/pull/6840

## Impact

## Testing

