### PR TITLE
Make.defs: Change "ifeq ($(XXX),y)" to "ifneq ($(XXX),)

### DIFF
--- a/audioutils/fmsynth/Make.defs
+++ b/audioutils/fmsynth/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_AUDIOUTILS_FMSYNTH_LIB),y)
+ifneq ($(CONFIG_AUDIOUTILS_FMSYNTH_LIB),)
 CONFIGURED_APPS += $(APPDIR)/audioutils/fmsynth
 endif

--- a/audioutils/mml_parser/Make.defs
+++ b/audioutils/mml_parser/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_AUDIOUTILS_MMLPARSER_LIB),y)
+ifneq ($(CONFIG_AUDIOUTILS_MMLPARSER_LIB),)
 CONFIGURED_APPS += $(APPDIR)/audioutils/mml_parser
 endif

--- a/audioutils/nxaudio/Make.defs
+++ b/audioutils/nxaudio/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_AUDIOUTILS_NXAUDIO_LIB),y)
+ifneq ($(CONFIG_AUDIOUTILS_NXAUDIO_LIB),)
 CONFIGURED_APPS += $(APPDIR)/audioutils/nxaudio
 endif

--- a/boot/mcuboot/Make.defs
+++ b/boot/mcuboot/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_BOOT_MCUBOOT),y)
+ifneq ($(CONFIG_BOOT_MCUBOOT),)
 CONFIGURED_APPS += $(APPDIR)/boot/mcuboot
 
 # It allows import of NuttX implementation headers for MCUboot interfaces.
@@ -33,7 +33,7 @@ CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboo
 
 # It allows import of MCUboot's crypto backend library headers.
 
-ifeq ($(CONFIG_MCUBOOT_USE_TINYCRYPT),y)
+ifneq ($(CONFIG_MCUBOOT_USE_TINYCRYPT),)
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/ext/tinycrypt/lib/include}
 CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/ext/tinycrypt/lib/include}
 endif

--- a/builtin/Make.defs
+++ b/builtin/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_BUILTIN),y)
+ifneq ($(CONFIG_BUILTIN),)
 CONFIGURED_APPS += $(APPDIR)/builtin
 endif

--- a/canutils/canlib/Make.defs
+++ b/canutils/canlib/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CANUTILS_CANLIB),y)
+ifneq ($(CONFIG_CANUTILS_CANLIB),)
 CONFIGURED_APPS += $(APPDIR)/canutils/canlib
 endif

--- a/canutils/libcanardv0/Make.defs
+++ b/canutils/libcanardv0/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CANUTILS_LIBCANARDV0),y)
+ifneq ($(CONFIG_CANUTILS_LIBCANARDV0),)
 CONFIGURED_APPS += $(APPDIR)/canutils/libcanardv0
 endif

--- a/canutils/libcanardv1/Make.defs
+++ b/canutils/libcanardv1/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CANUTILS_LIBCANARDV1),y)
+ifneq ($(CONFIG_CANUTILS_LIBCANARDV1),)
 CONFIGURED_APPS += $(APPDIR)/canutils/libcanardv1
 endif

--- a/canutils/libcanutils/Make.defs
+++ b/canutils/libcanutils/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################/
 
-ifeq ($(CONFIG_CANUTILS_LIBCANUTILS),y)
+ifneq ($(CONFIG_CANUTILS_LIBCANUTILS),)
 CONFIGURED_APPS += $(APPDIR)/canutils/libcanutils
 endif

--- a/canutils/libobd2/Make.defs
+++ b/canutils/libobd2/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CANUTILS_LIBOBD2),y)
+ifneq ($(CONFIG_CANUTILS_LIBOBD2),)
 CONFIGURED_APPS += $(APPDIR)/canutils/libobd2
 endif

--- a/crypto/libtomcrypt/Make.defs
+++ b/crypto/libtomcrypt/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CRYPTO_LIBTOMCRYPT),y)
+ifneq ($(CONFIG_CRYPTO_LIBTOMCRYPT),)
 CONFIGURED_APPS += $(APPDIR)/crypto/libtomcrypt
 
 # It allows `<tomcrypt.h>` import.

--- a/crypto/mbedtls/Make.defs
+++ b/crypto/mbedtls/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CRYPTO_MBEDTLS),y)
+ifneq ($(CONFIG_CRYPTO_MBEDTLS),)
 CONFIGURED_APPS += $(APPDIR)/crypto/mbedtls
 
 # Allows `<mbedtls/<>.h>` import.

--- a/examples/audio_rttl/Make.defs
+++ b/examples/audio_rttl/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_AUDIO_SOUND),y)
+ifneq ($(CONFIG_EXAMPLES_AUDIO_SOUND),)
 CONFIGURED_APPS += examples/audio_rttl
 endif

--- a/examples/bmi160/Make.defs
+++ b/examples/bmi160/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_SIXAXIS),y)
+ifneq ($(CONFIG_EXAMPLES_SIXAXIS),)
 CONFIGURED_APPS += examples/bmi160
 endif

--- a/examples/charger/Make.defs
+++ b/examples/charger/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_CHARGER),y)
+ifneq ($(CONFIG_EXAMPLES_CHARGER),)
 CONFIGURED_APPS += examples/charger
 endif

--- a/examples/foc/Make.defs
+++ b/examples/foc/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_FOC),y)
+ifneq ($(CONFIG_EXAMPLES_FOC),)
 CONFIGURED_APPS += examples/foc
 endif

--- a/examples/fxos8700cq_test/Make.defs
+++ b/examples/fxos8700cq_test/Make.defs
@@ -18,6 +18,6 @@
 #
 #############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_FXOS8700CQ),y)
+ifneq ($(CONFIG_EXAMPLES_FXOS8700CQ),)
 CONFIGURED_APPS += examples/fxos8700cq_test
 endif

--- a/examples/hts221_reader/Make.defs
+++ b/examples/hts221_reader/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_HTS221_READER),y)
+ifneq ($(CONFIG_EXAMPLES_HTS221_READER),)
 CONFIGURED_APPS += examples/hts221_reader
 endif

--- a/examples/lsm303_reader/Make.defs
+++ b/examples/lsm303_reader/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_LSM303_READER),y)
+ifneq ($(CONFIG_EXAMPLES_LSM303_READER),)
 CONFIGURED_APPS += examples/lsm303_reader
 endif

--- a/examples/lsm6dsl_reader/Make.defs
+++ b/examples/lsm6dsl_reader/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_LSM6DSL_READER),y)
+ifneq ($(CONFIG_EXAMPLES_LSM6DSL_READER),)
 CONFIGURED_APPS += examples/lsm6dsl_reader
 endif

--- a/examples/timer_gpio/Make.defs
+++ b/examples/timer_gpio/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EXAMPLES_TIMER_GPIO),y)
+ifneq ($(CONFIG_EXAMPLES_TIMER_GPIO),)
 CONFIGURED_APPS += $(APPDIR)/examples/timer_gpio
 endif

--- a/fsutils/flash_eraseall/Make.defs
+++ b/fsutils/flash_eraseall/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_FLASH_ERASEALL),y)
+ifneq ($(CONFIG_FSUTILS_FLASH_ERASEALL),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/flash_eraseall
 endif

--- a/fsutils/inifile/Make.defs
+++ b/fsutils/inifile/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_INIFILE),y)
+ifneq ($(CONFIG_FSUTILS_INIFILE),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/inifile
 endif

--- a/fsutils/inih/Make.defs
+++ b/fsutils/inih/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_INIH),y)
+ifneq ($(CONFIG_FSUTILS_INIH),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/inih
 endif

--- a/fsutils/ipcfg/Make.defs
+++ b/fsutils/ipcfg/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_IPCFG),y)
+ifneq ($(CONFIG_FSUTILS_IPCFG),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/ipcfg
 endif

--- a/fsutils/mkfatfs/Make.defs
+++ b/fsutils/mkfatfs/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_MKFATFS),y)
+ifneq ($(CONFIG_FSUTILS_MKFATFS),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/mkfatfs
 endif

--- a/fsutils/mksmartfs/Make.defs
+++ b/fsutils/mksmartfs/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_MKSMARTFS),y)
+ifneq ($(CONFIG_FSUTILS_MKSMARTFS),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/mksmartfs
 endif

--- a/fsutils/passwd/Make.defs
+++ b/fsutils/passwd/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_FSUTILS_PASSWD),y)
+ifneq ($(CONFIG_FSUTILS_PASSWD),)
 CONFIGURED_APPS += $(APPDIR)/fsutils/passwd
 endif

--- a/games/shift/Make.defs
+++ b/games/shift/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GAMES_SHIFT),y)
+ifneq ($(CONFIG_GAMES_SHIFT),)
 CONFIGURED_APPS += $(APPDIR)/games/shift
 endif

--- a/gpsutils/minmea/Make.defs
+++ b/gpsutils/minmea/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GPSUTILS_MINMEA_LIB),y)
+ifneq ($(CONFIG_GPSUTILS_MINMEA_LIB),)
 CONFIGURED_APPS += $(APPDIR)/gpsutils/minmea
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
     $(APPDIR)/gpsutils/minmea}

--- a/graphics/ft80x/Make.defs
+++ b/graphics/ft80x/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GRAPHICS_FT80X),y)
+ifneq ($(CONFIG_GRAPHICS_FT80X),)
 CONFIGURED_APPS += $(APPDIR)/graphics/ft80x
 endif

--- a/graphics/lvgl/Make.defs
+++ b/graphics/lvgl/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GRAPHICS_LVGL),y)
+ifneq ($(CONFIG_GRAPHICS_LVGL),)
 CONFIGURED_APPS += $(APPDIR)/graphics/lvgl
 
 # It allows `<lvgl/lvgl.h>` import.

--- a/graphics/nxglyphs/Make.defs
+++ b/graphics/nxglyphs/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NXWIDGETS),y)
+ifneq ($(CONFIG_NXWIDGETS),)
 CONFIGURED_APPS += $(APPDIR)/graphics/nxglyphs
 endif

--- a/graphics/nxwidgets/Make.defs
+++ b/graphics/nxwidgets/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NXWIDGETS),y)
+ifneq ($(CONFIG_NXWIDGETS),)
 CONFIGURED_APPS += $(APPDIR)/graphics/nxwidgets
 endif

--- a/graphics/pdcurs34/Make.defs
+++ b/graphics/pdcurs34/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GRAPHICS_PDCURSES),y)
+ifneq ($(CONFIG_GRAPHICS_PDCURSES),)
 CONFIGURED_APPS += $(APPDIR)/graphics/pdcurs34
 endif

--- a/graphics/slcd/Make.defs
+++ b/graphics/slcd/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_GRAPHICS_SLCD),y)
+ifneq ($(CONFIG_GRAPHICS_SLCD),)
 CONFIGURED_APPS += $(APPDIR)/graphics/slcd
 endif

--- a/graphics/tiff/Make.defs
+++ b/graphics/tiff/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_TIFF),y)
+ifneq ($(CONFIG_TIFF),)
 CONFIGURED_APPS += $(APPDIR)/graphics/tiff
 endif

--- a/industry/abnt_codi/Make.defs
+++ b/industry/abnt_codi/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_INDUSTRY_ABNT_CODI_LIB),y)
+ifneq ($(CONFIG_INDUSTRY_ABNT_CODI_LIB),)
 CONFIGURED_APPS += $(APPDIR)/industry/abnt_codi
 endif

--- a/industry/foc/Make.defs
+++ b/industry/foc/Make.defs
@@ -19,6 +19,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_INDUSTRY_FOC),y)
+ifneq ($(CONFIG_INDUSTRY_FOC),)
 CONFIGURED_APPS += $(APPDIR)/industry/foc
 endif

--- a/interpreters/ficl/Make.defs
+++ b/interpreters/ficl/Make.defs
@@ -1,3 +1,3 @@
-ifeq ($(CONFIG_INTERPRETERS_FICL),y)
+ifneq ($(CONFIG_INTERPRETERS_FICL),)
 CONFIGURED_APPS += $(APPDIR)/interpreters/ficl
 endif

--- a/math/libtommath/Make.defs
+++ b/math/libtommath/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_MATH_LIBTOMMATH),y)
+ifneq ($(CONFIG_MATH_LIBTOMMATH),)
 CONFIGURED_APPS += $(APPDIR)/math/libtommath
 
 # It allows `<tommath.h>` import.

--- a/mlearning/cmsis/libcmsisnn/Make.defs
+++ b/mlearning/cmsis/libcmsisnn/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_CMSIS_NN),y)
+ifneq ($(CONFIG_CMSIS_NN),)
 CONFIGURED_APPS += $(APPDIR)/mlearning/cmsis/libcmsisnn
 
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/cmsis/CMSIS_5/CMSIS/NN/Include/}

--- a/mlearning/darknet/Make.defs
+++ b/mlearning/darknet/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_DARKNET_YOLO),y)
+ifneq ($(CONFIG_DARKNET_YOLO),)
 CONFIGURED_APPS += $(APPDIR)/mlearning/darknet
 
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/darknet/darknet/include/}

--- a/mlearning/libnnablart/Make.defs
+++ b/mlearning/libnnablart/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NNABLA_RT),y)
+ifneq ($(CONFIG_NNABLA_RT),)
 CONFIGURED_APPS += $(APPDIR)/mlearning/libnnablart
 
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/mlearning/libnnablart/nnabla-c-runtime/include/}

--- a/modbus/Make.defs
+++ b/modbus/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_MODBUS),y)
+ifneq ($(CONFIG_MODBUS),)
 CONFIGURED_APPS += $(APPDIR)/modbus
 endif

--- a/netutils/chat/Make.defs
+++ b/netutils/chat/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_CHAT),y)
+ifneq ($(CONFIG_NETUTILS_CHAT),)
 CONFIGURED_APPS += $(APPDIR)/netutils/chat
 endif

--- a/netutils/cjson/Make.defs
+++ b/netutils/cjson/Make.defs
@@ -18,6 +18,6 @@
 #
 #############################################################################
 
-ifeq ($(CONFIG_NETUTILS_CJSON),y)
+ifneq ($(CONFIG_NETUTILS_CJSON),)
 CONFIGURED_APPS += $(APPDIR)/netutils/cjson
 endif

--- a/netutils/codecs/Make.defs
+++ b/netutils/codecs/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_CODECS),y)
+ifneq ($(CONFIG_NETUTILS_CODECS),)
 CONFIGURED_APPS += $(APPDIR)/netutils/codecs
 endif

--- a/netutils/dhcpc/Make.defs
+++ b/netutils/dhcpc/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_DHCPC),y)
+ifneq ($(CONFIG_NETUTILS_DHCPC),)
 CONFIGURED_APPS += $(APPDIR)/netutils/dhcpc
 endif

--- a/netutils/dhcpd/Make.defs
+++ b/netutils/dhcpd/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_DHCPD),y)
+ifneq ($(CONFIG_NETUTILS_DHCPD),)
 CONFIGURED_APPS += $(APPDIR)/netutils/dhcpd
 endif

--- a/netutils/discover/Make.defs
+++ b/netutils/discover/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_DISCOVER),y)
+ifneq ($(CONFIG_NETUTILS_DISCOVER),)
 CONFIGURED_APPS += $(APPDIR)/netutils/discover
 endif

--- a/netutils/esp8266/Make.defs
+++ b/netutils/esp8266/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_ESP8266),y)
+ifneq ($(CONFIG_NETUTILS_ESP8266),)
 CONFIGURED_APPS += $(APPDIR)/netutils/esp8266
 endif

--- a/netutils/ftpc/Make.defs
+++ b/netutils/ftpc/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_FTPC),y)
+ifneq ($(CONFIG_NETUTILS_FTPC),)
 CONFIGURED_APPS += $(APPDIR)/netutils/ftpc
 endif

--- a/netutils/ftpd/Make.defs
+++ b/netutils/ftpd/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_FTPD),y)
+ifneq ($(CONFIG_NETUTILS_FTPD),)
 CONFIGURED_APPS += $(APPDIR)/netutils/ftpd
 endif

--- a/netutils/libcurl4nx/Make.defs
+++ b/netutils/libcurl4nx/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_LIBCURL4NX),y)
+ifneq ($(CONFIG_NETUTILS_LIBCURL4NX),)
 CONFIGURED_APPS += $(APPDIR)/netutils/libcurl4nx
 endif

--- a/netutils/netinit/Make.defs
+++ b/netutils/netinit/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_NETINIT),y)
+ifneq ($(CONFIG_NETUTILS_NETINIT),)
 CONFIGURED_APPS += $(APPDIR)/netutils/netinit
 endif

--- a/netutils/netlib/Make.defs
+++ b/netutils/netlib/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_NETLIB),y)
+ifneq ($(CONFIG_NETUTILS_NETLIB),)
 CONFIGURED_APPS += $(APPDIR)/netutils/netlib
 endif

--- a/netutils/ntpclient/Make.defs
+++ b/netutils/ntpclient/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_NTPCLIENT),y)
+ifneq ($(CONFIG_NETUTILS_NTPCLIENT),)
 CONFIGURED_APPS += $(APPDIR)/netutils/ntpclient
 endif

--- a/netutils/ping/Make.defs
+++ b/netutils/ping/Make.defs
@@ -18,8 +18,8 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_PING),y)
+ifneq ($(CONFIG_NETUTILS_PING),)
 CONFIGURED_APPS += $(APPDIR)/netutils/ping
-else ifeq ($(CONFIG_NETUTILS_PING6),y)
+else ifneq ($(CONFIG_NETUTILS_PING6),)
 CONFIGURED_APPS += $(APPDIR)/netutils/ping
 endif

--- a/netutils/pppd/Make.defs
+++ b/netutils/pppd/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_PPPD),y)
+ifneq ($(CONFIG_NETUTILS_PPPD),)
 CONFIGURED_APPS += $(APPDIR)/netutils/pppd
 endif

--- a/netutils/smtp/Make.defs
+++ b/netutils/smtp/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_SMTP),y)
+ifneq ($(CONFIG_NETUTILS_SMTP),)
 CONFIGURED_APPS += $(APPDIR)/netutils/smtp
 endif

--- a/netutils/telnetc/Make.defs
+++ b/netutils/telnetc/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_TELNETC),y)
+ifneq ($(CONFIG_NETUTILS_TELNETC),)
 CONFIGURED_APPS += $(APPDIR)/netutils/telnetc
 endif

--- a/netutils/telnetd/Make.defs
+++ b/netutils/telnetd/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_TELNETD),y)
+ifneq ($(CONFIG_NETUTILS_TELNETD),)
 CONFIGURED_APPS += $(APPDIR)/netutils/telnetd
 endif

--- a/netutils/tftpc/Make.defs
+++ b/netutils/tftpc/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_TFTPC),y)
+ifneq ($(CONFIG_NETUTILS_TFTPC),)
 CONFIGURED_APPS += $(APPDIR)/netutils/tftpc
 endif

--- a/netutils/thttpd/Make.defs
+++ b/netutils/thttpd/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_THTTPD),y)
+ifneq ($(CONFIG_NETUTILS_THTTPD),)
 CONFIGURED_APPS += $(APPDIR)/netutils/thttpd
 endif

--- a/netutils/usrsock_rpmsg/Make.defs
+++ b/netutils/usrsock_rpmsg/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_USRSOCK_RPMSG),y)
+ifneq ($(CONFIG_NETUTILS_USRSOCK_RPMSG),)
 CONFIGURED_APPS += $(APPDIR)/netutils/usrsock_rpmsg
 endif

--- a/netutils/webclient/Make.defs
+++ b/netutils/webclient/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_WEBCLIENT),y)
+ifneq ($(CONFIG_NETUTILS_WEBCLIENT),)
 CONFIGURED_APPS += $(APPDIR)/netutils/webclient
 endif

--- a/netutils/webserver/Make.defs
+++ b/netutils/webserver/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_WEBSERVER),y)
+ifneq ($(CONFIG_NETUTILS_WEBSERVER),)
 CONFIGURED_APPS += $(APPDIR)/netutils/webserver
 endif

--- a/netutils/xmlrpc/Make.defs
+++ b/netutils/xmlrpc/Make.defs
@@ -17,6 +17,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NETUTILS_XMLRPC),y)
+ifneq ($(CONFIG_NETUTILS_XMLRPC),)
 CONFIGURED_APPS += $(APPDIR)/netutils/xmlrpc
 endif

--- a/nshlib/Make.defs
+++ b/nshlib/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_NSH_LIBRARY),y)
+ifneq ($(CONFIG_NSH_LIBRARY),)
 CONFIGURED_APPS += $(APPDIR)/nshlib
 endif

--- a/system/cle/Make.defs
+++ b/system/cle/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_CLE),y)
+ifneq ($(CONFIG_SYSTEM_CLE),)
 CONFIGURED_APPS += $(APPDIR)/system/cle
 endif

--- a/system/embedlog/Make.defs
+++ b/system/embedlog/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_EMBEDLOG),y)
+ifneq ($(CONFIG_SYSTEM_EMBEDLOG),)
 CONFIGURED_APPS += $(APPDIR)/system/embedlog
 endif

--- a/system/popen/Make.defs
+++ b/system/popen/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_POPEN),y)
+ifneq ($(CONFIG_SYSTEM_POPEN),)
 CONFIGURED_APPS += $(APPDIR)/system/popen
 endif

--- a/system/readline/Make.defs
+++ b/system/readline/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_READLINE),y)
+ifneq ($(CONFIG_SYSTEM_READLINE),)
 CONFIGURED_APPS += $(APPDIR)/system/readline
 endif

--- a/system/system/Make.defs
+++ b/system/system/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_SYSTEM),y)
+ifneq ($(CONFIG_SYSTEM_SYSTEM),)
 CONFIGURED_APPS += $(APPDIR)/system/system
 endif

--- a/system/termcurses/Make.defs
+++ b/system/termcurses/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SYSTEM_TERMCURSES),y)
+ifneq ($(CONFIG_SYSTEM_TERMCURSES),)
 CONFIGURED_APPS += $(APPDIR)/system/termcurses
 endif

--- a/testing/unity/Make.defs
+++ b/testing/unity/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_TESTING_UNITY),y)
+ifneq ($(CONFIG_TESTING_UNITY),)
 CONFIGURED_APPS += $(APPDIR)/testing/unity
 endif

--- a/wireless/ieee802154/libmac/Make.defs
+++ b/wireless/ieee802154/libmac/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_IEEE802154_LIBMAC),y)
+ifneq ($(CONFIG_IEEE802154_LIBMAC),)
 CONFIGURED_APPS += $(APPDIR)/wireless/ieee802154/libmac
 endif

--- a/wireless/ieee802154/libutils/Make.defs
+++ b/wireless/ieee802154/libutils/Make.defs
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_IEEE802154_LIBUTILS),y)
+ifneq ($(CONFIG_IEEE802154_LIBUTILS),)
 CONFIGURED_APPS += $(APPDIR)/wireless/ieee802154/libutils
 endif


### PR DESCRIPTION
## Summary
to support the tristate option correctly and unify the usage

## Impact
Minor, code refactor only

## Testing
Pass CI
