### PR TITLE
fix use of addroute/delroute

### DIFF
--- a/netutils/netlib/netlib_setdripv4addr.c
+++ b/netutils/netlib/netlib_setdripv4addr.c
@@ -66,18 +66,21 @@ int netlib_set_dripv4addr(FAR const char *ifname,
   int ret = ERROR;
 
 #ifdef CONFIG_NET_ROUTE
-  struct sockaddr_in target;
-  struct sockaddr_in netmask;
-  struct sockaddr_in router;
+  FAR struct sockaddr_in *v4_addr;
+  struct sockaddr_storage target;
+  struct sockaddr_storage netmask;
+  struct sockaddr_storage router;
 
   memset(&target, 0, sizeof(target));
-  target.sin_family  = AF_INET;
+  target.ss_family  = AF_INET;
 
   memset(&netmask, 0, sizeof(netmask));
-  netmask.sin_family  = AF_INET;
+  netmask.ss_family  = AF_INET;
 
-  router.sin_addr    = *addr;
-  router.sin_family  = AF_INET;
+  memset(&router, 0, sizeof(router));
+  v4_addr = (FAR struct sockaddr_in *)&router;
+  v4_addr->sin_family  = AF_INET;
+  v4_addr->sin_addr    = *addr;
 #endif
 
   if (ifname && addr)
@@ -108,16 +111,11 @@ int netlib_set_dripv4addr(FAR const char *ifname,
 
               /* This call fails if no default route exists, but it's OK */
 
-              delroute(sockfd,
-                       (FAR struct sockaddr_storage *)&target,
-                       (FAR struct sockaddr_storage *)&netmask);
+              delroute(sockfd, &target, &netmask);
 
               /* Then add the new default route */
 
-              ret = addroute(sockfd,
-                             (FAR struct sockaddr_storage *)&target,
-                             (FAR struct sockaddr_storage *)&netmask,
-                             (FAR struct sockaddr_storage *)&router);
+              ret = addroute(sockfd, &target, &netmask, &router);
             }
 #endif
 

--- a/nshlib/nsh_routecmds.c
+++ b/nshlib/nsh_routecmds.c
@@ -99,6 +99,7 @@ int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #ifdef CONFIG_NET_IPv6
     struct sockaddr_in6 ipv6;
 #endif
+    struct sockaddr_storage ipx;
   } target;
 
   union
@@ -109,6 +110,7 @@ int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #ifdef CONFIG_NET_IPv6
     struct sockaddr_in6 ipv6;
 #endif
+    struct sockaddr_storage ipx;
   } netmask;
 
   union
@@ -119,6 +121,7 @@ int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #ifdef CONFIG_NET_IPv6
   struct sockaddr_in6 ipv6;
 #endif
+  struct sockaddr_storage ipx;
   } router;
 
   union
@@ -430,10 +433,7 @@ int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   /* Then add the route */
 
-  ret = addroute(sockfd,
-                 (FAR struct sockaddr_storage *)&target,
-                 (FAR struct sockaddr_storage *)&netmask,
-                 (FAR struct sockaddr_storage *)&router);
+  ret = addroute(sockfd, &target.ipx, &netmask.ipx, &router.ipx);
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, argv[0], "addroute", NSH_ERRNO);
@@ -468,6 +468,7 @@ int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #ifdef CONFIG_NET_IPv6
     struct sockaddr_in6 ipv6;
 #endif
+    struct sockaddr_storage ipx;
   } target;
 
   union
@@ -478,6 +479,7 @@ int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #ifdef CONFIG_NET_IPv6
     struct sockaddr_in6 ipv6;
 #endif
+    struct sockaddr_storage ipx;
   } netmask;
 
   union
@@ -673,9 +675,7 @@ int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   /* Then delete the route */
 
-  ret = delroute(sockfd,
-                 (FAR struct sockaddr_storage *)&target,
-                 (FAR struct sockaddr_storage *)&netmask);
+  ret = delroute(sockfd, &target.ipx, &netmask.ipx);
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, argv[0], "delroute", NSH_ERRNO);


### PR DESCRIPTION
Signed-off-by: liyi <liyi25@xiaomi.com>

## Summary
fix the use of addroute/delroute
addroute/delroute function's input parameter may be a structure sockadd_in(netlib_set_dripv4addr),
which has only 16B. But structure sockaddr_storage's size is larger than 16B. In fact, its size is 128B. 
So when you pass a structure sockadd_in and try to copy as a structure sockaddr_storage
it will overstep the buffer's bounary. It is the similar condition for IPv6's structure sockaddr_in6.

## Impact
app's code must fit this change 

## Testing
before this modification, the nuttx may crash with "stack buffer overflow", like blow
![image](https://user-images.githubusercontent.com/38680504/186857730-22d0fff6-642c-4208-80f6-229c988afb8f.png)
The fault error is caused by the wrong way to use addroute (netlib_set_dripv4addr)

after this, it can work well!
![image](https://user-images.githubusercontent.com/38680504/186858485-4befd87b-fd73-49cc-bec8-5d4b883e2be5.png)

