### PR TITLE
make export: Fix make export for CONFIG_BUILD_KERNEL=y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,9 @@ ifneq ($(EXPORTDIR),)
 ifneq ($(CONFIG_BUILD_KERNEL),y)
 ifneq ($(BUILTIN_REGISTRY),)
 	for f in "${BUILTIN_REGISTRY}"$(DELIM)*.bdat "${BUILTIN_REGISTRY}"$(DELIM)*.pdat ; do \
-		[ -f "$${f}" ] && cp -f "$${f}" "${EXPORTDIR}"$(DELIM)registry ; \
+		if [ -f "$${f}" ]; then \
+			cp -f "$${f}" "${EXPORTDIR}"$(DELIM)registry ; \
+		fi \
 	done
 endif
 endif


### PR DESCRIPTION
The condition:
[ -f "$${f}" ] && cp -f "$${f}" "${EXPORTDIR}"$(DELIM)registry ;

Fails if the first part of the condition returns empty / false, stopping make for no reason due to the error.

