### PR TITLE
Fix hello_zig build break

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -91,7 +91,7 @@ SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(MAINSRC)
 OBJS = $(RAOBJS) $(CAOBJS) $(COBJS) $(CXXOBJS) $(RUSTOBJS) $(ZIGOBJS)
 
 ifneq ($(BUILD_MODULE),y)
-  OBJS += $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ) $(MAINZIGOBJS)
+  OBJS += $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ) $(MAINZIGOBJ)
 endif
 
 DEPPATH += --dep-path .
@@ -126,8 +126,9 @@ define ELFCOMPILERUST
 endef
 
 define ELFCOMPILEZIG
-       @echo "ZIG: $1"
-       $(Q) $(ZIG) build-obj $(ZIGELFFLAGS) $($(strip $1)_ZIGELFFLAGS) $1 --name $2
+	@echo "ZIG: $1"
+	# Remove target suffix here since zig compiler add .o automatically
+	$(Q) $(ZIG) build-obj $(ZIGELFFLAGS) $($(strip $1)_ZIGELFFLAGS) --name $(basename $2) $1 
 endef
 
 define ELFLD

--- a/examples/hello_zig/hello_zig_main.zig
+++ b/examples/hello_zig/hello_zig_main.zig
@@ -35,5 +35,6 @@ pub extern fn printf(_format: [*:0]const u8) c_int;
 pub export fn hello_zig_main(_argc: c_int, _argv: [*]const [*]const u8) c_int {
     _ = _argc;
     _ = _argv;
-    printf("Hello, Zig!\n");
+    _ = printf("Hello, Zig!\n");
+    return 0;
 }


### PR DESCRIPTION
## Summary
* Zig don't allow unused return value, so let's discard it explictly.
* Correct wrong make variable name for Zig main source, and update compile command for latest compiler.

## Impact
Zig only
## Testing
Custom board
