### PR TITLE
examples/i2schar: Fix compile error and warning

### DIFF
--- a/examples/i2schar/i2schar_main.c
+++ b/examples/i2schar/i2schar_main.c
@@ -212,7 +212,6 @@ static void parse_args(FAR struct i2schar_state_s *i2schar,
         }
     }
 }
-#endif
 
 /****************************************************************************
  * Public Functions

--- a/examples/i2schar/i2schar_transmitter.c
+++ b/examples/i2schar/i2schar_transmitter.c
@@ -109,9 +109,8 @@ pthread_addr_t i2schar_transmitter(pthread_addr_t arg)
       ret = apb_alloc(&desc);
       if (ret < 0)
         {
-           printf("
-             i2schar_transmitter: ERROR: failed to allocate buffer %d: %d\n",
-             i + 1, ret);
+           printf("i2schar_transmitter:"
+                  "ERROR: failed to allocate buffer %d: %d\n", i + 1, ret);
            close(fd);
            pthread_exit(NULL);
         }


### PR DESCRIPTION
## Summary
Fix compile error due to unnecessary endif.
Fix warning of long line.

## Impact
Before fixing the issue whenever the `i2schar` example was selected to be compiled it broke the compilation because of the unnecessary `endif`statement.

## Testing
Tested with internal CI.
