### PR TITLE
testing: getprime: Fix the thread number info

### DIFF
--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -114,6 +114,7 @@ static void get_prime_in_parallel(int n)
   pthread_t thread[MAX_THREADS];
   pthread_attr_t attr;
   pthread_addr_t result;
+  int arg[MAX_THREADS];
   int status;
   int i;
 
@@ -141,9 +142,10 @@ static void get_prime_in_parallel(int n)
 
   for (i = 0; i < n; i++)
     {
+      arg[i] = i;
       printf("Start thread #%d\n", i);
       status = pthread_create(&thread[i], &attr,
-                              thread_func, (FAR void *)&i);
+                              thread_func, (FAR void *)&arg[i]);
       ASSERT(status == OK);
     }
 


### PR DESCRIPTION
## Summary

- I noticed that getprime sometimes shows a wrong thread number
- This commit fixes this issue

## Impact

- None

## Testing

- Tested with sabre-6quad:netnsh

