### PR TITLE
netutils/dhcpc: Set close-on-exec by default to avoid udp_conn leak 

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -542,7 +542,7 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
 
       /* Create a UDP socket */
 
-      pdhcpc->sockfd = socket(PF_INET, SOCK_DGRAM, 0);
+      pdhcpc->sockfd = socket(PF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
       if (pdhcpc->sockfd < 0)
         {
           ninfo("socket handle %d\n", pdhcpc->sockfd);

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -765,7 +765,7 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
            * of time). Then loop and send the DISCOVER command again.
            */
 
-          else if (errno != EAGAIN)
+          else if (errno != EAGAIN && errno != EINTR)
             {
               /* An error other than a timeout was received -- error out */
 
@@ -865,7 +865,7 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
            * (at most 3 times).
            */
 
-          else if (errno != EAGAIN)
+          else if (errno != EAGAIN && errno != EINTR)
             {
               /* An error other than a timeout was received */
 

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -595,7 +595,7 @@ static void netinit_net_bringup(void)
       return;
     }
 
-#ifdef CONFIG_WIRELESS_WAPI
+#if defined(CONFIG_WIRELESS_WAPI) && defined(CONFIG_DRIVERS_IEEE80211)
   /* Associate the wlan with an access point. */
 
   if (netinit_associate(NET_DEVNAME) < 0)


### PR DESCRIPTION
## Summary

netutls/dhcpc: treat EINTR as normal errno

A return code of EINTR is perfectly normal, and isn't an error as such.
It's an indication that your program may need to do something because
a signal occurred, but if not, should re-call recv().

netutils/dhcpc: Set close-on-exec by default to avoid udp_conn leak
netinit: associate wlan if DRIVERS_IEEE80211 enabled

## Impact

N/A

## Testing

netinit/dhcpc