### PR TITLE
system/trace: expand dump string

### DIFF
--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -640,15 +640,16 @@ static int trace_dump_one(trace_dump_t type, FAR FILE *out, FAR uint8_t *p,
           trace_dump_unflatten(&ip, nst->nst_ip, sizeof(ip));
 
           if (type == TRACE_TYPE_ANDROID &&
-              strlen(nst->nst_data) > 2 &&
-              (memcmp(nst->nst_data, "B|", 2) == 0 ||
-               memcmp(nst->nst_data, "E|", 2) == 0))
+              nst->nst_data[1] == '\0' &&
+              (nst->nst_data[0] == 'B' ||
+               nst->nst_data[0] == 'E'))
             {
-              fprintf(out, "tracing_mark_write: %s\n", nst->nst_data);
+              fprintf(out, "tracing_mark_write: %c|%d|%pS\n",
+                      nst->nst_data[0], pid, (FAR void *)ip);
             }
           else
             {
-              fprintf(out, "0x%" PRIdPTR ": %s\n", ip, nst->nst_data);
+              fprintf(out, "%pS: %s\n", (FAR void *)ip, nst->nst_data);
             }
         }
         break;


### PR DESCRIPTION
## Summary
Optimize sched_note_begin/end, replace note_printf with note_string
the time required changed from 50us to 1us
Need to be used with [#7196](https://github.com/apache/incubator-nuttx/pull/7196)

## Impact

## Testing

