### PR TITLE
Separate NSH ability to mount a romfs at /etc and to run init scripts.

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -699,12 +699,12 @@ config NSH_DISABLE_LOOPS
 endif # !NSH_DISABLESCRIPT
 
 config NSH_ROMFSETC
-	bool "Support ROMFS start-up script"
+	bool "Mount a ROMFS at /etc (eg, to support a start-up script)"
 	default n
 	depends on FS_ROMFS
 	---help---
-		Mount a ROMFS filesystem at /etc and provide a system init
-		script at /etc/init.d/rc.sysinit and a startup script
+		Mount a ROMFS filesystem at /etc. This can be used to and provide
+		a system init script at /etc/init.d/rc.sysinit and a startup script
 		at /etc/init.d/rcS.  The default system init script will mount
 		a FAT FS RAMDISK at /tmp but the logic is easily extensible.
 
@@ -738,31 +738,6 @@ config NSH_ROMFSMOUNTPT
 		The default mountpoint for the ROMFS volume is /etc, but that
 		can be changed with this setting.  This must be a absolute path
 		beginning with '/'.
-
-config NSH_SYSINITSCRIPT
-	string "Relative path to sysinit script"
-	default "init.d/rc.sysinit"
-	---help---
-		This is the relative path to the sysinit script within the mountpoint.
-		The default is init.d/rc.sysinit. This is a relative path and must not
-		start with '/'.
-
-config NSH_INITSCRIPT
-	string "Relative path to startup script"
-	default "init.d/rcS"
-	---help---
-		This is the relative path to the startup script within the mountpoint.
-		The default is init.d/rcS.  This is a relative path and must not
-		start with '/'.
-
-config NSH_RCSCRIPT
-	string "Relative path to login script"
-	default ".nshrc"
-	depends on NSH_ROMFSRC
-	---help---
-		This is the relative path to the login script within the mountpoint.
-		The default is .nshrc.  This is a relative path and must not
-		start with '/'.
 
 config NSH_ROMFSDEVNO
 	int "ROMFS block device minor number"
@@ -857,13 +832,75 @@ config NSH_FATMOUNTPT
 		will mount a FAT FS under /tmp. This is the location where the FAT
 		FS will be mounted.  Default is "/tmp".
 
+endif # NSH_ROMFSETC
+
+config NSH_RUNSYSINITSCRIPT
+	bool "Run a sysinit script"
+    default n
+    select NSH_AUTOSCRIPTS
+
+if NSH_RUNSYSINITSCRIPT
+
+config NSH_SYSINITSCRIPT
+	string "Path to sysinit script"
+	default "/etc/init.d/rc.sysinit"
+	---help---
+		This is the path to the sysinit script executed by nsh at boot.
+		The default is init.d/rc.sysinit. This script can be in a ROMFS mounted
+		by NSH or in any other filesystem that was mounted by the board logic.
+
+endif
+
+config NSH_RUNINITSCRIPT
+	bool "Run a startup script"
+    default n
+    select NSH_AUTOSCRIPTS
+
+if NSH_RUNINITSCRIPT
+
+config NSH_INITSCRIPT
+	string "Path to startup script"
+	default "/etc/init.d/rcS"
+	---help---
+		This is the path to the startup script executed by nsh at boot.
+		The default is /etc/init.d/rcS. This script can be in a ROMFS mounted
+		by NSH or in any other filesystem that was mounted by the board logic.
+
+endif
+
+config NSH_RUNRCSCRIPT
+	bool "Run a login script"
+    default n
+    select NSH_AUTOSCRIPTS
+
+if NSH_RUNRCSCRIPT
+
+config NSH_RCSCRIPT
+	string "Path to login script"
+	default "/etc/init.d/.nshrc"
+	---help---
+		This is the relative path to the login script within the mountpoint.
+		The default is /etc/init.d/.nshrc. This script can be in a ROMFS
+		mounted by NSG or in any other filesystem that was mounted by the board
+		logic.
+
+endif
+
+#this config is enabled is ANY script is enabled
+config NSH_AUTOSCRIPTS
+    bool
+    default n
+
+if NSH_AUTOSCRIPTS
+
 config NSH_SCRIPT_REDIRECT_PATH
 	string "rcS redirect output"
 	default ""
 	---help---
 		This option can redirect rcS output.such as /dev/log or other.
 
-endif # NSH_ROMFSETC
+endif
+
 endmenu # Scripting Support
 
 menu "Console Configuration"

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -1963,14 +1963,6 @@ configuration setting apply:
   `/etc`, but that can be changed with this setting. This must be a absolute
   path beginning with `/`.
 
-- `CONFIG_NSH_SYSINITSCRIPT` – This is the relative path to the system init
-  script within the mountpoint. The default is `init.d/rc.sysinit`. This
-  is a relative path and must not start with `/`.
-
-- `CONFIG_NSH_INITSCRIPT` – This is the relative path to the startup script
-  within the mountpoint. The default is `init.d/rcS`. This is a relative path
-  and must not start with `/`.
-
 - `CONFIG_NSH_ROMFSDEVNO` – This is the minor number of the ROMFS block device.
   The default is `0` corresponding to `/dev/ram0`.
 
@@ -1994,6 +1986,27 @@ mount a FAT FS under `/tmp`. The following selections describe that FAT FS.
 
 - `CONFIG_NSH_FATMOUNTPT` – This is the location where the FAT FS will be
   mounted. Default is `/tmp`.
+
+## Init scripts
+
+Scripts can be run to initialize the system when NSH starts. For increased
+flexibility, this can be enabled even if `CONFIG_NSH_ROMFSETC` is not enabled,
+since startup scripts can also be executed from any filesystem initialized
+by the board logic.
+
+- `CONFIG_NSH_SYSINITSCRIPT` – This is the absolute path to the system init
+  script. The default is `/etcinit.d/rc.sysinit`. This is executed before the
+  network is initialized.
+
+- `CONFIG_NSH_INITSCRIPT` – This is the absolute path to the startup script.
+  The default is `/etc/init.d/rcS`. This is executed after the network has been
+  initialized.
+
+- `CONFIG_NSH_RCSCRIPT` – This is the absolute path to the login script.
+  The default is `/etc/init.d/rcS`. This is executed at console login, eg at
+  system startup, but also on USB connection and in when someone logs in via
+  telnet.
+
 
 ## Common Problems
 

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -340,28 +340,7 @@
 #    define CONFIG_NSH_ROMFSMOUNTPT "/etc"
 #  endif
 
-#  ifndef CONFIG_NSH_SYSINITSCRIPT
-#    define CONFIG_NSH_SYSINITSCRIPT "init.d/rc.sysinit"
-#  endif
-
-#  ifndef CONFIG_NSH_INITSCRIPT
-#    define CONFIG_NSH_INITSCRIPT "init.d/rcS"
-#  endif
-
-#  undef NSH_SYSINITPATH
-#  define NSH_SYSINITPATH CONFIG_NSH_ROMFSMOUNTPT "/" CONFIG_NSH_SYSINITSCRIPT
-
-#  undef NSH_INITPATH
-#  define NSH_INITPATH CONFIG_NSH_ROMFSMOUNTPT "/" CONFIG_NSH_INITSCRIPT
-
 #  ifdef CONFIG_NSH_ROMFSRC
-#    ifndef CONFIG_NSH_RCSCRIPT
-#      define CONFIG_NSH_RCSCRIPT ".nshrc"
-#    endif
-
-#    undef NSH_RCPATH
-#    define NSH_RCPATH CONFIG_NSH_ROMFSMOUNTPT "/" CONFIG_NSH_RCSCRIPT
-#  endif
 
 #  ifndef CONFIG_NSH_ROMFSDEVNO
 #    define CONFIG_NSH_ROMFSDEVNO 0
@@ -376,14 +355,7 @@
 #  define MKMOUNT_DEVNAME(m) "/dev/ram" STR_RAMDEVNO(m)
 #  define MOUNT_DEVNAME      MKMOUNT_DEVNAME(CONFIG_NSH_ROMFSDEVNO)
 
-#else
-
-#  undef CONFIG_NSH_ROMFSRC
-#  undef CONFIG_NSH_ROMFSMOUNTPT
-#  undef CONFIG_NSH_INITSCRIPT
-#  undef CONFIG_NSH_RCSCRIPT
-#  undef CONFIG_NSH_ROMFSDEVNO
-#  undef CONFIG_NSH_ROMFSSECTSIZE
+#  endif
 
 #endif
 
@@ -835,13 +807,19 @@ int nsh_usbconsole(void);
 #if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
 int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                FAR const char *path);
-#ifdef CONFIG_NSH_ROMFSETC
+
+#ifdef CONFIG_NSH_RUNSYSINITSCRIPT
 int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl);
+#endif
+
+#ifdef CONFIG_NSH_RUNINITSCRIPT
 int nsh_initscript(FAR struct nsh_vtbl_s *vtbl);
-#ifdef CONFIG_NSH_ROMFSRC
+#endif
+
+#ifdef CONFIG_NSH_RUNRCSCRIPT
 int nsh_loginscript(FAR struct nsh_vtbl_s *vtbl);
 #endif
-#endif
+
 #endif
 
 /* Certain commands are only available if the boardctl() interface is

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -261,8 +261,8 @@ int nsh_consolemain(int argc, FAR char *argv[])
    * Any output will go to /dev/console.
    */
 
-#ifdef CONFIG_NSH_ROMFSETC
-  nsh_initscript(&pstate->cn_vtbl);
+#ifdef CONFIG_NSH_RUNSYSINITSCRIPT
+  nsh_sysinitscript(&pstate->cn_vtbl);
 #endif
 
 #ifdef CONFIG_NSH_NETINIT
@@ -275,6 +275,10 @@ int nsh_consolemain(int argc, FAR char *argv[])
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
+#ifdef CONFIG_NSH_RUNINITSCRIPT
+  nsh_initscript(&pstate->cn_vtbl);
 #endif
 
   /* First map stderr and stdout to alternative devices */

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -77,7 +77,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
   usbtrace_enable(TRACE_BITSET);
 #endif
 
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
+#if defined(CONFIG_NSH_RUNSYSINITSCRIPT) && !defined(CONFIG_NSH_DISABLESCRIPT)
   /* Execute the system init script */
 
   nsh_sysinitscript(&pstate->cn_vtbl);
@@ -95,7 +95,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
   boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
+#if defined(CONFIG_NSH_RUNINITSCRIPT) && !defined(CONFIG_NSH_DISABLESCRIPT)
   /* Execute the start-up script */
 
   nsh_initscript(&pstate->cn_vtbl);

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -34,7 +34,8 @@
  * Private Functions
  ****************************************************************************/
 
-#if defined(CONFIG_NSH_ROMFSETC) || defined(CONFIG_NSH_ROMFSRC)
+#if defined(CONFIG_NSH_RUNSYSINITSCRIPT) || defined(CONFIG_NSH_RUNINITSCRIPT) \
+ || defined(CONFIG_NSH_RUNRCSCRIPT)
 static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
                                FAR const char *cmd,
                                FAR const char *path)
@@ -191,10 +192,10 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NSH_ROMFSETC
+#ifdef CONFIG_NSH_RUNSYSINITSCRIPT
 int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl)
 {
-  return nsh_script_redirect(vtbl, "sysinit", NSH_SYSINITPATH);
+  return nsh_script_redirect(vtbl, "sysinit", CONFIG_NSH_SYSINITSCRIPT);
 }
 #endif
 
@@ -209,7 +210,7 @@ int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NSH_ROMFSETC
+#ifdef CONFIG_NSH_RUNINITSCRIPT
 int nsh_initscript(FAR struct nsh_vtbl_s *vtbl)
 {
   static bool initialized;
@@ -227,7 +228,7 @@ int nsh_initscript(FAR struct nsh_vtbl_s *vtbl)
 
   if (!already)
     {
-      ret = nsh_script_redirect(vtbl, "init", NSH_INITPATH);
+      ret = nsh_script_redirect(vtbl, "init", CONFIG_NSH_INITSCRIPT);
 #ifndef CONFIG_NSH_DISABLESCRIPT
       /* Reset the option flags */
 
@@ -247,10 +248,10 @@ int nsh_initscript(FAR struct nsh_vtbl_s *vtbl)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NSH_ROMFSRC
+#ifdef CONFIG_NSH_RUNRCSCRIPT
 int nsh_loginscript(FAR struct nsh_vtbl_s *vtbl)
 {
-  return nsh_script_redirect(vtbl, "login", NSH_RCPATH);
+  return nsh_script_redirect(vtbl, "login", CONFIG_NSH_RCSCRIPT);
 }
 #endif
 #endif /* CONFIG_NSH_ROMFSETC */

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -108,7 +108,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 
       /* Execute the login script */
 
-#ifdef CONFIG_NSH_ROMFSRC
+#ifdef CONFIG_NSH_RUNRCSCRIPT
       nsh_loginscript(vtbl);
 #endif
     }

--- a/nshlib/nsh_stdsession.c
+++ b/nshlib/nsh_stdsession.c
@@ -106,7 +106,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 
       /* Execute the login script */
 
-#ifdef CONFIG_NSH_ROMFSRC
+#ifdef CONFIG_NSH_RUNRCSCRIPT
       nsh_loginscript(vtbl);
 #endif
     }

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -117,7 +117,7 @@ int nsh_telnetmain(int argc, FAR char *argv[])
 
   /* Execute the login script */
 
-#ifdef CONFIG_NSH_ROMFSRC
+#ifdef CONFIG_NSH_RUNRCSCRIPT
   nsh_loginscript(vtbl);
 #endif
 
@@ -250,9 +250,9 @@ int nsh_telnetstart(sa_family_t family)
        * safe to call nsh_initscript multiple times).
        */
 
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
+#if defined(CONFIG_NSH_RUNSYSINITSCRIPT) && !defined(CONFIG_NSH_CONSOLE)
       pstate = nsh_newconsole();
-      nsh_initscript(&pstate->cn_vtbl);
+      nsh_sysinitscript(&pstate->cn_vtbl);
       nsh_release(&pstate->cn_vtbl);
 #endif
 
@@ -263,6 +263,12 @@ int nsh_telnetstart(sa_family_t family)
 #endif
 
       /* Perform architecture-specific final-initialization(if configured) */
+
+#if defined(CONFIG_NSH_RUNINITSCRIPT) && !defined(CONFIG_NSH_CONSOLE)
+      pstate = nsh_newconsole();
+      nsh_initscript(&pstate->cn_vtbl);
+      nsh_release(&pstate->cn_vtbl);
+#endif
 
 #if defined(CONFIG_NSH_ARCHINIT) && \
     defined(CONFIG_BOARDCTL_FINALINIT) && \

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -286,7 +286,7 @@ int nsh_consolemain(int argc, FAR char *argv[])
 
   /* Execute the one-time start-up script (output may go to /dev/null) */
 
-#ifdef CONFIG_NSH_ROMFSETC
+#ifdef CONFIG_NSH_RUNINITSCRIPT
   nsh_initscript(&pstate->cn_vtbl);
 #endif
 


### PR DESCRIPTION
## Summary
This is useful because the board can mount its own filesystem without requiring any particular type of filesystem and mountpoint.

## Impact
Anyone using nsh init scripts need to regenerate their config.

## Testing
Build is OK, Kconfig menus work as expected
New code with an init script on a custom FS runs on my custom stm32f429 "hn70ap" board.
