### PR TITLE
net/usrsock: fix usrsocktest test case break

### DIFF
--- a/examples/usrsocktest/usrsocktest_basic_daemon.c
+++ b/examples/usrsocktest/usrsocktest_basic_daemon.c
@@ -333,7 +333,7 @@ static void basic_daemon_dup2(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(2, usrsocktest_daemon_get_num_active_sockets());
 
   ret = dup2(sd2, sd);
-  TEST_ASSERT_EQUAL(0, ret);
+  TEST_ASSERT_EQUAL(sd, ret);
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
 
   ret = close(sd2);

--- a/examples/usrsocktest/usrsocktest_block_recv.c
+++ b/examples/usrsocktest/usrsocktest_block_recv.c
@@ -248,7 +248,8 @@ static void no_block_connect(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(1, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("a", data, 1);
   TEST_ASSERT_EQUAL(sizeof(remoteaddr), addrlen);
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(6, usrsocktest_daemon_get_recv_bytes());
@@ -265,7 +266,8 @@ static void no_block_connect(FAR struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(5, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("abcde", data, 5);
   TEST_ASSERT_EQUAL(sizeof(remoteaddr), addrlen);
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(11, usrsocktest_daemon_get_recv_bytes());

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -856,7 +856,7 @@ static int recvfrom_request(int fd, FAR struct daemon_priv_s *priv,
 
   if (!tsock->connected)
     {
-      ret = -ENOTCONN;
+      ret = (tsock->endp) ? 0 : -ENOTCONN;
       goto prepare;
     }
 

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -2053,6 +2053,12 @@ errout_closepipe:
 out:
   pthread_mutex_unlock(&daemon_mutex);
   usrsocktest_dbg("ret: %d\n", ret);
+
+  if (ret == OK)
+    {
+      usleep(100);
+    }
+
   return ret;
 }
 
@@ -2328,6 +2334,11 @@ bool usrsocktest_send_delayed_command(const char cmd,
   while (sem_wait(&delayed_cmd->startsem) != OK);
 
   sq_addlast(&delayed_cmd->node, &priv->delayed_cmd_threads);
+
+  if (ret == OK)
+    {
+      usleep(100);
+    }
 
   return true;
 }

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -36,6 +36,7 @@
 #include <pthread.h>
 
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <nuttx/net/usrsock.h>
@@ -74,6 +75,7 @@ struct test_socket_s
   bool connect_refused:1;
   bool disconnected:1;
   int recv_avail_bytes;
+  int flags;
   FAR void *endp;
   struct usrsock_message_req_ack_s pending_resp;
 };
@@ -1333,7 +1335,12 @@ prepare:
 
   resp.reqack.head.flags = 0;
   resp.reqack.result = ret;
-  if (ret >= 0)
+  if (req->max_addrlen == 0)
+    {
+      resp.valuelen = 0;
+      resp.valuelen_nontrunc = sizeof(addr);
+    }
+  else if (ret >= 0)
     {
       resp.valuelen = sizeof(addr);
       resp.valuelen_nontrunc = sizeof(addr);
@@ -1366,6 +1373,133 @@ prepare:
       /* Send address (value) */
 
       wlen = write(fd, &addr, resp.valuelen);
+      if (wlen < 0)
+        {
+          return -errno;
+        }
+
+      if (wlen != resp.valuelen)
+        {
+          return -ENOSPC;
+        }
+    }
+
+  return OK;
+}
+
+static int ioctl_request(int fd, FAR struct daemon_priv_s *priv,
+                         FAR void *hdrbuf)
+{
+  FAR struct usrsock_request_ioctl_s *req = hdrbuf;
+  struct usrsock_message_datareq_ack_s resp = {
+  };
+
+  FAR struct test_socket_s *tsock;
+  uint32_t value;
+  ssize_t wlen;
+  ssize_t rlen;
+  int ret;
+
+  /* Check if this socket exists. */
+
+  tsock = test_socket_get(priv, req->usockid);
+  if (!tsock)
+    {
+      ret = -EBADFD;
+      goto prepare;
+    }
+
+  if (req->arglen != sizeof(value))
+    {
+      ret = -EINVAL;
+      goto prepare;
+    }
+
+  /* Read value. */
+
+  rlen = read(fd, &value, sizeof(value));
+  if (rlen < 0 || rlen < sizeof(value))
+    {
+      ret = -EFAULT;
+      goto prepare;
+    }
+
+  ret = OK;
+
+prepare:
+
+  /* Prepare response. */
+
+  resp.reqack.xid = req->head.xid;
+  resp.reqack.head.msgid  = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
+  resp.reqack.head.flags  = 0;
+  resp.reqack.head.events = 0;
+
+  if (priv->conf->delay_all_responses)
+    {
+      resp.reqack.head.flags = USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
+      resp.reqack.result = -EINPROGRESS;
+      resp.valuelen = 0;
+      resp.valuelen_nontrunc = 0;
+
+      /* Send ack response. */
+
+      wlen = write(fd, &resp, sizeof(resp));
+      if (wlen < 0)
+        {
+          return -errno;
+        }
+
+      if (wlen != sizeof(resp))
+        {
+          return -ENOSPC;
+        }
+
+      pthread_mutex_unlock(&daemon_mutex);
+      usleep(50 * 1000);
+      pthread_mutex_lock(&daemon_mutex);
+
+      /* Previous write was acknowledgment to request, informing that request
+       * is still in progress. Now write actual completion response.
+       */
+
+      resp.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
+      resp.reqack.head.flags &= ~USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS;
+    }
+
+  resp.reqack.head.flags = 0;
+  resp.reqack.result = ret;
+  if (ret >= 0)
+    {
+      resp.valuelen = sizeof(value);
+      resp.valuelen_nontrunc = sizeof(value);
+
+      tsock->flags |= value;
+      value = tsock->flags;
+    }
+  else
+    {
+      resp.valuelen = 0;
+    }
+
+  /* Send response. */
+
+  wlen = write(fd, &resp, sizeof(resp));
+  if (wlen < 0)
+    {
+      return -errno;
+    }
+
+  if (wlen != sizeof(resp))
+    {
+      return -ENOSPC;
+    }
+
+  if (resp.valuelen > 0)
+    {
+      /* Send address (value) */
+
+      wlen = write(fd, &value, resp.valuelen);
       if (wlen < 0)
         {
           return -errno;
@@ -1436,6 +1570,12 @@ static int handle_usrsock_request(int fd, FAR struct daemon_priv_s *priv)
         {
           sizeof(struct usrsock_request_getsockname_s),
           getsockname_request,
+        },
+
+      [USRSOCK_REQUEST_IOCTL] =
+        {
+          sizeof(struct usrsock_request_ioctl_s),
+          ioctl_request,
         },
     };
 

--- a/examples/usrsocktest/usrsocktest_noblock_recv.c
+++ b/examples/usrsocktest/usrsocktest_noblock_recv.c
@@ -180,7 +180,8 @@ static void receive(struct usrsocktest_daemon_conf_s *dconf)
   TEST_ASSERT_EQUAL(3, ret);
   TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", data, 3);
   TEST_ASSERT_EQUAL(addrlen, sizeof(remoteaddr));
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr, addrlen);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(&remoteaddr, &addr,
+                                addrlen - sizeof(addr.sin_zero));
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(datalen + ret, usrsocktest_daemon_get_recv_bytes());
@@ -365,7 +366,7 @@ static void delayed_connect(struct usrsocktest_daemon_conf_s *dconf)
                  &addrlen);
   TEST_ASSERT_EQUAL(-1, ret);
   TEST_ASSERT_EQUAL(EAGAIN, errno);
-  TEST_ASSERT_EQUAL(0, addrlen);
+  TEST_ASSERT_EQUAL(sizeof(remoteaddr), addrlen);
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_connected_sockets());
   TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
   TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_send_bytes());

--- a/examples/usrsocktest/usrsocktest_wake_with_signal.c
+++ b/examples/usrsocktest/usrsocktest_wake_with_signal.c
@@ -29,6 +29,8 @@
 #include <errno.h>
 #include <poll.h>
 
+#include <nuttx/clock.h>
+
 #include "defines.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

1. examples/usrsocktest: add some delay to wait the daemon task ready
2. examples/usrsocktest: add USRSOCK_REQUEST_IOCTL support

   The test model of usrsock ioctl() has changed after file socket layer implemented from vfs,
   usrsock must implement the ioctl() hook to pass this test

3. examples/usrsocktest: fix build break

```
   usrsocktest_wake_with_signal.c: In function ‘do_wake_test’:
   usrsocktest_wake_with_signal.c:553:16: error: ‘USEC_PER_MSEC’ undeclared (first use in this function)
     553 |   usleep(100 * USEC_PER_MSEC); /* Let worker thread proceed to blocking
         |                ^~~~~~~~~~~~~
```

4. examples/usrsocktest: correct the check region of remote address

   let us skip the sin_zero

5. examples/usrsocktest: correct return value check of dup2()

```
   DUP(2) Linux Programmer's Manual

   NAME
          dup, dup2, dup3 - duplicate a file descriptor
   ...
   RETURN VALUE
          On success, these system calls return the new file descriptor.
          On error, -1 is returned, and errno is set appropriately.
```


## Impact

## Testing

```
NuttShell (NSH) NuttX-10.4.0
MOTD: username=admin password=Administrator
nsh> usrsocktest
Starting unit-tests...
Testing group "char_dev" =>
	Group "char_dev": [OK]
Testing group "no_daemon" =>
	Group "no_daemon": [OK]
Testing group "basic_daemon" =>
	Group "basic_daemon": [OK]
Testing group "basic_connect" =>
	Group "basic_connect": [OK]
Testing group "basic_connect_delay" =>
	Group "basic_connect_delay": [OK]
Testing group "no_block_connect" =>
	Group "no_block_connect": [OK]
Testing group "basic_send" =>
	Group "basic_send": [OK]
Testing group "no_block_send" =>
	Group "no_block_send": [OK]
Testing group "block_send" =>
	Group "block_send": [OK]
Testing group "no_block_recv" =>
	Group "no_block_recv": [OK]
Testing group "block_recv" =>
	Group "block_recv": [OK]
Testing group "remote_disconnect" =>
	Group "remote_disconnect": [OK]
Testing group "basic_setsockopt" =>
	Group "basic_setsockopt": [OK]
Testing group "basic_getsockopt" =>
	Group "basic_getsockopt": [OK]
Testing group "basic_getsockname" =>
	Group "basic_getsockname": [OK]
Testing group "wake_with_signal" =>
	Group "wake_with_signal": [OK]
Testing group "multithread" =>
	Group "multithread": [OK]
Unit-test groups done... OK:17, FAILED:0, TOTAL:17
 -- number of checks made: 3589
HEAP BEFORE TESTS:
             total       used       free    largest
Mem:      67108368    1860016   65248352   65248192
HEAP AFTER TESTS:
             total       used       free    largest
Mem:      67108368    2200400   64907968   64906336

```