### PR TITLE
examples/rpmsgsocket: fix wrong typo

### DIFF
--- a/examples/rpmsgsocket/Kconfig
+++ b/examples/rpmsgsocket/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config EXAMPLES_RPMSGSOCKET
-	tristate "Rpmsg scoekt example"
+	tristate "Rpmsg socket example"
 	depends on NET_RPMSG
 	default n
 	---help---


### PR DESCRIPTION
Signed-off-by: yintao <yintao@xiaomi.com>

## Summary 
fix wrong typo in examples/rpmsgsocket
## Impact
none
## Testing
vela ci passed
