### PR TITLE
Refine nshlib implementation

### DIFF
--- a/examples/nxterm/nxterm_main.c
+++ b/examples/nxterm/nxterm_main.c
@@ -223,22 +223,6 @@ int main(int argc, FAR char *argv[])
   printf("nxterm_main: Initialize NSH\n");
   nsh_initialize();
 
-  /* If the Telnet console is selected as a front-end, then start the
-   * Telnet daemon.
-   */
-
-#ifdef CONFIG_NSH_TELNET
-  ret = nsh_telnetstart(AF_UNSPEC);
-  if (ret < 0)
-    {
-      /* The daemon is NOT running.  Report the error then fail...
-       * either with the serial console up or just exiting.
-       */
-
-      fprintf(stderr, "ERROR: Failed to start TELNET daemon: %d\n", ret);
-    }
-#endif
-
   /* NX Initialization ******************************************************/
 
   /* Initialize NX */

--- a/graphics/nxwm/src/cnxterm.cxx
+++ b/graphics/nxwm/src/cnxterm.cxx
@@ -653,19 +653,5 @@ bool NxWM::nshlibInitialize(void)
   // Initialize the NSH library
 
   nsh_initialize();
-
-  // If the Telnet console is selected as a front-end, then start the
-  // Telnet daemon.
-
-#ifdef CONFIG_NSH_TELNET
-  int ret = nsh_telnetstart(AF_UNSPEC);
-  if (ret < 0)
-    {
-      // The daemon is NOT running!
-
-      return false;
-   }
-#endif
-
   return true;
 }

--- a/graphics/twm4nx/apps/cnxterm.cxx
+++ b/graphics/twm4nx/apps/cnxterm.cxx
@@ -574,20 +574,6 @@ bool CNxTermFactory::nshlibInitialize(void)
   // Initialize the NSH library
 
   nsh_initialize();
-
-  // If the Telnet console is selected as a front-end, then start the
-  // Telnet daemon.
-
-#ifdef CONFIG_NSH_TELNET
-  int ret = nsh_telnetstart(AF_UNSPEC);
-  if (ret < 0)
-    {
-      // The daemon is NOT running!
-
-      return false;
-   }
-#endif
-
   return true;
 }
 

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -34,8 +34,6 @@
 #include "nsh.h"
 #include "nsh_console.h"
 
-#include "netutils/netinit.h"
-
 #if defined(CONFIG_NSH_ALTCONDEV) && !defined(HAVE_USB_CONSOLE)
 
 /****************************************************************************
@@ -250,38 +248,6 @@ int nsh_consolemain(int argc, FAR char *argv[])
   int ret;
 
   DEBUGASSERT(pstate);
-
-  /* Initialize any USB tracing options that were requested */
-
-#ifdef CONFIG_NSH_USBDEV_TRACE
-  usbtrace_enable(TRACE_BITSET);
-#endif
-
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
-  /* Execute the system init script */
-
-  nsh_sysinitscript(&pstate->cn_vtbl);
-#endif
-
-#ifdef CONFIG_NSH_NETINIT
-  /* Bring up the network */
-
-  netinit_bringup();
-#endif
-
-#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
-  /* Perform architecture-specific final-initialization (if configured) */
-
-  boardctl(BOARDIOC_FINALINIT, 0);
-#endif
-
-  /* Execute the one-time start-up script.
-   * Any output will go to /dev/console.
-   */
-
-#ifdef CONFIG_NSH_ROMFSETC
-  nsh_initscript(&pstate->cn_vtbl);
-#endif
 
   /* First map stderr and stdout to alternative devices */
 

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -257,12 +257,10 @@ int nsh_consolemain(int argc, FAR char *argv[])
   usbtrace_enable(TRACE_BITSET);
 #endif
 
-  /* Execute the one-time start-up script.
-   * Any output will go to /dev/console.
-   */
+#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
+  /* Execute the system init script */
 
-#ifdef CONFIG_NSH_ROMFSETC
-  nsh_initscript(&pstate->cn_vtbl);
+  nsh_sysinitscript(&pstate->cn_vtbl);
 #endif
 
 #ifdef CONFIG_NSH_NETINIT
@@ -277,10 +275,17 @@ int nsh_consolemain(int argc, FAR char *argv[])
   boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
+  /* Execute the one-time start-up script.
+   * Any output will go to /dev/console.
+   */
+
+#ifdef CONFIG_NSH_ROMFSETC
+  nsh_initscript(&pstate->cn_vtbl);
+#endif
+
   /* First map stderr and stdout to alternative devices */
 
   ret = nsh_clone_console(pstate);
-
   if (ret < 0)
     {
       return ret;

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -32,8 +32,6 @@
 #include "nsh.h"
 #include "nsh_console.h"
 
-#include "netutils/netinit.h"
-
 #if !defined(CONFIG_NSH_ALTCONDEV) && !defined(HAVE_USB_CONSOLE) && \
     !defined(HAVE_USB_KEYBOARD)
 
@@ -70,36 +68,6 @@ int nsh_consolemain(int argc, FAR char *argv[])
   int ret;
 
   DEBUGASSERT(pstate != NULL);
-
-#ifdef CONFIG_NSH_USBDEV_TRACE
-  /* Initialize any USB tracing options that were requested */
-
-  usbtrace_enable(TRACE_BITSET);
-#endif
-
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
-  /* Execute the system init script */
-
-  nsh_sysinitscript(&pstate->cn_vtbl);
-#endif
-
-#ifdef CONFIG_NSH_NETINIT
-  /* Bring up the network */
-
-  netinit_bringup();
-#endif
-
-#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
-  /* Perform architecture-specific final-initialization (if configured) */
-
-  boardctl(BOARDIOC_FINALINIT, 0);
-#endif
-
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
-  /* Execute the start-up script */
-
-  nsh_initscript(&pstate->cn_vtbl);
-#endif
 
   /* Execute the session */
 

--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -54,7 +54,7 @@ static const struct extmatch_vtable_s g_nsh_extmatch =
  * Description:
  *   This interface is used to initialize the NuttShell (NSH).
  *   nsh_initialize() should be called once during application start-up prior
- *   to executing either nsh_consolemain() or nsh_telnetstart().
+ *   to executing nsh_consolemain().
  *
  * Input Parameters:
  *   None
@@ -86,5 +86,17 @@ void nsh_initialize(void)
   /* Perform architecture-specific initialization (if configured) */
 
   boardctl(BOARDIOC_INIT, 0);
+#endif
+
+#if defined(CONFIG_NSH_TELNET) && !defined(CONFIG_NSH_DISABLE_TELNETSTART) && \
+  !defined(CONFIG_NETINIT_NETLOCAL)
+  /* If the Telnet console is selected as a front-end, then start the
+   * Telnet daemon UNLESS network initialization is deferred via
+   * CONFIG_NETINIT_NETLOCAL.  In that case, the telnet daemon must be
+   * started manually with the telnetd command after the network has
+   * been initialized
+   */
+
+  nsh_telnetstart(AF_UNSPEC);
 #endif
 }

--- a/nshlib/nsh_telnetd.c
+++ b/nshlib/nsh_telnetd.c
@@ -31,7 +31,6 @@
 
 #include <arpa/inet.h>
 
-#include "netutils/netinit.h"
 #include "netutils/telnetd.h"
 
 #ifdef CONFIG_TELNET_CHARACTER_MODE
@@ -225,9 +224,6 @@ int nsh_telnetstart(sa_family_t family)
 
   if (state == TELNETD_NOTRUNNING)
     {
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
-      FAR struct console_stdio_s *pstate;
-#endif
       struct telnetd_config_s config;
 
       /* There is a tiny race condition here if two tasks were to try to
@@ -235,40 +231,6 @@ int nsh_telnetstart(sa_family_t family)
        */
 
       state = TELNETD_STARTED;
-
-      /* Initialize any USB tracing options that were requested.  If
-       * standard console is also defined, then we will defer this step to
-       * the standard console.
-       */
-
-#if defined(CONFIG_NSH_USBDEV_TRACE) && !defined(CONFIG_NSH_CONSOLE)
-      usbtrace_enable(TRACE_BITSET);
-#endif
-
-      /* Execute the startup script.  If standard console is also defined,
-       * then we will not bother with the initscript here (although it is
-       * safe to call nsh_initscript multiple times).
-       */
-
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_CONSOLE)
-      pstate = nsh_newconsole();
-      nsh_initscript(&pstate->cn_vtbl);
-      nsh_release(&pstate->cn_vtbl);
-#endif
-
-#if defined(CONFIG_NSH_NETINIT) && !defined(CONFIG_NSH_CONSOLE)
-      /* Bring up the network */
-
-      netinit_bringup();
-#endif
-
-      /* Perform architecture-specific final-initialization(if configured) */
-
-#if defined(CONFIG_NSH_ARCHINIT) && \
-    defined(CONFIG_BOARDCTL_FINALINIT) && \
-    !defined(CONFIG_NSH_CONSOLE)
-      boardctl(BOARDIOC_FINALINIT, 0);
-#endif
 
       /* Configure the telnet daemon */
 

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -284,10 +284,10 @@ int nsh_consolemain(int argc, FAR char *argv[])
   nsh_nullstdio();
 #endif
 
-  /* Execute the one-time start-up script (output may go to /dev/null) */
+#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
+  /* Execute the system init script */
 
-#ifdef CONFIG_NSH_ROMFSETC
-  nsh_initscript(&pstate->cn_vtbl);
+  nsh_sysinitscript(&pstate->cn_vtbl);
 #endif
 
 #ifdef CONFIG_NSH_NETINIT
@@ -300,6 +300,12 @@ int nsh_consolemain(int argc, FAR char *argv[])
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
+  /* Execute the one-time start-up script (output may go to /dev/null) */
+
+#ifdef CONFIG_NSH_ROMFSETC
+  nsh_initscript(&pstate->cn_vtbl);
 #endif
 
   /* Now loop, executing creating a session for each USB connection */

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -248,12 +248,6 @@ int nsh_consolemain(int argc, FAR char *argv[])
 
   DEBUGASSERT(pstate);
 
-  /* Initialize any USB tracing options that were requested */
-
-#ifdef CONFIG_NSH_USBDEV_TRACE
-  usbtrace_enable(TRACE_BITSET);
-#endif
-
   /* Initialize the USB serial driver */
 
 #if defined(CONFIG_PL2303) || defined(CONFIG_CDCACM)
@@ -282,30 +276,6 @@ int nsh_consolemain(int argc, FAR char *argv[])
 
 #ifndef CONFIG_DEV_CONSOLE
   nsh_nullstdio();
-#endif
-
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
-  /* Execute the system init script */
-
-  nsh_sysinitscript(&pstate->cn_vtbl);
-#endif
-
-#ifdef CONFIG_NSH_NETINIT
-  /* Bring up the network */
-
-  netinit_bringup();
-#endif
-
-#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
-  /* Perform architecture-specific final-initialization (if configured) */
-
-  boardctl(BOARDIOC_FINALINIT, 0);
-#endif
-
-  /* Execute the one-time start-up script (output may go to /dev/null) */
-
-#ifdef CONFIG_NSH_ROMFSETC
-  nsh_initscript(&pstate->cn_vtbl);
 #endif
 
   /* Now loop, executing creating a session for each USB connection */

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -127,27 +127,6 @@ int main(int argc, FAR char *argv[])
 
   nsh_initialize();
 
-#if defined(CONFIG_NSH_TELNET) && !defined(CONFIG_NSH_DISABLE_TELNETSTART) && \
-  !defined(CONFIG_NETINIT_NETLOCAL)
-  /* If the Telnet console is selected as a front-end, then start the
-   * Telnet daemon UNLESS network initialization is deferred via
-   * CONFIG_NETINIT_NETLOCAL.  In that case, the telnet daemon must be
-   * started manually with the telnetd command after the network has
-   * been initialized
-   */
-
-  ret = nsh_telnetstart(AF_UNSPEC);
-  if (ret < 0)
-    {
-      /* The daemon is NOT running.  Report the error then fail...
-       * either with the serial console up or just exiting.
-       */
-
-      fprintf(stderr, "ERROR: Failed to start TELNET daemon: %d\n", ret);
-      exitval = 1;
-    }
-#endif
-
 #ifdef CONFIG_NSH_CONSOLE
   /* If the serial console front end is selected, run it on this thread */
 

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -31,53 +31,16 @@
 #include <sched.h>
 #include <errno.h>
 
-#if defined(CONFIG_LIBC_EXECFUNCS)
-#  include <nuttx/symtab.h>
-#endif
-
 #include "nshlib/nshlib.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Symbol table is not needed if loadable binary modules are not supported */
-
-#if !defined(CONFIG_LIBC_EXECFUNCS)
-#  undef CONFIG_SYSTEM_NSH_SYMTAB
-#endif
-
-/* boardctl() support is also required for application-space symbol table
- * support.
- */
-
-#if !defined(CONFIG_BOARDCTL) || !defined(CONFIG_BOARDCTL_APP_SYMTAB)
-#  undef CONFIG_SYSTEM_NSH_SYMTAB
-#endif
-
-/* If a symbol table is provided by board-specific logic, then we do not
- * need to do anything from the application space.
- */
-
-#ifdef CONFIG_EXECFUNCS_HAVE_SYMTAB
-#  undef CONFIG_SYSTEM_NSH_SYMTAB
-#endif
-
 /* The NSH telnet console requires networking support (and TCP/IP) */
 
 #ifndef CONFIG_NET
 #  undef CONFIG_NSH_TELNET
-#endif
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-#if defined(CONFIG_SYSTEM_NSH_SYMTAB)
-
-extern const struct symtab_s CONFIG_SYSTEM_NSH_SYMTAB_ARRAYNAME[];
-extern const int CONFIG_SYSTEM_NSH_SYMTAB_COUNTNAME;
-
 #endif
 
 /****************************************************************************
@@ -96,9 +59,6 @@ extern const int CONFIG_SYSTEM_NSH_SYMTAB_COUNTNAME;
 
 int main(int argc, FAR char *argv[])
 {
-#if defined (CONFIG_SYSTEM_NSH_SYMTAB)
-  struct boardioc_symtab_s symdesc;
-#endif
   struct sched_param param;
   int ret = 0;
 
@@ -112,15 +72,6 @@ int main(int argc, FAR char *argv[])
       param.sched_priority = CONFIG_SYSTEM_NSH_PRIORITY;
       sched_setparam(0, &param);
     }
-
-#if defined(CONFIG_SYSTEM_NSH_SYMTAB)
-  /* Make sure that we are using our symbol table */
-
-  symdesc.symtab   = (FAR struct symtab_s *)CONFIG_SYSTEM_NSH_SYMTAB_ARRAYNAME; /* Discard 'const' */
-  symdesc.nsymbols = CONFIG_SYSTEM_NSH_SYMTAB_COUNTNAME;
-
-  boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
-#endif
 
   /* Initialize the NSH library */
 

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -100,8 +100,7 @@ int main(int argc, FAR char *argv[])
   struct boardioc_symtab_s symdesc;
 #endif
   struct sched_param param;
-  int exitval = 0;
-  int ret;
+  int ret = 0;
 
   /* Check the task priority that we were started with */
 
@@ -137,8 +136,8 @@ int main(int argc, FAR char *argv[])
    */
 
   fprintf(stderr, "ERROR: nsh_consolemain() returned: %d\n", ret);
-  exitval = 1;
+  ret = 1;
 #endif
 
-  return exitval;
+  return ret;
 }


### PR DESCRIPTION
## Summary

- nshlib: Call nsh_sysinitscript in usb or alt console like normal one
- nshlib: Call nsh_telnetstart in nsh_initialize to avoid the dupliation
- nshlib: Move commoin initialization from console_main to nsh_initialize

## Impact
nshlib

## Testing
sim:nsh
