### PR TITLE
net/sockopt: move BINDTODEVICE to socket level

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -7,7 +7,7 @@ config NETUTILS_DHCPC
 	bool "DHCP client"
 	default n
 	depends on NET_UDP && NET_BROADCAST && NET_IPv4
-	select NET_UDP_BINDTODEVICE if !NET_UDP_NO_STACK
+	select NET_BINDTODEVICE if !NET_UDP_NO_STACK
 	---help---
 		Enable support for the DHCP client.
 

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -565,14 +565,14 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
           return NULL;
         }
 
-#ifdef CONFIG_NET_UDP_BINDTODEVICE
+#ifdef CONFIG_NET_BINDTODEVICE
       /* Bind socket to interface, because UDP packets have to be sent to the
        * broadcast address at a moment when it is not possible to decide the
        * target network device using the local or remote address (which is,
        * by definition and purpose of DHCP, undefined yet).
        */
 
-      ret = setsockopt(pdhcpc->sockfd, IPPROTO_UDP, UDP_BINDTODEVICE,
+      ret = setsockopt(pdhcpc->sockfd, SOL_SOCKET, SO_BINDTODEVICE,
                        pdhcpc->interface, strlen(pdhcpc->interface));
       if (ret < 0)
         {

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -864,14 +864,14 @@ static inline int dhcpd_socket(FAR const char *interface)
     }
 #endif
 
-#ifdef CONFIG_NET_UDP_BINDTODEVICE
+#ifdef CONFIG_NET_BINDTODEVICE
   /* Bind socket to interface, because UDP packets have to be sent to the
    * broadcast address at a moment when it is not possible to decide the
    * target network device using the local or remote address (which is,
    * by definition and purpose of DHCP, undefined yet).
    */
 
-  if (setsockopt(sockfd, IPPROTO_UDP, UDP_BINDTODEVICE,
+  if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
                  interface, strlen(interface)) < 0)
     {
       ninfo("ERROR: setsockopt UDP_BINDTODEVICE failed: %d\n", errno);


### PR DESCRIPTION
## Summary

net/sockopt: move BINDTODEVICE to socket level

rename the UDP_BINDTODEVICE to SO_BINDTODEVICE to follow the linux
style to be compatible with non-UDP protocol binding requirements

Signed-off-by: chao.an [anchao@xiaomi.com](mailto:anchao@xiaomi.com)

## Impact

Depends on: https://github.com/apache/incubator-nuttx/pull/6907

## Testing

dhcpc renew
sim/tcpblaster