### PR TITLE
nxlooper nxplayer nxrecorder: fix coverity bug

### DIFF
--- a/system/nxlooper/nxlooper_main.c
+++ b/system/nxlooper/nxlooper_main.c
@@ -528,9 +528,9 @@ int main(int argc, FAR char *argv[])
       /* Read a line from the terminal */
 
       len = readline(buffer, sizeof(buffer), stdin, stdout);
-      buffer[len] = '\0';
       if (len > 0)
         {
+          buffer[len] = '\0';
           if (strncmp(buffer, "!", 1) != 0)
             {
               /* nxlooper command */

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -771,9 +771,9 @@ int main(int argc, FAR char *argv[])
       /* Read a line from the terminal */
 
       len = readline(buffer, sizeof(buffer), stdin, stdout);
-      buffer[len] = '\0';
       if (len > 0)
         {
+          buffer[len] = '\0';
           if (strncmp(buffer, "!", 1) != 0)
             {
               /* nxplayer command */

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -484,9 +484,9 @@ int main(int argc, FAR char *argv[])
       /* Read a line from the terminal */
 
       len = readline(buffer, sizeof(buffer), stdin, stdout);
-      buffer[len] = '\0';
       if (len > 0)
         {
+          buffer[len] = '\0';
           if (strncmp(buffer, "!", 1) != 0)
             {
               /* nxrecorder command */


### PR DESCRIPTION
## Summary
readline might return EOF, which causes coverity bug.

## Impact

## Testing

