### PR TITLE
dhcpd: fix build warning

### DIFF
--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -1422,7 +1422,7 @@ static inline int dhcpd_openlistener(FAR const char *interface)
 
   /* Get the IP address of the selected device */
 
-  strncpy(req.ifr_name, interface, IFNAMSIZ);
+  strlcpy(req.ifr_name, interface, IFNAMSIZ);
   ret = ioctl(sockfd, SIOCGIFADDR, (unsigned long)&req);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

CC:  dhcpd.c
In function 'dhcpd_openlistener',
    inlined from 'dhcpd_run.part.0' at dhcpd.c:1513:20:
dhcpd.c:1425:3: error: 'strncpy' specified bound 16 equals destination size [-Werror=stringop-truncation]
 1425 |   strncpy(req.ifr_name, interface, IFNAMSIZ);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>
Change-Id: I8f9dd8bfb7cc9d270f02ab11b4953aa2dec7cc8b

## Impact

Minor change

## Testing
CI
