### PR TITLE
ostest: fix sighand_test report error

### DIFF
--- a/testing/ostest/sighand.c
+++ b/testing/ostest/sighand.c
@@ -346,7 +346,11 @@ void sighand_test(void)
   /* Wait a bit */
 
   FFLUSH();
-  sleep(2);
+  status = sleep(2);
+  while (status)
+    {
+      status = sleep(status);
+    }
 
   /* Then check the result */
 


### PR DESCRIPTION

## Summary

ostest: fix sighand_test report error

sighand_test: ERROR waiter task did not exit

reason:
sleep will be interrupt by signal

Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

ostest

## Testing

sim:smp