### PR TITLE
examples/foc: add options to run routines only

### DIFF
--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -164,6 +164,12 @@ static int validate_args(FAR struct args_s *args)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
     args->mmode != FOC_MMODE_POS &&
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+    args->mmode != FOC_MMODE_ALIGN_ONLY &&
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+    args->mmode != FOC_MMODE_IDENT_ONLY &&
+#endif
     1)
     {
       PRINTF("Invalid ctrl mode value %d s\n", args->mmode);

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -548,6 +548,18 @@ static int foc_motor_setpoint(FAR struct foc_motor_b16_s *motor, uint32_t sp)
         }
 #endif
 
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+      case FOC_MMODE_ALIGN_ONLY:
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+      case FOC_MMODE_IDENT_ONLY:
+#endif
+        {
+          /* Do nothing */
+
+          break;
+        }
+
       default:
         {
           PRINTF("ERROR: unsupported ctrl mode %d\n", motor->envp->mmode);
@@ -995,7 +1007,23 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
 
   /* Initialize controller state */
 
-  motor->ctrl_state = FOC_CTRL_STATE_INIT;
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+  if (motor->envp->mmode == FOC_MMODE_ALIGN_ONLY)
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_ALIGN;
+    }
+  else
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  if (motor->envp->mmode == FOC_MMODE_IDENT_ONLY)
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_IDENT;
+    }
+  else
+#endif
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_INIT;
+    }
 
 #if defined(CONFIG_EXAMPLES_FOC_SENSORED) ||  \
     defined(CONFIG_EXAMPLES_FOC_HAVE_RUN) ||  \
@@ -1215,6 +1243,11 @@ int foc_motor_control(FAR struct foc_motor_b16_s *motor)
 
               motor->ctrl_state += 1;
               motor->foc_mode = FOC_HANDLER_MODE_IDLE;
+
+              if (motor->envp->mmode == FOC_MMODE_ALIGN_ONLY)
+                {
+                  motor->ctrl_state = FOC_CTRL_STATE_TERMINATE;
+                }
             }
 
           break;
@@ -1239,6 +1272,11 @@ int foc_motor_control(FAR struct foc_motor_b16_s *motor)
 
               motor->ctrl_state += 1;
               motor->foc_mode = FOC_HANDLER_MODE_IDLE;
+
+              if (motor->envp->mmode == FOC_MMODE_IDENT_ONLY)
+                {
+                  motor->ctrl_state = FOC_CTRL_STATE_TERMINATE;
+                }
             }
 
           break;

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -525,6 +525,18 @@ static int foc_motor_setpoint(FAR struct foc_motor_f32_s *motor, uint32_t sp)
         }
 #endif
 
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+      case FOC_MMODE_ALIGN_ONLY:
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+      case FOC_MMODE_IDENT_ONLY:
+#endif
+        {
+          /* Do nothing */
+
+          break;
+        }
+
       default:
         {
           PRINTF("ERROR: unsupported ctrl mode %d\n", motor->envp->mmode);
@@ -977,7 +989,23 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
 
   /* Initialize controller state */
 
-  motor->ctrl_state = FOC_CTRL_STATE_INIT;
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+  if (motor->envp->mmode == FOC_MMODE_ALIGN_ONLY)
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_ALIGN;
+    }
+  else
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  if (motor->envp->mmode == FOC_MMODE_IDENT_ONLY)
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_IDENT;
+    }
+  else
+#endif
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_INIT;
+    }
 
 #if defined(CONFIG_EXAMPLES_FOC_SENSORED) ||  \
     defined(CONFIG_EXAMPLES_FOC_HAVE_RUN) ||  \
@@ -1197,6 +1225,11 @@ int foc_motor_control(FAR struct foc_motor_f32_s *motor)
 
               motor->ctrl_state += 1;
               motor->foc_mode = FOC_HANDLER_MODE_IDLE;
+
+              if (motor->envp->mmode == FOC_MMODE_ALIGN_ONLY)
+                {
+                  motor->ctrl_state = FOC_CTRL_STATE_TERMINATE;
+                }
             }
 
           break;
@@ -1221,6 +1254,11 @@ int foc_motor_control(FAR struct foc_motor_f32_s *motor)
 
               motor->ctrl_state += 1;
               motor->foc_mode = FOC_HANDLER_MODE_IDLE;
+
+              if (motor->envp->mmode == FOC_MMODE_IDENT_ONLY)
+                {
+                  motor->ctrl_state = FOC_CTRL_STATE_TERMINATE;
+                }
             }
 
           break;

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -93,6 +93,13 @@ static void foc_help(void)
   PRINTF("       1 - torqe control\n");
   PRINTF("       2 - velocity control\n");
   PRINTF("       3 - position control\n");
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+  PRINTF("       4 - align only\n");
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  PRINTF("       5 - ident only\n");
+#endif
+
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
   PRINTF("  [-r] torque [x1000]\n");
 #endif

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -63,15 +63,21 @@ enum foc_foc_mode_e
 
 enum foc_motor_mode_e
 {
-  FOC_MMODE_INVALID = 0,     /* Reserved */
+  FOC_MMODE_INVALID    = 0,  /* Reserved */
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-  FOC_MMODE_TORQ    = 1,     /* Torque control */
+  FOC_MMODE_TORQ       = 1,  /* Torque control */
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-  FOC_MMODE_VEL     = 2,     /* Velocity control */
+  FOC_MMODE_VEL        = 2,  /* Velocity control */
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-  FOC_MMODE_POS     = 3      /* Position control */
+  FOC_MMODE_POS        = 3,  /* Position control */
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
+  FOC_MMODE_ALIGN_ONLY = 4,  /* Sensor alignment only */
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  FOC_MMODE_IDENT_ONLY = 5,  /* Motor identification only */
 #endif
 };
 


### PR DESCRIPTION
## Summary

- examples/foc: add options to run only the sensor alignment routine or the motor identification routine

## Impact

## Testing
steval-eth001v1/foc_f32
