### PR TITLE
apps: Fix the bug that didn't initialize structure

### DIFF
--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
@@ -267,6 +267,7 @@ int main(int argc, char *argv[])
 
           /* Wait the packet ready */
 
+          memset(&pfd, 0, sizeof(struct pollfd));
           pfd.ptr = &priv.file;
           pfd.events = POLLIN | POLLFILE;
           ret = poll(&pfd, 1, -1);


### PR DESCRIPTION
Signed-off-by: weizihan <weizihan@xiaomi.com>

## Summary
netutils/usrsock_rpmsg/usrsock_rpmsg_client.c
Fix the bug that didn't initialize structure

## Impact
usrsock_rpmsg_client.c Calling memset to initialize pfd

## Testing
passed vela CI
