### PR TITLE
wireless: gs2200m: Add SIOCGIFFLAGS support to gs2200m_main.c

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -1568,6 +1568,7 @@ static int ioctl_request(int fd, FAR struct gs2200m_s *priv,
   switch (req->cmd)
     {
       case SIOCGIFADDR:
+      case SIOCGIFFLAGS:
       case SIOCGIFHWADDR:
       case SIOCGIWNWID:
       case SIOCGIWFREQ:


### PR DESCRIPTION
## Summary

- I noticed that the latest ifconfig command shows nothing
- Finally, I found that gs2200m_main.c needs to handle SIOCGIFFLAGS
- This commit fixes this issue

## Impact

- gs2200m only

## Testing

- Tested with spresense:wifi
- NOTE: gs2200m driver needs to be updated as well
