### PR TITLE
ftpd: server port made configurable.

### DIFF
--- a/examples/ftpd/Kconfig
+++ b/examples/ftpd/Kconfig
@@ -11,6 +11,10 @@ config EXAMPLES_FTPD
 
 if EXAMPLES_FTPD
 
+config EXAMPLES_FTPD_PORT
+	int "FTP Daemon Port"
+	default 21
+
 config EXAMPLES_FTPD_STACKSIZE
 	int "FTP Daemon Stack Size"
 	default DEFAULT_TASK_STACKSIZE

--- a/examples/ftpd/ftpd_main.c
+++ b/examples/ftpd/ftpd_main.c
@@ -22,6 +22,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <sys/types.h>
 
 #include <stdio.h>
@@ -169,9 +171,9 @@ int ftpd_daemon(int s_argc, char **s_argv)
   /* Open FTPD */
 
 #if ADDR_FAMILY == AF_INET6
-  handle = ftpd_open(AF_INET6);
+  handle = ftpd_open(CONFIG_EXAMPLES_FTPD_PORT, AF_INET6);
 #else
-  handle = ftpd_open(AF_INET);
+  handle = ftpd_open(CONFIG_EXAMPLES_FTPD_PORT, AF_INET);
 #endif
 
   if (!handle)

--- a/include/netutils/ftpd.h
+++ b/include/netutils/ftpd.h
@@ -119,6 +119,7 @@ extern "C"
  *   used to run the server.
  *
  * Input Parameters:
+ *    port - The port that the server will listen to.
  *    family - The type of INET family to use when opening the socket.
  *    AF_INET and AF_INET6 are supported.
  *
@@ -128,7 +129,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FTPD_SESSION ftpd_open(sa_family_t family);
+FTPD_SESSION ftpd_open(int port, sa_family_t family);
 
 /****************************************************************************
  * Name: ftpd_adduser

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -4262,7 +4262,9 @@ static FAR void *ftpd_worker(FAR void *arg)
  *   used to run the server.
  *
  * Input Parameters:
- *    None
+ *    port - The port that the server will listen to.
+ *    family - The type of INET family to use when opening the socket.
+ *    AF_INET and AF_INET6 are supported.
  *
  * Returned Value:
  *   On success, a non-NULL handle is returned that can be used to reference
@@ -4270,15 +4272,11 @@ static FAR void *ftpd_worker(FAR void *arg)
  *
  ****************************************************************************/
 
-FTPD_SESSION ftpd_open(sa_family_t family)
+FTPD_SESSION ftpd_open(int port, sa_family_t family)
 {
   FAR struct ftpd_server_s *server;
 
-  server = ftpd_openserver(21, family);
-  if (server == NULL)
-    {
-      server = ftpd_openserver(2211, family);
-    }
+  server = ftpd_openserver(port, family);
 
   return (FTPD_SESSION)server;
 }


### PR DESCRIPTION
## Summary

The ftpd was previously only working on the hard-coded port 21.

This commit allows the user to specify the desired port when the server is created.

## Impact

ftpd can run on any port.

## Testing

Tested within custom application on an STM32F427 board.  
Builds and runs as expected.
