### PR TITLE
wireless/wapi: correct check of return value

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -403,7 +403,7 @@ static int wapi_show_cmd(int sock, int argc, FAR char **argv)
   /* Get sensitivity */
 
   ret = wapi_get_sensitivity(sock, ifname, &sense);
-  if (ret == 0)
+  if (ret >= 0)
     {
       printf("    Sense: %d\n", sense);
     }
@@ -412,7 +412,7 @@ static int wapi_show_cmd(int sock, int argc, FAR char **argv)
 
   memset(country, 0, sizeof(country));
   ret = wapi_get_country(sock, ifname, country);
-  if (ret == 0)
+  if (ret >= 0)
     {
       printf("  Country: %s\n", country);
     }
@@ -834,7 +834,7 @@ static int wapi_country_cmd(int sock, int argc, FAR char **argv)
   if (argc == 1)
     {
       ret = wapi_get_country(sock, argv[0], country);
-      if (ret == 0)
+      if (ret >= 0)
         {
           printf("%s\n", country);
         }
@@ -862,7 +862,7 @@ static int wapi_sense_cmd(int sock, int argc, FAR char **argv)
   int ret;
 
   ret = wapi_get_sensitivity(sock, argv[0], &sense);
-  if (ret == 0)
+  if (ret >= 0)
     {
       printf("%d\n", sense);
     }

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -1461,7 +1461,7 @@ int wapi_get_country(int sock, FAR const char *ifname,
 
   strlcpy(wrq.ifr_name, ifname, IFNAMSIZ);
   wrq.u.data.pointer = (FAR void *)country;
-  wrq.u.data.length = 2;
+  wrq.u.data.length = 3;
   ret = ioctl(sock, SIOCGIWCOUNTRY, (unsigned long)((uintptr_t)&wrq));
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

wireless/wapi: correct check of return value

1. correct check of return value
```
----------------------
 * Name: ioctl
...
 * Returned Value:
 *   >=0 on success (positive non-zero values are cmd-specific)
 *   -1 on failure with errno set properly:
```

2. country code length should contain LF

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

bcm43013