### PR TITLE
ostest/prioinherit: fix priority inheritance test when compiled without optimisation

### DIFF
--- a/testing/ostest/prioinherit.c
+++ b/testing/ostest/prioinherit.c
@@ -209,7 +209,7 @@ static int nhighpri_running(void)
  * Name: highpri_thread
  ****************************************************************************/
 
-static void *highpri_thread(void *parameter)
+static FAR void *highpri_thread(FAR void *parameter)
 {
   int threadno = (int)((intptr_t)parameter);
   int ret;
@@ -279,7 +279,7 @@ static inline void hog_cpu(void)
  * Name: medpri_thread
  ****************************************************************************/
 
-static void *medpri_thread(void *parameter)
+static FAR void *medpri_thread(FAR void *parameter)
 {
   printf("medpri_thread: Started ... I won't let go of the CPU!\n");
   g_middlestate = RUNNING;
@@ -305,9 +305,9 @@ static void *medpri_thread(void *parameter)
  * Name: lowpri_thread
  ****************************************************************************/
 
-static void *lowpri_thread(void *parameter)
+static FAR void *lowpri_thread(FAR void *parameter)
 {
-  void *retval = (void *) - 1;
+  FAR void *retval = (FAR void *)-1;
   struct sched_param sparam;
   int threadno = (int)((intptr_t)parameter);
   int expected;
@@ -502,7 +502,7 @@ void priority_inheritance(void)
   for (i = 0; i < NHIGHPRI_THREADS; i++) g_highstate[i] = NOTSTARTED;
   for (i = 0; i < NLOWPRI_THREADS; i++)  g_lowstate[i]  = NOTSTARTED;
 
-  status = sched_getparam (getpid(), &sparam);
+  status = sched_getparam(getpid(), &sparam);
   if (status != 0)
     {
       printf("priority_inheritance: sched_getparam failed\n");
@@ -550,7 +550,7 @@ void priority_inheritance(void)
         }
 
       status = pthread_create(&lowpri[i], &attr, lowpri_thread,
-                              (void *)((uintptr_t)threadno));
+                              (FAR void *)((uintptr_t)threadno));
       if (status != 0)
         {
           printf("priority_inheritance: "
@@ -631,7 +631,7 @@ void priority_inheritance(void)
       FFLUSH();
 
       status = pthread_create(&highpri[i], &attr, highpri_thread,
-                              (void *)((uintptr_t)threadno));
+                              (FAR void *)((uintptr_t)threadno));
       if (status != 0)
         {
           printf("priority_inheritance: "
@@ -686,8 +686,8 @@ void priority_inheritance(void)
       snprintf(args[1], sizeof(args[1]), "%d", i * 10000);
       snprintf(args[2], sizeof(args[2]), "%d", i == 0 ? 100000 : 1000);
 
-      pids[i] = task_create(name, priority, 1024, adversary,
-                            (FAR char * const *)argv);
+      pids[i] = task_create(name, priority, CONFIG_DEFAULT_TASK_STACKSIZE,
+                            adversary, (FAR char * const *)argv);
       priority += PRIORIY_SPREED;
     }
 


### PR DESCRIPTION
## Summary
When application is compiled without optimisation the stack usage is higher. 1K stack of `adversary` task is getting overflowed and that leads to crash. Set stack size to CONFIG_DEFAULT_TASK_STACKSIZE for `adversary` task.

## Impact
Improve stability of ostest

## Testing
ostest passed when compiled with `CONFIG_DEBUG_FULLOPT=n` on stm32f4-discovery and same70-qmtech boards.
