### PR TITLE
wapi: Verify if password size if valid

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -546,8 +546,18 @@ static int wapi_psk_cmd(int sock, int argc, FAR char **argv)
 {
   enum wpa_alg_e alg_flag;
   uint8_t auth_wpa;
+  int passlen;
   int cipher;
   int ret;
+
+  /* Check if password len >= 8 && <= 63 */
+
+  passlen = strnlen(argv[1], 64);
+  if (passlen < 8 || passlen > 63)
+    {
+      printf("The password should have between 8 and 63 characters!\n");
+      return -EINVAL;
+    }
 
   /* Convert input strings to values */
 


### PR DESCRIPTION
## Summary
Avoid setting a password with invalid size, according with IEEE802.11i:
"A pass-phrase is a sequence of between 8 and 63 ASCII-encoded characters. The limit of 63 comes from the desire to distinguish between a pass-phrase and a PSK displayed as 64 hexadecimal characters."
## Impact
Some WIFI libs like the ESP32 expects that the password size respect the norm.
## Testing
```
nsh> wapi psk wlan1 SmallP 3
The password should have between 8 and 63 characters!
ERROR: Process command (psk) failed.
```
