### PR TITLE
poll: Don't need monitor POLLERR or POLLHUP explicitly

### DIFF
--- a/examples/tcpblaster/tcpblaster_client.c
+++ b/examples/tcpblaster/tcpblaster_client.c
@@ -148,7 +148,7 @@ void tcpblaster_client(void)
 
       memset(fds, 0, 1 * sizeof(struct pollfd));
       fds[0].fd     = sockfd;
-      fds[0].events = POLLOUT | POLLHUP;
+      fds[0].events = POLLOUT;
 
       /* Wait until we can send data or until the connection is lost */
 

--- a/examples/tcpblaster/tcpblaster_server.c
+++ b/examples/tcpblaster/tcpblaster_server.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/tcpblaster/tcpblaster-server.c
+ * apps/examples/tcpblaster/tcpblaster_server.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -191,7 +191,7 @@ void tcpblaster_server(void)
 
       memset(fds, 0, 1 * sizeof(struct pollfd));
       fds[0].fd     = acceptsd;
-      fds[0].events = POLLIN | POLLHUP;
+      fds[0].events = POLLIN;
 
       /* Wait until we can receive data or until the connection is lost */
 

--- a/examples/udpblaster/udpblaster_target.c
+++ b/examples/udpblaster/udpblaster_target.c
@@ -290,7 +290,7 @@ int main(int argc, FAR char *argv[])
 
       memset(fds, 0, 1 * sizeof(struct pollfd));
       fds[0].fd     = sockfd;
-      fds[0].events = POLLOUT | POLLHUP;
+      fds[0].events = POLLOUT;
 
       /* Wait until we can send data or until the connection is lost */
 

--- a/graphics/twm4nx/src/cinput.cxx
+++ b/graphics/twm4nx/src/cinput.cxx
@@ -785,12 +785,12 @@ int CInput::session(void)
       struct pollfd pfd[NINPUT_DEVICES];
 #ifndef CONFIG_TWM4NX_NOKEYBOARD
       pfd[KBD_INDEX].fd        = m_kbdFd;
-      pfd[KBD_INDEX].events    = POLLIN | POLLERR | POLLHUP;
+      pfd[KBD_INDEX].events    = POLLIN;
       pfd[KBD_INDEX].revents   = 0;
 #endif
 #ifndef CONFIG_TWM4NX_NOMOUSE
       pfd[MOUSE_INDEX].fd      = m_mouseFd;
-      pfd[MOUSE_INDEX].events  = POLLIN | POLLERR | POLLHUP;
+      pfd[MOUSE_INDEX].events  = POLLIN;
       pfd[MOUSE_INDEX].revents = 0;
 #endif
 

--- a/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
+++ b/netutils/usrsock_rpmsg/usrsock_rpmsg_server.c
@@ -942,7 +942,7 @@ static int usrsock_rpmsg_prepare_poll(struct usrsock_rpmsg_s *priv,
       if (priv->pfds[i].ptr)
         {
           pfds[count] = priv->pfds[i];
-          pfds[count++].events |= POLLERR | POLLHUP | POLLSOCK;
+          pfds[count++].events |= POLLSOCK;
         }
     }
 


### PR DESCRIPTION
## Summary
since spec require the implementation always report POLLERR/POLLHUP: https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
Follow nuttx patch: https://github.com/apache/incubator-nuttx/pull/7227

## Impact
Minor

## Testing
Pass CI
