### PR TITLE
quickjs: add qjs tool configuration item

### DIFF
--- a/interpreters/quickjs/Kconfig
+++ b/interpreters/quickjs/Kconfig
@@ -9,9 +9,20 @@ config INTERPRETERS_QUICKJS
 
 if INTERPRETERS_QUICKJS
 
+choice
+	prompt "QuickJS command line interpreter"
+	default INTERPRETERS_QUICKJS_NONE
+
+config INTERPRETERS_QUICKJS_NONE
+	bool "distable quickjs interpreter"
+
 config INTERPRETERS_QUICKJS_MINI
-	bool "Minimal interpreter"
-	default n
+	bool "Minimal quickjs interpreter"
+
+config INTERPRETERS_QUICKJS_FULL
+	bool "normal quickjs interpreter"
+
+endchoice # QuickJS command line interpreter
 
 config INTERPRETERS_QUICKJS_BIGNUM
 	bool "Bignum support"

--- a/interpreters/quickjs/Makefile
+++ b/interpreters/quickjs/Makefile
@@ -28,13 +28,6 @@ QUICKJS_URL      = $(QUICKJS_URL_BASE)/$(QUICKJS_TARBALL)
 
 CSRCS = quickjs.c libregexp.c libbf.c libunicode.c cutils.c
 
-ifeq ($(CONFIG_INTERPRETERS_QUICKJS_MINI),y)
-MAINSRC = qjsmini.c
-else
-CSRCS += quickjs-libc.c repl.c
-MAINSRC = qjs.c
-endif
-
 VERSION=\"$(QUICKJS_VERSION)\"
 
 CFLAGS += -DCONFIG_VERSION=$(VERSION) -Wno-shadow
@@ -59,10 +52,12 @@ endif
 
 VPATH += $(QUICKJS_UNPACK)
 
+ifneq ($(CONFIG_INTERPRETERS_QUICKJS_NONE),y)
 PROGNAME  = qjs
 PRIORITY  = $(CONFIG_INTERPRETERS_QUICKJS_PRIORITY)
 STACKSIZE = $(CONFIG_INTERPRETERS_QUICKJS_STACKSIZE)
 MODULE    = $(CONFIG_INTERPRETERS_QUICKJS)
+endif
 
 $(QUICKJS_TARBALL):
 	$(Q) echo "Downloading $(QUICKJS_TARBALL)"
@@ -79,19 +74,25 @@ $(QUICKJS_UNPACK)/.patch: $(QUICKJS_UNPACK)
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(QUICKJS_UNPACK)/.git),)
-
+QUICKJS_DOWNLOAD=$(QUICKJS_UNPACK)/.patch
 distclean::
 	$(call DELDIR, $(QUICKJS_UNPACK))
 	$(call DELFILE, $(QUICKJS_TARBALL))
-
-build_host: $(QUICKJS_UNPACK)/.patch
-else
-build_host:
 endif
+
+ifeq ($(CONFIG_INTERPRETERS_QUICKJS_MINI),y)
+MAINSRC = qjsmini.c
+endif
+
+ifeq ($(CONFIG_INTERPRETERS_QUICKJS_FULL),y)
+CSRCS += quickjs-libc.c repl.c
+MAINSRC = qjs.c
+context:: $(QUICKJS_DOWNLOAD)
 	$(MAKE) -C $(QUICKJS_UNPACK) \
 		CONFIG_BIGNUM=$(CONFIG_INTERPRETERS_QUICKJS_BIGNUM)
-
-context:: build_host
+else
+context:: $(QUICKJS_DOWNLOAD)
+endif
 
 clean::
 	$(Q) test ! -d $(QUICKJS_UNPACK) || $(MAKE) -C $(QUICKJS_UNPACK) clean


### PR DESCRIPTION
## Summary
Do not compile and generate the qjs tool by default

## Impact

## Testing

