### PR TITLE
apps/nshlib: add uptime command support

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -518,6 +518,10 @@ config NSH_DISABLE_UNSET
 	bool "Disable unset"
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_UPTIME
+	bool "Disable uptime"
+	default DEFAULT_SMALL
+
 config NSH_DISABLE_URLDECODE
 	bool "Disable urldecode"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1204,6 +1204,10 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
   int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 #endif
 
+#ifndef CONFIG_NSH_DISABLE_UPTIME
+  int cmd_uptime(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
+
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_BASE64)
 #  ifndef CONFIG_NSH_DISABLE_BASE64DEC
   int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -564,6 +564,10 @@ static const struct cmdmap_s g_cmdmap[] =
   { "unset",    cmd_unset,    2, 2, "<name>" },
 #endif
 
+#ifndef CONFIG_NSH_DISABLE_UPTIME
+  { "uptime",   cmd_uptime,   1, 2, "[-sph]" },
+#endif
+
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_URLCODE)
 #  ifndef CONFIG_NSH_DISABLE_URLDECODE
   { "urldecode", cmd_urldecode, 2, 3, "[-f] <string or filepath>" },

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -571,7 +571,7 @@ int cmd_exec(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       return ERROR;
     }
 
-  nsh_output(vtbl, "Calling %p\n", (void*)addr);
+  nsh_output(vtbl, "Calling %p\n", (void *)addr);
   return ((exec_t)addr)();
 }
 #endif


### PR DESCRIPTION
## Summary

support uptime command for NuttX

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

N/A

## Testing

run uptime command on sim:
nsh>
nsh>
nsh> uptime
19:35:01 up  1:40, load average: 0.00, 0.00, 0.00
nsh>
nsh>
nsh> uptime -s
2022-09-16 17:54:26
nsh>
nsh>
nsh> uptime -p
up 1 hour, 40 minutes
nsh>
nsh>
nsh> uptime -h
Usage:
uptime [options]
Options:
-p, show uptime in pretty format
-h, display this help and exit
-s, system up since
nsh>
nsh>
nsh> uptime -abc
uptime: invalid option -- -abc
Usage:
uptime [options]
Options:
-p, show uptime in pretty format
-h, display this help and exit
-s, system up since
nsh>
nsh>
nsh> date
Fri, Sep 16 19:35:18 2022
nsh>
nsh>
