### PR TITLE
examples/foc: improvements

### DIFF
--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -352,6 +352,14 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
               PRINTF("ERROR: foc_dev_params_set failed %d!\n", ret);
               goto errout;
             }
+
+          /* Terminate control thread */
+
+          if (motor.ctrl_state == FOC_CTRL_STATE_TERMINATE)
+            {
+              PRINTF("TERMINATE CTRL THREAD\n");
+              goto errout;
+            }
         }
       else
         {

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -353,6 +353,14 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
               PRINTF("ERROR: foc_dev_prams_set failed %d!\n", ret);
               goto errout;
             }
+
+          /* Terminate control thread */
+
+          if (motor.ctrl_state == FOC_CTRL_STATE_TERMINATE)
+            {
+              PRINTF("TERMINATE CTRL THREAD\n");
+              goto errout;
+            }
         }
       else
         {

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1120,6 +1120,13 @@ int foc_motor_control(FAR struct foc_motor_b16_s *motor)
           break;
         }
 
+      case FOC_CTRL_STATE_TERMINATE:
+        {
+          /* Do nothing */
+
+          break;
+        }
+
       default:
         {
           PRINTF("ERROR: invalid ctrl_state=%d\n", motor->ctrl_state);

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1112,6 +1112,19 @@ int foc_motor_control(FAR struct foc_motor_f32_s *motor)
         {
           motor->foc_mode = FOC_HANDLER_MODE_IDLE;
 
+#ifndef CONFIG_EXAMPLES_FOC_HAVE_RUN
+          /* Terminate */
+
+          motor->ctrl_state += 1;
+#endif
+
+          break;
+        }
+
+      case FOC_CTRL_STATE_TERMINATE:
+        {
+          /* Do nothing */
+
           break;
         }
 

--- a/examples/foc/foc_mq.c
+++ b/examples/foc/foc_mq.c
@@ -41,11 +41,11 @@
 int foc_mq_handle(mqd_t mq, FAR struct foc_mq_s *h)
 {
   int      ret = OK;
-  uint8_t  buffer[5];
+  uint8_t  buffer[CONTROL_MQ_MSGSIZE];
 
   /* Get data from AUX */
 
-  ret = mq_receive(mq, (char *)buffer, 5, 0);
+  ret = mq_receive(mq, (char *)buffer, CONTROL_MQ_MSGSIZE, 0);
   if (ret < 0)
     {
       if (errno != EAGAIN)
@@ -65,7 +65,7 @@ int foc_mq_handle(mqd_t mq, FAR struct foc_mq_s *h)
 
   /* Verify message length */
 
-  if (ret != 5)
+  if (ret != CONTROL_MQ_MSGSIZE)
     {
       PRINTF("ERROR: invalid message length = %d\n", ret);
       goto errout;

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -80,13 +80,16 @@ static struct option g_long_options[] =
 static void foc_help(void)
 {
   PRINTF("Usage: foc [OPTIONS]\n");
-  PRINTF("  [-t] run time\n");
+  PRINTF("  [-t] run time (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_TIME_DEFAULT);
   PRINTF("  [-h] shows this message and exits\n");
-  PRINTF("  [-f] FOC run mode\n");
+  PRINTF("  [-f] FOC run mode (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_FMODE);
   PRINTF("       1 - IDLE mode\n");
   PRINTF("       2 - voltage mode\n");
   PRINTF("       3 - current mode\n");
-  PRINTF("  [-m] controller mode\n");
+  PRINTF("  [-m] controller mode (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_MMODE);
   PRINTF("       1 - torqe control\n");
   PRINTF("       2 - velocity control\n");
   PRINTF("       3 - position control\n");
@@ -99,18 +102,22 @@ static void foc_help(void)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
   PRINTF("  [-x] position [x1000]\n");
 #endif
-  PRINTF("  [-s] motor state\n");
+  PRINTF("  [-s] motor state init (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_STATE_INIT);
   PRINTF("       1 - motor free\n");
   PRINTF("       2 - motor stop\n");
   PRINTF("       3 - motor CW\n");
   PRINTF("       4 - motor CCW\n");
   PRINTF("  [-j] enable specific instances\n");
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-  PRINTF("  [-o] openloop Vq/Iq setting [x1000]\n");
+  PRINTF("  [-o] openloop Vq/Iq setting [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_OPENLOOP_Q);
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  PRINTF("  [--fki] PI Kp coefficient [x1000]\n");
-  PRINTF("  [--fkp] PI Ki coefficient [x1000]\n");
+  PRINTF("  [--fki] PI Kp coefficient [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDQ_KP);
+  PRINTF("  [--fkp] PI Ki coefficient [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDQ_KI);
 #endif
 }
 

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -88,7 +88,8 @@ enum foc_controller_state_e
   FOC_CTRL_STATE_RUN_INIT,
   FOC_CTRL_STATE_RUN,
 #endif
-  FOC_CTRL_STATE_IDLE
+  FOC_CTRL_STATE_IDLE,
+  FOC_CTRL_STATE_TERMINATE
 };
 
 /* FOC thread data */


### PR DESCRIPTION
## Summary

- examples/foc: print default values in the help message
- examples/foc: terminate the control thread if no work to do
- examples/foc: make sure that the queue is empty before start the control thread

## Impact

## Testing
steval-eth001v1/foc_f32
