### PR TITLE
Add the missing FAR macro for all source files under apps/nshlib

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -867,7 +867,7 @@ int nsh_loginscript(FAR struct nsh_vtbl_s *vtbl);
 struct console_stdio_s;
 int nsh_session(FAR struct console_stdio_s *pstate,
                 bool login, int argc, FAR char *argv[]);
-int nsh_parse(FAR struct nsh_vtbl_s *vtbl, char *cmdline);
+int nsh_parse(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline);
 
 /****************************************************************************
  * Name: nsh_login
@@ -888,7 +888,7 @@ int nsh_telnetlogin(FAR struct console_stdio_s *pstate);
 
 /* Application interface */
 
-int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, char *argv[]);
+int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[]);
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
@@ -911,8 +911,8 @@ void nsh_freefullpath(FAR char *fullpath);
 
 /* Debug */
 
-void nsh_dumpbuffer(FAR struct nsh_vtbl_s *vtbl, const char *msg,
-                    const uint8_t *buffer, ssize_t nbytes);
+void nsh_dumpbuffer(FAR struct nsh_vtbl_s *vtbl, FAR const char *msg,
+                    FAR const uint8_t *buffer, ssize_t nbytes);
 
 #ifdef CONFIG_NSH_USBDEV_TRACE
 /* USB debug support */
@@ -923,285 +923,287 @@ void nsh_usbtrace(void);
 /* Shell command handlers */
 
 #ifndef CONFIG_NSH_DISABLE_BASENAME
-  int cmd_basename(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_basename(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_LOOPS)
-  int cmd_break(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_break(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_DIRNAME
-  int cmd_dirname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_dirname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_ECHO
-  int cmd_echo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_echo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_PRINTF
-  int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_EXEC
-  int cmd_exec(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_exec(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_EXPORT
-  int cmd_export(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_export(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_MB
-  int cmd_mb(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mb(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_MH
-  int cmd_mh(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mh(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_MW
-  int cmd_mw(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mw(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_FREE
-  int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_MEMDUMP
-  int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_TIME
-  int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_PS
-  int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_XD
-  int cmd_xd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_xd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_MODULE) && !defined(CONFIG_NSH_DISABLE_MODCMDS)
-int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
-int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #endif
 
 #ifdef HAVE_IRQINFO
-int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_TEST)
-  int cmd_test(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
-  int cmd_lbracket(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_test(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+  int cmd_lbracket(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_TIMEDATECTL
-  int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc,
+                      FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_DATE
-  int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CAT
-  int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_CP
-  int cmd_cp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_cp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_CMP
-  int cmd_cmp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_cmp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_DD
-  int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_HEXDUMP
-  int cmd_hexdump(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_hexdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
-  int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_LS
-  int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if defined(CONFIG_SYSLOG_DEVPATH) && !defined(CONFIG_NSH_DISABLE_DMESG)
-  int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
-  int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
 #  ifndef CONFIG_NSH_DISABLE_SOURCE
-  int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #endif /* CONFIG_FILE_STREAM && !CONFIG_NSH_DISABLESCRIPT */
 
 #ifdef NSH_HAVE_DIROPTS
 #  ifndef CONFIG_NSH_DISABLE_MKDIR
-  int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_MV
-  int cmd_mv(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mv(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_RM
-  int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_RMDIR
-  int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 # endif /* NSH_HAVE_DIROPTS */
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #  if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
-  int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_SMART_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSMART)
-  int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0 && \
       !defined(CONFIG_NSH_DISABLE_MKFIFO)
-  int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifdef NSH_HAVE_CATFILE
 #    ifndef CONFIG_NSH_DISABLE_DF
-  int cmd_df(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_df(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #    ifndef CONFIG_NSH_DISABLE_MOUNT
-  int cmd_mount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_UMOUNT
-  int cmd_umount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_umount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_MKRD
-  int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifdef CONFIG_FSUTILS_MKFATFS
 #    ifndef CONFIG_NSH_DISABLE_MKFATFS
-  int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #   endif
 #  endif /* CONFIG_FSUTILS_MKFATFS */
 #  if defined(CONFIG_FS_SMARTFS) && defined(CONFIG_FSUTILS_MKSMARTFS)
 #    ifndef CONFIG_NSH_DISABLE_MKSMARTFS
-  int cmd_mksmartfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_mksmartfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif /* CONFIG_FS_SMARTFS */
 #  ifndef CONFIG_NSH_DISABLE_TRUNCATE
-  int cmd_truncate(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_truncate(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_NSH_LOGIN_PASSWD) && \
      !defined(CONFIG_FSUTILS_PASSWD_READONLY)
 #    ifndef CONFIG_NSH_DISABLE_USERADD
-  int cmd_useradd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_useradd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #    ifndef CONFIG_NSH_DISABLE_USERDEL
-  int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #    ifndef CONFIG_NSH_DISABLE_PASSWD
-  int cmd_passwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_passwd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #endif /* !CONFIG_DISABLE_MOUNTPOINT */
 
 #if !defined(CONFIG_DISABLE_ENVIRON)
 #  ifndef CONFIG_NSH_DISABLE_CD
-  int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_PWD
-  int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #endif /* !CONFIG_DISABLE_MOUNTPOINT */
 
 #ifndef CONFIG_NSH_DISABLE_ENV
-  int cmd_env(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_env(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_NET)
 #  if defined(CONFIG_NET_ARP) && !defined(CONFIG_NSH_DISABLE_ARP)
-  int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_NET_ROUTE) && !defined(CONFIG_NSH_DISABLE_ADDROUTE)
-  int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_NET_ROUTE) && !defined(CONFIG_NSH_DISABLE_DELROUTE)
-  int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifdef CONFIG_NET_UDP
 #    ifndef CONFIG_NSH_DISABLE_GET
-  int cmd_get(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_get(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_IFCONFIG
-  int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_IFUPDOWN
-  int cmd_ifup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
-  int cmd_ifdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_ifup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+  int cmd_ifdown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_NFS)
 #    ifndef CONFIG_NSH_DISABLE_NFSMOUNT
-  int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #  ifdef CONFIG_NET_UDP
 #    ifndef CONFIG_NSH_DISABLE_PUT
-  int cmd_put(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_put(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #  ifdef CONFIG_NET_TCP
 #    ifndef CONFIG_NSH_DISABLE_WGET
-  int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_ROUTE
-  int cmd_route(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_route(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  if defined(CONFIG_NSH_TELNET)
 #    ifndef CONFIG_NSH_DISABLE_TELNETD
-  int cmd_telnetd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_telnetd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #    endif
 #  endif
 #endif /* CONFIG_NET */
 
 #if defined(CONFIG_LIBC_NETDB) && !defined(CONFIG_NSH_DISABLE_NSLOOKUP)
-  int cmd_nslookup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_nslookup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_BOARDCTL_POWEROFF) && !defined(CONFIG_NSH_DISABLE_POWEROFF)
-  int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_PM) && !defined(CONFIG_NSH_DISABLE_PMCONFIG)
-int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_BOARDCTL_RESET) && !defined(CONFIG_NSH_DISABLE_REBOOT)
-  int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
-  int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc,
+                      FAR char **argv);
 #endif
 
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
-  int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if (defined(CONFIG_BOARDCTL_POWEROFF) || defined(CONFIG_BOARDCTL_RESET)) && \
     !defined(CONFIG_NSH_DISABLE_SHUTDOWN)
-  int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_UNAME
-  int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_SET
-  int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_UNSET
-  int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_KILL
-  int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_SLEEP
-  int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_USLEEP
-  int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_UPTIME
@@ -1210,25 +1212,27 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
 
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_BASE64)
 #  ifndef CONFIG_NSH_DISABLE_BASE64DEC
-  int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc,
+                       FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_BASE64ENC
-  int cmd_base64encode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_base64encode(FAR struct nsh_vtbl_s *vtbl, int argc,
+                       FAR char **argv);
 #  endif
 #endif
 
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_HASH_MD5)
 #  ifndef CONFIG_NSH_DISABLE_MD5
-  int cmd_md5(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_md5(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #endif
 
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_URLCODE)
 #  ifndef CONFIG_NSH_DISABLE_URLDECODE
-  int cmd_urlencode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_urlencode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_URLENCODE
-  int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+  int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
 #endif
 

--- a/nshlib/nsh_codeccmd.c
+++ b/nshlib/nsh_codeccmd.c
@@ -233,7 +233,7 @@ static int calc_codec_buffsize(int srclen, uint8_t mode)
 
 #ifdef NEED_CMD_CODECS_PROC
 static int cmd_codecs_proc(FAR struct nsh_vtbl_s *vtbl, int argc,
-                           char **argv, uint8_t mode,
+                           FAR char **argv, uint8_t mode,
                            codec_callback_t func)
 {
 #ifdef HAVE_CODECS_HASH_MD5
@@ -525,7 +525,7 @@ errout:
  ****************************************************************************/
 
 #ifdef HAVE_CODECS_URLENCODE
-int cmd_urlencode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_urlencode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return cmd_codecs_proc(vtbl, argc, argv, CODEC_MODE_URLENCODE,
                          urlencode_cb);
@@ -537,7 +537,7 @@ int cmd_urlencode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifdef HAVE_CODECS_URLDECODE
-int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return cmd_codecs_proc(vtbl, argc, argv, CODEC_MODE_URLDECODE,
                          urldecode_cb);
@@ -549,7 +549,7 @@ int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifdef HAVE_CODECS_BASE64ENC
-int cmd_base64encode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_base64encode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return cmd_codecs_proc(vtbl, argc, argv, CODEC_MODE_BASE64ENC, b64enc_cb);
 }
@@ -560,7 +560,7 @@ int cmd_base64encode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifdef HAVE_CODECS_BASE64DEC
-int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return cmd_codecs_proc(vtbl, argc, argv, CODEC_MODE_BASE64DEC, b64dec_cb);
 }
@@ -571,7 +571,7 @@ int cmd_base64decode(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifdef HAVE_CODECS_HASH_MD5
-int cmd_md5(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_md5(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return cmd_codecs_proc(vtbl, argc, argv, CODEC_MODE_HASH_MD5, md5_cb);
 }

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -65,20 +65,21 @@ struct cmdmap_s
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_HELP
-static int  cmd_help(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+static int  cmd_help(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
-static int  cmd_true(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
-static int  cmd_false(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+static int  cmd_true(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+static int  cmd_false(FAR struct nsh_vtbl_s *vtbl, int argc,
+                      FAR char **argv);
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_EXIT
-static int  cmd_exit(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+static int  cmd_exit(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 static int  cmd_unrecognized(FAR struct nsh_vtbl_s *vtbl, int argc,
-                             char **argv);
+                             FAR char **argv);
 
 /****************************************************************************
  * Private Data
@@ -887,7 +888,7 @@ static inline void help_builtins(FAR struct nsh_vtbl_s *vtbl)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_HELP
-static int cmd_help(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+static int cmd_help(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *cmd = NULL;
 #ifndef CONFIG_NSH_HELP_TERSE
@@ -971,7 +972,7 @@ static int cmd_help(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 static int cmd_unrecognized(FAR struct nsh_vtbl_s *vtbl, int argc,
-                            char **argv)
+                            FAR char **argv)
 {
   UNUSED(argc);
 
@@ -984,7 +985,7 @@ static int cmd_unrecognized(FAR struct nsh_vtbl_s *vtbl, int argc,
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
-static int cmd_true(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+static int cmd_true(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(vtbl);
   UNUSED(argc);
@@ -1000,7 +1001,7 @@ static int cmd_true(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
-static int cmd_false(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+static int cmd_false(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(vtbl);
   UNUSED(argc);
@@ -1015,7 +1016,7 @@ static int cmd_false(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_EXIT
-static int cmd_exit(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+static int cmd_exit(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
   UNUSED(argv);
@@ -1041,7 +1042,7 @@ static int cmd_exit(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  *
  ****************************************************************************/
 
-int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, char *argv[])
+int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[])
 {
   const struct cmdmap_s *cmdmap;
   const char            *cmd;

--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -66,15 +66,15 @@ struct dd_s
 {
   FAR struct nsh_vtbl_s *vtbl;
 
-  int      infd;       /* File descriptor of the input device */
-  int      outfd;      /* File descriptor of the output device */
-  uint32_t nsectors;   /* Number of sectors to transfer */
-  uint32_t sector;     /* The current sector number */
-  uint32_t skip;       /* The number of sectors skipped on input */
-  bool     eof;        /* true: The end of the input or output file has been hit */
-  uint16_t sectsize;   /* Size of one sector */
-  uint16_t nbytes;     /* Number of valid bytes in the buffer */
-  uint8_t *buffer;     /* Buffer of data to write to the output file */
+  int          infd;       /* File descriptor of the input device */
+  int          outfd;      /* File descriptor of the output device */
+  uint32_t     nsectors;   /* Number of sectors to transfer */
+  uint32_t     sector;     /* The current sector number */
+  uint32_t     skip;       /* The number of sectors skipped on input */
+  bool         eof;        /* true: The end of the input or output file has been hit */
+  uint16_t     sectsize;   /* Size of one sector */
+  uint16_t     nbytes;     /* Number of valid bytes in the buffer */
+  FAR uint8_t *buffer;     /* Buffer of data to write to the output file */
 };
 
 /****************************************************************************
@@ -191,7 +191,7 @@ static inline int dd_outfopen(FAR const char *name, FAR struct dd_s *dd)
  * Name: cmd_dd
  ****************************************************************************/
 
-int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct dd_s dd;
   FAR char *infile = NULL;

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -131,9 +131,9 @@ static void str_escape(FAR char *s)
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_ENVIRON
-static inline FAR const char *nsh_getwd(const char *wd)
+static inline FAR const char *nsh_getwd(FAR const char *wd)
 {
-  const char *val;
+  FAR const char *val;
 
   /* If no working directory is defined, then default to the home directory */
 
@@ -185,7 +185,7 @@ FAR const char *nsh_getcwd(void)
 FAR char *nsh_getfullpath(FAR struct nsh_vtbl_s *vtbl,
                           FAR const char *relpath)
 {
-  const char *wd;
+  FAR const char *wd;
 
   /* Handle some special cases */
 
@@ -237,7 +237,7 @@ void nsh_freefullpath(FAR char *fullpath)
 
 #ifndef CONFIG_DISABLE_ENVIRON
 #ifndef CONFIG_NSH_DISABLE_CD
-int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *path = argv[1];
   FAR char *alloc = NULL;
@@ -297,7 +297,7 @@ int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_ECHO
-int cmd_echo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_echo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   int newline = 1;
   int escape = 0;
@@ -360,7 +360,7 @@ int cmd_echo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_ENV
-int cmd_env(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_env(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -375,7 +375,7 @@ int cmd_env(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifndef CONFIG_DISABLE_ENVIRON
 #ifndef CONFIG_NSH_DISABLE_PWD
-int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
   UNUSED(argv);
@@ -391,7 +391,7 @@ int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_SET
-int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *value;
   int ret = OK;
@@ -536,7 +536,7 @@ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_UNSET
-int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -577,7 +577,7 @@ int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_EXPORT
-int cmd_export(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_export(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *value = "";
   int status;

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -89,7 +89,7 @@
  * Name: ls_specialdir
  ****************************************************************************/
 
-static inline int ls_specialdir(const char *dir)
+static inline int ls_specialdir(FAR const char *dir)
 {
   /* '.' and '..' directories are not listed like normal directories */
 
@@ -311,8 +311,8 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
  ****************************************************************************/
 
 #if !defined(CONFIG_NSH_DISABLE_LS)
-static int ls_recursive(FAR struct nsh_vtbl_s *vtbl, const char *dirpath,
-                        struct dirent *entryp, void *pvarg)
+static int ls_recursive(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
+                        FAR struct dirent *entryp, FAR void *pvarg)
 {
   int ret = OK;
 
@@ -357,7 +357,7 @@ static int ls_recursive(FAR struct nsh_vtbl_s *vtbl, const char *dirpath,
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_BASENAME
-int cmd_basename(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_basename(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *filename;
 
@@ -397,7 +397,7 @@ int cmd_basename(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_DIRNAME
-int cmd_dirname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_dirname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -419,7 +419,7 @@ int cmd_dirname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_CAT
-int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *fullpath;
   int i;
@@ -458,7 +458,7 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_SYSLOG_DEVPATH) && !defined(CONFIG_NSH_DISABLE_DMESG)
-int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -471,7 +471,7 @@ int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_CP
-int cmd_cp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_cp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -571,7 +571,7 @@ int cmd_cp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
     {
       int nbytesread;
       int nbyteswritten;
-      char *iobuffer = vtbl->iobuffer;
+      FAR char *iobuffer = vtbl->iobuffer;
 
       do
         {
@@ -669,7 +669,7 @@ errout:
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #   if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
-int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *loopdev = NULL;
   FAR char *filepath = NULL;
@@ -830,7 +830,7 @@ errout_with_paths:
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #   if defined(CONFIG_SMART_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSMART)
-int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *loopdev = NULL;
   FAR char *filepath = NULL;
@@ -1001,7 +1001,7 @@ errout_with_paths:
  ****************************************************************************/
 
 #if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
-int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *linkpath;
   FAR char *tgtpath;
@@ -1073,7 +1073,7 @@ errout_with_nomemory:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_LS
-int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct stat st;
   FAR const char *relpath;
@@ -1202,7 +1202,7 @@ int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef NSH_HAVE_DIROPTS
 #ifndef CONFIG_NSH_DISABLE_MKDIR
-int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *fullpath = NULL;
   bool parent = false;
@@ -1226,7 +1226,7 @@ int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
   if (fullpath != NULL)
     {
-      char *slash = parent ? fullpath : "";
+      FAR char *slash = parent ? fullpath : "";
 
       for (; ; )
         {
@@ -1269,7 +1269,7 @@ int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FSUTILS_MKFATFS)
 #ifndef CONFIG_NSH_DISABLE_MKFATFS
-int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct fat_format_s fmt = FAT_FORMAT_INITIALIZER;
   FAR char *fullpath;
@@ -1372,7 +1372,7 @@ int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #if defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0 && \
     !defined(CONFIG_NSH_DISABLE_MKFIFO)
-int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1399,7 +1399,7 @@ int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_MKRD
-int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *fmt;
   struct boardioc_mkrd_s desc;
@@ -1503,9 +1503,9 @@ errout_with_fmt:
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_SMARTFS) && \
     defined(CONFIG_FSUTILS_MKSMARTFS)
 #ifndef CONFIG_NSH_DISABLE_MKSMARTFS
-int cmd_mksmartfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mksmartfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char *fullpath = NULL;
+  FAR char *fullpath = NULL;
   int ret = OK;
   uint16_t  sectorsize = 0;
   int force = 0;
@@ -1595,7 +1595,7 @@ int cmd_mksmartfs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef NSH_HAVE_DIROPTS
 #ifndef CONFIG_NSH_DISABLE_MV
-int cmd_mv(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mv(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1644,7 +1644,7 @@ errout_with_oldpath:
  ****************************************************************************/
 
 #if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
-int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1740,7 +1740,7 @@ static int unlink_recursive(FAR char *path)
   return ret;
 }
 
-int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1780,7 +1780,7 @@ int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef NSH_HAVE_DIROPTS
 #ifndef CONFIG_NSH_DISABLE_RMDIR
-int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1809,7 +1809,7 @@ int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
 #ifndef CONFIG_NSH_DISABLE_SOURCE
-int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1823,7 +1823,7 @@ int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_CMP
-int cmd_cmp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_cmp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -1936,7 +1936,7 @@ errout:
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #ifndef CONFIG_NSH_DISABLE_TRUNCATE
-int cmd_truncate(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_truncate(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -37,7 +37,7 @@
  * Name: cmd_free
  ****************************************************************************/
 
-int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -52,7 +52,7 @@ int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  * Name: cmd_memdump
  ****************************************************************************/
 
-int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *arg = "used";
 

--- a/nshlib/nsh_mntcmds.c
+++ b/nshlib/nsh_mntcmds.c
@@ -54,7 +54,7 @@
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && !defined(CONFIG_NSH_DISABLE_DF)
 #ifdef NSH_HAVE_CATFILE
-int cmd_df(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_df(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
 #if defined(HAVE_DF_HUMANREADBLE) && defined(HAVE_DF_BLOCKOUTPUT)
   if (argc > 1 && strcmp(argv[1], "-h") == 0)
@@ -83,7 +83,7 @@ int cmd_df(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && !defined(CONFIG_NSH_DISABLE_MOUNT)
-int cmd_mount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_mount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *source;
   FAR char *fullsource;
@@ -235,7 +235,7 @@ errout:
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_NET) && \
     defined(CONFIG_NFS) && !defined(CONFIG_NSH_DISABLE_NFSMOUNT)
-int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct nfs_args data;
   FAR char *address;
@@ -359,11 +359,11 @@ int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && !defined(CONFIG_NSH_DISABLE_UMOUNT)
-int cmd_umount(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_umount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
-  char *fullpath = nsh_getfullpath(vtbl, argv[1]);
+  FAR char *fullpath = nsh_getfullpath(vtbl, argv[1]);
   int ret = ERROR;
 
   if (fullpath)

--- a/nshlib/nsh_modcmds.c
+++ b/nshlib/nsh_modcmds.c
@@ -42,7 +42,7 @@
  * Name: cmd_insmod
  ****************************************************************************/
 
-int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -66,7 +66,7 @@ int cmd_insmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  * Name: cmd_rmmod
  ****************************************************************************/
 
-int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -101,7 +101,7 @@ int cmd_rmmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -203,8 +203,8 @@ static int ifconfig_callback(FAR struct nsh_vtbl_s *vtbl, FAR char *devname)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP
-int tftpc_parseargs(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv,
-                    struct tftpc_args_s *args)
+int tftpc_parseargs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv,
+                    FAR struct tftpc_args_s *args)
 {
   FAR const char *fmt = g_fmtarginvalid;
   bool badarg = false;
@@ -342,7 +342,7 @@ errout:
 #ifdef CONFIG_NET_TCP
 #ifndef CONFIG_NSH_DISABLE_WGET
 static int wget_callback(FAR char **buffer, int offset, int datend,
-                          FAR int *buflen, FAR void *arg)
+                         FAR int *buflen, FAR void *arg)
 {
   ssize_t written = write((int)((intptr_t)arg), &((*buffer)[offset]),
                           datend - offset);
@@ -464,7 +464,7 @@ static inline void nsh_sethwaddr(FAR const char *ifname,
 
 #ifdef CONFIG_NET_UDP
 #ifndef CONFIG_NSH_DISABLE_GET
-int cmd_get(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_get(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct tftpc_args_s args;
   FAR char *fullpath;
@@ -505,7 +505,7 @@ int cmd_get(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_IFUPDOWN
-int cmd_ifup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ifup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *ifname = NULL;
   int ret;
@@ -528,7 +528,7 @@ int cmd_ifup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_IFUPDOWN
-int cmd_ifdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ifdown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *ifname = NULL;
   int ret;
@@ -552,7 +552,7 @@ int cmd_ifdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_IFCONFIG
-int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
 #ifdef CONFIG_NET_IPv4
   struct in_addr addr;
@@ -986,7 +986,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_LIBC_NETDB) && !defined(CONFIG_NSH_DISABLE_NSLOOKUP)
-int cmd_nslookup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_nslookup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR struct addrinfo *info;
   FAR struct addrinfo *next;
@@ -1036,7 +1036,7 @@ int cmd_nslookup(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_NET_ARP) && !defined(CONFIG_NSH_DISABLE_ARP)
-int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct sockaddr_in inaddr;
   struct ether_addr mac;
@@ -1238,7 +1238,7 @@ errout_invalid:
 
 #ifdef CONFIG_NET_UDP
 #ifndef CONFIG_NSH_DISABLE_PUT
-int cmd_put(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_put(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct tftpc_args_s args;
   FAR char *fullpath;
@@ -1280,7 +1280,7 @@ int cmd_put(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #ifdef CONFIG_NET_TCP
 #ifndef CONFIG_NSH_DISABLE_WGET
-int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *localfile = NULL;
   FAR char *allocfile = NULL;

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -125,7 +125,7 @@ static void nsh_memlist_free(FAR struct nsh_memlist_s *memlist);
 static void nsh_releaseargs(struct cmdarg_s *arg);
 static pthread_addr_t nsh_child(pthread_addr_t arg);
 static struct cmdarg_s *nsh_cloneargs(FAR struct nsh_vtbl_s *vtbl,
-               int fd, int argc, char *argv[]);
+               int fd, int argc, FAR char *argv[]);
 #endif
 
 static int nsh_saveresult(FAR struct nsh_vtbl_s *vtbl, bool result);
@@ -164,8 +164,10 @@ static void nsh_dequote(FAR char *cmdline);
 
 static FAR char *nsh_argexpand(FAR struct nsh_vtbl_s *vtbl,
                FAR char *cmdline, FAR char **allocation, FAR int *isenvvar);
-static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl, char **saveptr,
-               FAR NSH_MEMLIST_TYPE *memlist, FAR int *isenvvar);
+static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
+                              FAR char **saveptr,
+                              FAR NSH_MEMLIST_TYPE *memlist,
+                              FAR int *isenvvar);
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
 #ifndef CONFIG_NSH_DISABLE_LOOPS
@@ -392,7 +394,7 @@ static pthread_addr_t nsh_child(pthread_addr_t arg)
 
 #ifndef CONFIG_NSH_DISABLEBG
 static struct cmdarg_s *nsh_cloneargs(FAR struct nsh_vtbl_s *vtbl,
-                                      int fd, int argc, char *argv[])
+                                      int fd, int argc, FAR char *argv[])
 {
   struct cmdarg_s *ret = (struct cmdarg_s *)zalloc(sizeof(struct cmdarg_s));
   int i;
@@ -2223,7 +2225,7 @@ static int nsh_nice(FAR struct nsh_vtbl_s *vtbl, FAR char **ppcmd,
               FAR char *val = nsh_argument(vtbl, saveptr, memlist, NULL);
               if (val)
                 {
-                  char *endptr;
+                  FAR char *endptr;
                   vtbl->np.np_nice = (int)strtol(val, &endptr, 0);
                   if (vtbl->np.np_nice > 19 || vtbl->np.np_nice < -20 ||
                       endptr == val || *endptr != '\0')
@@ -2738,7 +2740,7 @@ int nsh_parse(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
  ****************************************************************************/
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_LOOPS)
-int cmd_break(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_break(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
   UNUSED(argv);

--- a/nshlib/nsh_passwdcmds.c
+++ b/nshlib/nsh_passwdcmds.c
@@ -42,7 +42,7 @@
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_USERADD
-int cmd_useradd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_useradd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -65,7 +65,7 @@ int cmd_useradd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_USERDEL
-int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -88,7 +88,7 @@ int cmd_userdel(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_PASSWD
-int cmd_passwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_passwd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 

--- a/nshlib/nsh_printf.c
+++ b/nshlib/nsh_printf.c
@@ -44,7 +44,7 @@
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_PRINTF
-int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_printf(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *fmt;
   char ch;

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -581,7 +581,7 @@ int cmd_exec(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_PS
-int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
   UNUSED(argv);
@@ -624,10 +624,10 @@ int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_KILL
-int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char *ptr;
-  char *endptr;
+  FAR char *ptr;
+  FAR char *endptr;
   long signal;
   long pid;
 
@@ -727,11 +727,11 @@ invalid_arg:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_SLEEP
-int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
-  char *endptr;
+  FAR char *endptr;
   long secs;
 
   secs = strtol(argv[1], &endptr, 0);
@@ -751,11 +751,11 @@ int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_USLEEP
-int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
-  char *endptr;
+  FAR char *endptr;
   long usecs;
 
   usecs = strtol(argv[1], &endptr, 0);

--- a/nshlib/nsh_routecmds.c
+++ b/nshlib/nsh_routecmds.c
@@ -89,7 +89,7 @@ static int slash_notation(FAR char *arg)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_ADDROUTE
-int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_addroute(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   union
   {
@@ -458,7 +458,7 @@ errout:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_DELROUTE
-int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_delroute(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   union
   {
@@ -700,7 +700,7 @@ errout:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_ROUTE
-int cmd_route(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_route(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
   bool ipv6 = false;

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -78,7 +78,7 @@ static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
  *
  ****************************************************************************/
 
-int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
+int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
                FAR const char *path)
 {
   FAR char *fullpath;

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -94,7 +94,7 @@ static const char g_unknown[] = "unknown";
 #if (defined(CONFIG_BOARDCTL_POWEROFF) || defined(CONFIG_BOARDCTL_RESET)) && \
     !defined(CONFIG_NSH_DISABLE_SHUTDOWN)
 
-int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
 #if defined(CONFIG_BOARDCTL_POWEROFF) && defined(CONFIG_BOARDCTL_RESET)
   /* If both shutdown and reset are supported, then a single option may
@@ -181,7 +181,7 @@ static int cmd_pmconfig_recursive(FAR struct nsh_vtbl_s *vtbl,
                                   FAR struct dirent *entryp,
                                   FAR void *pvarg)
 {
-  char *path;
+  FAR char *path;
   int ret = ERROR;
 
   if (DIRENT_ISDIRECTORY(entryp->d_type))
@@ -200,7 +200,7 @@ static int cmd_pmconfig_recursive(FAR struct nsh_vtbl_s *vtbl,
   return ret;
 }
 
-int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct boardioc_pm_ctrl_s ctrl =
   {
@@ -291,7 +291,7 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_BOARDCTL_POWEROFF) && !defined(CONFIG_NSH_DISABLE_POWEROFF)
-int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   /* Invoke the BOARDIOC_POWEROFF board control to shutdown the board.  If
    * the board_power_off function returns, then it was not possible to power-
@@ -321,7 +321,7 @@ int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #if defined(CONFIG_BOARDCTL_RESET) && !defined(CONFIG_NSH_DISABLE_REBOOT)
-int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   /* Invoke the BOARDIOC_RESET board control to reset the board.  If
    * the board_reset() function returns, then it was not possible to
@@ -347,7 +347,7 @@ int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 #endif
 
 #if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
-int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -374,7 +374,7 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
 
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
 static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
-                          FAR const char *path, char **argv)
+                          FAR const char *path, FAR char **argv)
 {
   struct rptun_ping_s ping;
   unsigned long val = 0;
@@ -439,10 +439,11 @@ static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
 }
 
 static int cmd_rptun_recursive(FAR struct nsh_vtbl_s *vtbl,
-                               const char *dirpath,
-                               struct dirent *entryp, void *pvarg)
+                               FAR const char *dirpath,
+                               FAR struct dirent *entryp,
+                               FAR void *pvarg)
 {
-  char *path;
+  FAR char *path;
   int ret = ERROR;
 
   if (DIRENT_ISDIRECTORY(entryp->d_type))
@@ -460,7 +461,7 @@ static int cmd_rptun_recursive(FAR struct nsh_vtbl_s *vtbl,
   return ret;
 }
 
-int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   if (argc < 3)
     {
@@ -483,7 +484,7 @@ int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_UNAME
-int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *str;
   struct utsname info;

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -354,7 +354,7 @@ int nsh_telnetstart(sa_family_t family)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_TELNETD
-int cmd_telnetd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_telnetd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(vtbl);
   UNUSED(argc);

--- a/nshlib/nsh_test.c
+++ b/nshlib/nsh_test.c
@@ -74,11 +74,12 @@
  * Name: binaryexpression
  ****************************************************************************/
 
-static inline int binaryexpression(FAR struct nsh_vtbl_s *vtbl, char **argv)
+static inline int binaryexpression(FAR struct nsh_vtbl_s *vtbl,
+                                   FAR char **argv)
 {
   UNUSED(vtbl);
 
-  char *endptr;
+  FAR char *endptr;
   long integer1;
   long integer2;
 
@@ -175,10 +176,11 @@ static inline int binaryexpression(FAR struct nsh_vtbl_s *vtbl, char **argv)
  * Name: unaryexpression
  ****************************************************************************/
 
-static inline int unaryexpression(FAR struct nsh_vtbl_s *vtbl, char **argv)
+static inline int unaryexpression(FAR struct nsh_vtbl_s *vtbl,
+                                  FAR char **argv)
 {
   struct stat buf;
-  char *fullpath;
+  FAR char *fullpath;
   int   ret;
 
   /* -n STRING */
@@ -304,7 +306,7 @@ static inline int unaryexpression(FAR struct nsh_vtbl_s *vtbl, char **argv)
  * Name: expression
  ****************************************************************************/
 
-static int expression(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+static int expression(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   int value;
   int i = 0;
@@ -409,7 +411,7 @@ errout_syntax:
  * Name: cmd_test
  ****************************************************************************/
 
-int cmd_test(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_test(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   return expression(vtbl, argc - 1, &argv[1]);
 }
@@ -418,7 +420,7 @@ int cmd_test(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  * Name: cmd_lbracket
  ****************************************************************************/
 
-int cmd_lbracket(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_lbracket(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   /* Verify that the closing right bracket is the last thing on the command
    * line.

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -289,7 +289,7 @@ errout_bad_parm:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_TIME
-int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
@@ -370,7 +370,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_DATE
-int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *newtime = NULL;
   FAR const char *errfmt;
@@ -435,7 +435,7 @@ errout:
  ****************************************************************************/
 
 #ifndef CONFIG_NSH_DISABLE_TIMEDATECTL
-int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   char timbuf[MAX_TIME_STRING];
   FAR char *newtz = NULL;

--- a/nshlib/nsh_vars.c
+++ b/nshlib/nsh_vars.c
@@ -42,7 +42,7 @@
  * Name: nsh_cmpname
  ****************************************************************************/
 
-static bool nsh_cmpname(const char *pszname, const char *peqname)
+static bool nsh_cmpname(FAR const char *pszname, FAR const char *peqname)
 {
   /* Search until we find anything different in the two names */
 


### PR DESCRIPTION
## Summary

Add the missing **`FAR`** macro for all source files under `apps/nshlib`

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact


## Testing
