### PR TITLE
examples: clean warning of pipe

### DIFF
--- a/examples/pipe/transfer_test.c
+++ b/examples/pipe/transfer_test.c
@@ -63,53 +63,76 @@
 static void *transfer_reader(pthread_addr_t pvarg)
 {
   char buffer[READ_SIZE];
-  int fd = (int)pvarg;
+  int fd = (intptr_t)pvarg;
   int ret;
   int nbytes;
   int value;
   int ndx;
+  void *p;
 
   printf("transfer_reader: started\n");
-  for (nbytes = 0, value = 0; nbytes < NREAD_BYTES;)
+  for (nbytes = 0, value = 0; nbytes < NREAD_BYTES; )
     {
       ret = read(fd, buffer, READ_SIZE);
-      if (ret < 0 )
+      if (ret < 0)
         {
-           fprintf(stderr, "transfer_reader: read failed, errno=%d\n", errno);
-           return (void*)1;
+          fprintf(stderr, \
+          "transfer_reader: read failed, errno=%d\n", \
+          errno);
+
+          p = (void *) 1;
+          return p;
         }
       else if (ret == 0)
         {
           if (nbytes < NREAD_BYTES)
             {
-              fprintf(stderr, "transfer_reader: Too few bytes read -- aborting: %d\n", nbytes);
-              return (void*)2;
+              fprintf(stderr, \
+              "transfer_reader: Too few bytes read -- aborting: %d\n", \
+              nbytes);
+
+              p = (void *) 2;
+              return p;
             }
-          break;
+            break;
         }
+
       for (ndx = 0; ndx < ret; ndx++)
         {
           if (value >= WRITE_SIZE)
             {
               value = 0;
             }
+
           if (buffer[ndx] != value)
             {
-              fprintf(stderr, "transfer_reader: Byte %d, expected %d, found %d\n",
-                      nbytes + ndx, value, buffer[ndx]);
-              return (void*)3;
+              fprintf(stderr, \
+              "transfer_reader: Byte %d, expected %d, found %d\n",
+                    nbytes + ndx, value, buffer[ndx]);
+
+              p = (void *) 3;
+              return p;
             }
+
           value++;
         }
+
       nbytes += ret;
       if (nbytes > NREAD_BYTES)
         {
-          fprintf(stderr, "transfer_reader: Too many bytes read -- aborting: %d\n", nbytes);
-          return (void*)4;
+          fprintf(stderr, \
+          "transfer_reader: Too many bytes read -- aborting: %d\n", \
+          nbytes);
+
+          p = (void *) 4;
+          return p;
         }
     }
+
   printf("transfer_reader: %d bytes read\n", nbytes);
-  return (void*)0;
+
+  p = (void *) 0;
+  return p;
 }
 
 /****************************************************************************
@@ -119,9 +142,10 @@ static void *transfer_reader(pthread_addr_t pvarg)
 static void *transfer_writer(pthread_addr_t pvarg)
 {
   char buffer[WRITE_SIZE];
-  int fd = (int)pvarg;
+  int fd = (intptr_t)pvarg;
   int ret;
   int i;
+  void *p;
 
   printf("transfer_writer: started\n");
   for (i = 0; i < WRITE_SIZE; i++)
@@ -132,19 +156,25 @@ static void *transfer_writer(pthread_addr_t pvarg)
   for (i = 0; i < NWRITES; i++)
     {
       ret = write(fd, buffer, WRITE_SIZE);
-      if (ret < 0 )
+      if (ret < 0)
         {
-           fprintf(stderr, "transfer_writer: write failed, errno=%d\n", errno);
-           return (void*)1;
+          fprintf(stderr, \
+          "transfer_writer: write failed, errno=%d\n", errno);
+          p = (void *) 1;
+          return p;
         }
       else if (ret != WRITE_SIZE)
         {
-           fprintf(stderr, "transfer_writer: Unexpected write size=%d\n", ret);
-           return (void*)2;
+          fprintf(stderr, \
+          "transfer_writer: Unexpected write size=%d\n", ret);
+          p = (void *) 2;
+          return p;
         }
     }
+
   printf("transfer_writer: %d bytes written\n", NWRITE_BYTES);
-  return (void*)0;
+  p = (void *) 0;
+  return p;
 }
 
 /****************************************************************************
@@ -165,27 +195,37 @@ int transfer_test(int fdin, int fdout)
 
   /* Start transfer_reader thread */
 
-  printf("transfer_test: Starting transfer_reader thread\n");
-  ret = pthread_create(&readerid, NULL, transfer_reader, (pthread_addr_t)fdin);
+  printf("transfer_test: \
+        Starting transfer_reader thread\n");
+  ret = pthread_create(&readerid, NULL, \
+        transfer_reader, (void *)(intptr_t)fdin);
   if (ret != 0)
     {
-      fprintf(stderr, "transfer_test: Failed to create transfer_reader thread, error=%d\n", ret);
+        fprintf(stderr, \
+        "transfer_test: Failed to create transfer_reader thread, \
+        error=%d\n", ret);
       return 1;
     }
 
   /* Start transfer_writer thread */
 
   printf("transfer_test: Starting transfer_writer thread\n");
-  ret = pthread_create(&writerid, NULL, transfer_writer, (pthread_addr_t)fdout);
+  ret = pthread_create(&writerid, \
+        NULL, transfer_writer, (void *)(intptr_t)fdout);
   if (ret != 0)
     {
-      fprintf(stderr, "transfer_test: Failed to create transfer_writer thread, error=%d\n", ret);
+      fprintf(stderr, \
+        "transfer_test: Failed to create transfer_writer thread, \
+        error=%d\n", ret);
       pthread_detach(readerid);
       ret = pthread_cancel(readerid);
       if (ret != 0)
         {
-          fprintf(stderr, "transfer_test: Failed to cancel transfer_reader thread, error=%d\n", ret);
+          fprintf(stderr, \
+            "transfer_test: Failed to cancel transfer_reader thread, \
+            error=%d\n", ret);
         }
+
       return 2;
     }
 
@@ -199,7 +239,7 @@ int transfer_test(int fdin, int fdout)
     }
   else
     {
-      ret = (int)value;
+      ret = (intptr_t)value;
       printf("transfer_test: transfer_writer returned %d\n", ret);
     }
 
@@ -213,7 +253,7 @@ int transfer_test(int fdin, int fdout)
     }
   else
     {
-      tmp = (int)value;
+      tmp = (intptr_t)value;
       printf("transfer_test: transfer_reader returned %d\n", tmp);
     }
 
@@ -221,6 +261,8 @@ int transfer_test(int fdin, int fdout)
     {
       ret = tmp;
     }
+
   printf("transfer_test: returning %d\n", ret);
   return ret;
 }
+


### PR DESCRIPTION

## Summary
clean example pipe build warning 

transfer_test.c:66:12: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   int fd = (int)pvarg;
            ^
transfer_test.c: In function 'transfer_writer':
transfer_test.c:122:12: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   int fd = (int)pvarg;
            ^
transfer_test.c: In function 'transfer_test':
transfer_test.c:169:58: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   ret = pthread_create(&readerid, NULL, transfer_reader, (pthread_addr_t)fdin);
                                                          ^
transfer_test.c:179:58: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   ret = pthread_create(&writerid, NULL, transfer_writer, (pthread_addr_t)fdout);
                                                          ^
transfer_test.c:202:13: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
       ret = (int)value;
             ^
transfer_test.c:216:13: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
       tmp = (int)value;
             ^

Signed-off-by: nietingting <nietingting@xiaomi.com>

## Impact
no
## Testing
test on local 
