### PR TITLE
Don't download tarballs if a local git repo found

### DIFF
--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -83,10 +83,13 @@ $(MCUBOOT_UNPACK): $(MCUBOOT_TARBALL)
 	$(Q) mv mcuboot-$(MCUBOOT_VERSION) $(MCUBOOT_UNPACK)
 	$(Q) touch $(MCUBOOT_UNPACK)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(MCUBOOT_UNPACK)/.git),)
 context:: $(MCUBOOT_UNPACK)
 
 distclean::
 	$(call DELFILE, $(MCUBOOT_TARBALL))
 	$(call DELDIR, $(MCUBOOT_UNPACK))
+endif
 
 include $(APPDIR)/Application.mk

--- a/crypto/libtomcrypt/Makefile
+++ b/crypto/libtomcrypt/Makefile
@@ -476,10 +476,13 @@ $(LIBTOMCRYPT_UNPACKNAME): $(LIBTOMCRYPT_ZIP)
 	$(Q) patch -p0 < ltcrypt-flush.patch # Missing stdout flush in demo app
 	$(Q) touch $(LIBTOMCRYPT_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LIBTOMCRYPT_UNPACKNAME)/.git),)
 context:: $(LIBTOMCRYPT_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(LIBTOMCRYPT_UNPACKNAME))
 	$(call DELFILE, $(LIBTOMCRYPT_ZIP))
+endif
 
 include $(APPDIR)/Application.mk

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -50,11 +50,14 @@ $(MBEDTLS_UNPACKNAME): $(MBEDTLS_ZIP)
 	$(Q) mv	mbedtls-$(MBEDTLS_VERSION) $(MBEDTLS_UNPACKNAME)
 	$(Q) touch $(MBEDTLS_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(MBEDTLS_UNPACKNAME)/.git),)
 context:: $(MBEDTLS_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(MBEDTLS_UNPACKNAME))
 	$(call DELFILE, $(MBEDTLS_ZIP))
+endif
 
 # Configuration Applications
 

--- a/examples/lvgldemo/Makefile
+++ b/examples/lvgldemo/Makefile
@@ -87,10 +87,13 @@ $(LVGL_EXAMPLES_UNPACKNAME): $(LVGL_EXAMPLES_TARBALL)
 	$(Q) mv	lv_demos-$(LVGL_EXAMPLES_VERSION) $(LVGL_EXAMPLES_UNPACKNAME)
 	$(Q) touch $(LVGL_EXAMPLES_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LVGL_EXAMPLES_UNPACKNAME)/.git),)
 context:: $(LVGL_EXAMPLES_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(LVGL_EXAMPLES_UNPACKNAME))
 	$(call DELFILE, $(LVGL_EXAMPLES_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/gpsutils/minmea/Makefile
+++ b/gpsutils/minmea/Makefile
@@ -40,12 +40,16 @@ $(MINMEA_UNPACKDIR):
 CSRCS	= minmea/minmea.c
 CFLAGS += -std=c99
 
-context:: $(MINMEA_UNPACKDIR)
 
 clean::
 	$(call DELFILE, $(OBJS))
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(MINMEA_UNPACKDIR)/.git),)
+context:: $(MINMEA_UNPACKDIR)
+
 distclean::
 	$(call DELDIR, $(MINMEA_UNPACKDIR))
+endif
 
 include $(APPDIR)/Application.mk

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -70,10 +70,13 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) mv	lvgl-$(LVGL_VERSION) $(LVGL_UNPACKNAME)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 context:: $(LVGL_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(LVGL_UNPACKNAME))
 	$(call DELFILE, $(LVGL_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/interpreters/duktape/Makefile
+++ b/interpreters/duktape/Makefile
@@ -62,10 +62,13 @@ $(DUKTAPE_UNPACK): $(DUKTAPE_TARBALL)
 $(DUKTAPE_UNPACK)/.patch: $(DUKTAPE_UNPACK)
 	$(Q) touch $(DUKTAPE_UNPACK)/.patch
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(DUKTAPE_UNPACK)/.git),)
 context:: $(DUKTAPE_UNPACK)/.patch
 
 distclean::
 	$(call DELDIR, $(DUKTAPE_UNPACK))
 	$(call DELFILE, $(DUKTAPE_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/interpreters/lua/Makefile
+++ b/interpreters/lua/Makefile
@@ -75,7 +75,10 @@ $(LUA_UNPACK): $(LUA_TARBALL)
 	$(Q) echo "Unpacking $(LUA_TARBALL) to $(LUA_UNPACK)"
 	$(Q) tar -xvzf $(LUA_TARBALL)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LUA_UNPACK)/.git),)
 context:: $(LUA_UNPACK)
+endif
 
 # Register core modules
 
@@ -129,7 +132,9 @@ clean_context::
 
 distclean:: clean_context clean
 	$(call DELFILE, registry$(DELIM).updated)
+ifeq ($(wildcard $(LUA_UNPACK)/.git),)
 	$(call DELDIR, $(LUA_UNPACK))
 	$(call DELFILE, $(LUA_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/interpreters/quickjs/Makefile
+++ b/interpreters/quickjs/Makefile
@@ -77,7 +77,17 @@ $(QUICKJS_UNPACK): $(QUICKJS_TARBALL)
 $(QUICKJS_UNPACK)/.patch: $(QUICKJS_UNPACK)
 	$(Q) touch $(QUICKJS_UNPACK)/.patch
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(QUICKJS_UNPACK)/.git),)
+
+distclean::
+	$(call DELDIR, $(QUICKJS_UNPACK))
+	$(call DELFILE, $(QUICKJS_TARBALL))
+
 build_host: $(QUICKJS_UNPACK)/.patch
+else
+build_host:
+endif
 	$(MAKE) -C $(QUICKJS_UNPACK) \
 		CONFIG_BIGNUM=$(CONFIG_INTERPRETERS_QUICKJS_BIGNUM)
 
@@ -85,9 +95,5 @@ context:: build_host
 
 clean::
 	$(Q) test ! -d $(QUICKJS_UNPACK) || $(MAKE) -C $(QUICKJS_UNPACK) clean
-
-distclean::
-	$(call DELDIR, $(QUICKJS_UNPACK))
-	$(call DELFILE, $(QUICKJS_TARBALL))
 
 include $(APPDIR)/Application.mk

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -50,10 +50,13 @@ $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) mv wasm-micro-runtime-$(WAMR_VERSION) $(WAMR_UNPACK)
 	$(Q) touch $(WAMR_UNPACK)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(WAMR_UNPACK)/.git),)
 context:: $(WAMR_UNPACK)
 
 distclean::
 	$(call DELDIR, $(WAMR_UNPACK))
 	$(call DELFILE, $(WAMR_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/interpreters/wasm3/Makefile
+++ b/interpreters/wasm3/Makefile
@@ -68,13 +68,13 @@ $(WASM3_UNPACK): $(WASM3_TARBALL)
 	$(Q) tar xzvf $(WASM3_TARBALL)
 	$(Q) mv wasm3-$(WASM3_VERSION) $(WASM3_UNPACK)
 
-$(WASM3_UNPACK)/.patch: $(WASM3_UNPACK)
-	$(Q) touch $(WASM3_UNPACK)/.patch
-
-context:: $(WASM3_UNPACK)/.patch
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(WASM3_UNPACK)/.git),)
+context:: $(WASM3_UNPACK)
 
 distclean::
 	$(call DELDIR, $(WASM3_UNPACK))
 	$(call DELFILE, $(WASM3_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/math/libtommath/Makefile
+++ b/math/libtommath/Makefile
@@ -103,10 +103,13 @@ $(LIBTOMMATH_UNPACKNAME): $(LIBTOMMATH_ZIP)
 	$(Q) mv	libtommath-$(LIBTOMMATH_VERSION) $(LIBTOMMATH_UNPACKNAME)
 	$(Q) touch $(LIBTOMMATH_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LIBTOMMATH_UNPACKNAME)/.git),)
 context:: $(LIBTOMMATH_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(LIBTOMMATH_UNPACKNAME))
 	$(call DELFILE, $(LIBTOMMATH_ZIP))
+endif
 
 include $(APPDIR)/Application.mk

--- a/mlearning/cmsis/Makefile
+++ b/mlearning/cmsis/Makefile
@@ -26,10 +26,13 @@ cmsis.zip:
 	$(Q) mv CMSIS_5-$(CONFIG_CMSIS_VER) CMSIS_5
 	$(Q) patch -p0 < cmsis-nn-support_nnabla.patch
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard CMSIS_5/.git),)
 context:: cmsis.zip
 
 distclean::
 	$(call DELDIR, CMSIS_5)
 	$(call DELFILE, cmsis.zip)
+endif
 
 include $(APPDIR)/Application.mk

--- a/mlearning/darknet/Makefile
+++ b/mlearning/darknet/Makefile
@@ -20,7 +20,6 @@
 
 include $(APPDIR)/Make.defs
 
-ifeq ($(CONFIG_DARKNET_YOLO),y)
 SRC = darknet/src
 
 CSRCS   +=$(SRC)/gemm.c
@@ -79,12 +78,13 @@ darknet.zip:
 	$(Q) unzip -o darknet.zip
 	$(Q) mv darknet-$(DARKNET_YOLO_VER) darknet
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard darknet/.git),)
 context:: darknet.zip
 
 distclean::
 	$(call DELDIR, darknet)
 	$(call DELFILE, darknet.zip)
-
 endif
 
 include $(APPDIR)/Application.mk

--- a/mlearning/libnnablart/Makefile
+++ b/mlearning/libnnablart/Makefile
@@ -20,7 +20,6 @@
 
 include $(APPDIR)/Make.defs
 
-ifeq ($(CONFIG_NNABLA_RT),y)
 SRC = nnabla-c-runtime/src
 
 CSRCS   += $(SRC)/functions/utilities/accessor.c
@@ -115,12 +114,13 @@ nnabla.zip:
 	$(Q) unzip -o nnabla.zip
 	$(Q) mv nnabla-c-runtime-$(CONFIG_NNABLA_RT_VER) nnabla-c-runtime
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard nnabla-c-runtime/.git),)
 context:: nnabla.zip
 
 distclean::
 	$(call DELDIR, nnabla-c-runtime)
 	$(call DELFILE, nnabla.zip)
-
 endif
 
 include $(APPDIR)/Application.mk

--- a/netutils/cjson/Makefile
+++ b/netutils/cjson/Makefile
@@ -46,6 +46,8 @@ CFLAGS += -DCJSON_INCLUDE_CONFIG_H
 CSRCS = $(CJSON_SRCDIR)$(DELIM)cJSON.c
 CSRCS += $(CJSON_SRCDIR)$(DELIM)cJSON_Utils.c
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(CJSON_UNPACKNAME)/.git),)
 $(CJSON_TARBALL):
 	@echo "Downloading: $(CJSON_TARBALL)"
 	$(Q) curl -O -L $(CONFIG_NETUTILS_CJSON_URL)/$(CJSON_TARBALL)
@@ -54,6 +56,7 @@ $(CJSON_UNPACKNAME): $(CJSON_TARBALL)
 	@echo "Unpacking: $(CJSON_TARBALL) -> $(CJSON_UNPACKNAME)"
 	$(Q) $(UNPACK) $(CJSON_TARBALL)
 	$(Q) touch $(CJSON_UNPACKNAME)
+endif
 
 $(CJSON_SRCDIR)$(DELIM)cJSON.h: $(CJSON_UNPACKNAME)
 
@@ -68,8 +71,10 @@ $(APPS_INCDIR)$(DELIM)cJSON_Utils.h: $(CJSON_SRCDIR)$(DELIM)cJSON_Utils.h
 context:: $(APPS_INCDIR)$(DELIM)cJSON.h $(APPS_INCDIR)$(DELIM)cJSON_Utils.h
 
 distclean::
+ifeq ($(wildcard $(CJSON_UNPACKNAME)/.git),)
 	$(call DELDIR, $(CJSON_UNPACKNAME))
 	$(call DELFILE, $(CJSON_TARBALL))
+endif
 	$(call DELFILE, $(APPDIR)/include/netutils/cJSON.h)
 	$(call DELFILE, $(APPDIR)/include/netutils/cJSON_Utils.h)
 

--- a/netutils/mqttc/Makefile
+++ b/netutils/mqttc/Makefile
@@ -39,10 +39,13 @@ $(MQTTC_UNPACK): $(MQTTC_TARBALL)
 	$(Q) mv MQTT-C-$(MQTTC_VERSION) $(MQTTC_UNPACK)
 	$(Q) touch $(MQTTC_UNPACK)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(MQTTC_UNPACK)/.git),)
 context:: $(MQTTC_UNPACK)
 
 distclean::
 	$(call DELFILE, $(MQTTC_TARBALL))
 	$(call DELDIR, $(MQTTC_UNPACK))
+endif
 
 include $(APPDIR)/Application.mk

--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -82,12 +82,15 @@ CSRCS += $(ADB_UNPACKNAME)/tcp_service.c
 CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_socket.c
 endif
 
-context:: $(ADB_UNPACKDIR)
-
 clean::
 	$(call DELFILE, $(OBJS))
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(ADB_UNPACKDIR)/.git),)
+context:: $(ADB_UNPACKDIR)
+
 distclean::
 	$(call DELDIR, $(ADB_UNPACKDIR))
+endif
 
 include $(APPDIR)/Application.mk

--- a/system/argtable3/Makefile
+++ b/system/argtable3/Makefile
@@ -52,10 +52,13 @@ $(ARGTABLE3_UNPACK): $(ARGTABLE3_TARBALL)
 	$(Q) tar zxf $(ARGTABLE3_TARBALL)
 	$(Q) mv argtable3-$(ARGTABLE3_VERSION) $(ARGTABLE3_UNPACK)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(ARGTABLE3_UNPACK)/.git),)
 context:: $(ARGTABLE3_UNPACK)
 
 distclean::
 	$(call DELFILE, $(ARGTABLE3_TARBALL))
 	$(call DELDIR, $(ARGTABLE3_UNPACK))
+endif
 
 include $(APPDIR)/Application.mk

--- a/system/embedlog/Makefile
+++ b/system/embedlog/Makefile
@@ -208,6 +208,8 @@ endif
 
 # building of embedlog
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(EMBEDLOG_SOURCES)/.git),)
 $(EMBEDLOG_TARBALL):
 	@echo "Downloading: $@"
 	$(Q) curl -L -o $@ $(EMBEDLOG_URL)/$@
@@ -218,6 +220,7 @@ $(EMBEDLOG_SOURCES): $(EMBEDLOG_TARBALL)
 	$(Q) $(call DELDIR, $@)
 	$(Q) $(UNPACK) $<
 	$(Q) touch $@
+endif
 
 $(EMBEDLOG_SOURCES)/include/embedlog.h: $(EMBEDLOG_SOURCES)/include/embedlog.h.in
 	@echo "Generating: $@"

--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -320,10 +320,13 @@ CSRCS += echo-server.c
 
 endif
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LIBUV_UNPACK)/.git),)
 context:: $(LIBUV_UNPACK)/.patch
 
 distclean::
 	$(call DELDIR, $(LIBUV_UNPACK))
 	$(call DELFILE, $(LIBUV_TARBALL))
+endif
 
 include $(APPDIR)/Application.mk

--- a/testing/iozone/Makefile
+++ b/testing/iozone/Makefile
@@ -55,10 +55,13 @@ $(IOZONE_UNPACKNAME): $(IOZONE_ZIP)
 	$(Q) cat iozone.patch | patch -s -N -d $(IOZONE_UNPACKNAME) -p1
 	$(Q) touch $(IOZONE_UNPACKNAME)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(IOZONE_UNPACKNAME)/.git),)
 context:: $(IOZONE_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(IOZONE_UNPACKNAME))
 	$(call DELFILE, $(IOZONE_ZIP))
+endif
 
 include $(APPDIR)/Application.mk

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -132,9 +132,12 @@ $(LTP_UNPACK):
 	$(Q) git -C $(LTP_UNPACK) am < 0001-Fix-static-struct-warning.patch
 	$(Q) git -C $(LTP_UNPACK) am < 0002-Use-ifdef-instead-of-if-for-__linux__.patch
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LTP_UNPACK)/.git),)
 context:: $(LTP_UNPACK)
 
 distclean::
 	$(Q) rm -rf $(LTP_UNPACK)
+endif
 
 include $(APPDIR)/Application.mk

--- a/testing/unity/Makefile
+++ b/testing/unity/Makefile
@@ -45,6 +45,8 @@ CFLAGS += -DUNITY_INCLUDE_CONFIG_H
 
 CSRCS = $(UNITY_SRCDIR)$(DELIM)unity.c
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(UNITY_UNPACKNAME)/.git),)
 $(UNITY_TARBALL):
 	@echo "Downloading: $(UNITY_TARBALL)"
 	$(Q) curl -L -O $(CONFIG_TESTING_UNITY_URL)/$(UNITY_TARBALL)
@@ -53,6 +55,7 @@ $(UNITY_UNPACKNAME): $(UNITY_TARBALL)
 	@echo "Unpacking: $(UNITY_TARBALL) -> $(UNITY_UNPACKNAME)"
 	$(Q) $(UNPACK) $(UNITY_TARBALL)
 	$(Q) touch $(UNITY_UNPACKNAME)
+endif
 
 $(UNITY_SRCDIR)$(DELIM)unity.h: $(UNITY_UNPACKNAME)
 
@@ -67,8 +70,10 @@ $(APPS_INCDIR)$(DELIM)unity_internals.h: $(UNITY_SRCDIR)$(DELIM)unity_internals.
 context:: $(APPS_INCDIR)$(DELIM)unity.h $(APPS_INCDIR)$(DELIM)unity_internals.h
 
 distclean::
+ifeq ($(wildcard $(UNITY_UNPACKNAME)/.git),)
 	$(call DELDIR, $(UNITY_UNPACKNAME))
 	$(call DELFILE, $(UNITY_TARBALL))
+endif
 	$(call DELFILE, $(APPDIR)/include/testing/unity.h)
 	$(call DELFILE, $(APPDIR)/include/testing/unity_internals.h)
 

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -40,11 +40,14 @@ $(NIMBLE_UNPACKDIR): $(NIMBLE_TAR)
 	$(Q) mv mynewt-nimble-$(CONFIG_NIMBLE_REF) $(NIMBLE_UNPACKDIR)
 	$(Q) touch $(NIMBLE_UNPACKDIR)
 
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(NIMBLE_UNPACKDIR)/.git),)
 context:: $(NIMBLE_UNPACKDIR)
 
 distclean::
 	$(call DELFILE,$(NIMBLE_TAR))
 	$(call DELDIR,$(NIMBLE_UNPACKDIR))
+endif
 
 # nimBLE assumes this flag since it expects undefined macros to be zero value
 


### PR DESCRIPTION
## Summary
Don't download tarballs if a local git repo found, to save time or avoid modify the makefile in local, make it easy to intergrate nuttx with customized third party software.
## Impact
Refactor only
## Testing
CI and local machine.
