### PR TITLE
nshlib: Disable dmesg if RAMLOG_SYSLOG disabled

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -273,7 +273,6 @@ config NSH_DISABLE_DIRNAME
 config NSH_DISABLE_DMESG
 	bool "Disable dmesg"
 	default DEFAULT_SMALL
-	depends on RAMLOG_SYSLOG
 
 config NSH_DISABLE_ECHO
 	bool "Disable echo"


### PR DESCRIPTION
## Summary
You can't disable dmesg if RAMLOG_SYSLOG disabled since `NSH_DISABLE_DMESG` depends on it.
## Impact
dmesg only, minor
## Testing
Custom build
