### PR TITLE
tools/README.md: Fix typo and reflow paragraph

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -5,9 +5,9 @@
 This script converts from any image type supported by Python imaging library to
 the RLE-encoded format used by NxWidgets.
 
-RLE (Run Length Length) is a very simply encoding that compress quite well with
-certain kinds of images: Images that that have many pixels of the same color
-adjacent on a row (like simple graphics). It does not work well with
+RLE (Run Length Encoding) is a very simply encoding that compress quite well
+with certain kinds of images: Images that that have many pixels of the same
+color adjacent on a row (like simple graphics). It does not work well with
 photographic images.
 
 But even simple graphics may not encode compactly if, for example, they have


### PR DESCRIPTION
## Summary

Fix typo (Run Length Length -> Run Length Encoding) and reflow paragraph due to the changed length.

## Impact

Improves documentation.

## Testing

None.