### PR TITLE
interpreters/wamr/Kconfig: Add INTERPRETERS_WAMR_DEBUG_INTERP option

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -51,6 +51,17 @@ config INTERPRETERS_NONE
 
 endchoice
 
+config INTERPRETERS_WAMR_DEBUG_INTERP
+	bool "Enable debugger support in the interpreter"
+	default n
+	# Note: It only works with the classic interpreter
+	depends on INTERPRETERS_WAMR_CLASSIC
+	# Note: It uses thread-manager internally
+	depends on INTERPRETERS_WAMR_THREAD_MGR
+	# Note: It sets up the listening socket with SO_LINGER
+	depends on NET_TCP
+	depends on NET_SOLINGER
+
 config INTERPRETERS_WAMR_LOG
 	bool "Enable log"
 	default n


### PR DESCRIPTION
## Summary
Add an option to enable WAMR_BUILD_DEBUG_INTERP equivalent.

The corresponding WAMR PR: https://github.com/bytecodealliance/wasm-micro-runtime/pull/1426

## Impact

## Testing
Tested with sim/Linux/amd64 and esp32 devkit-c.
(with a few more patches)