### PR TITLE
apps: system: add libjpeg

### DIFF
--- a/graphics/libjpeg/0001-libjpeg-add-preconfigured-jconfig.h.patch
+++ b/graphics/libjpeg/0001-libjpeg-add-preconfigured-jconfig.h.patch
@@ -1,0 +1,82 @@
+From a6220cb02fdab278588dad24ec55aef28de8f005 Mon Sep 17 00:00:00 2001
+From: Alin Jerpelea <alin.jerpelea@sony.com>
+Date: Tue, 18 Oct 2022 12:18:59 +0200
+Subject: [PATCH] libjpeg: add preconfigured jconfig.h
+
+Add a generated header with configuration for libjpeg.
+
+Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>
+---
+ libjpeg/jconfig.h | 60 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 60 insertions(+)
+ create mode 100644 jconfig.h
+
+diff --git a/libjpeg/jconfig.h b/libjpeg/jconfig.h
+new file mode 100644
+index 0000000..2d05a3b
+--- /dev/null
++++ b/libjpeg/jconfig.h
+@@ -0,0 +1,60 @@
++/* jconfig.h.  Generated from jconfig.cfg by configure.  */
++/* jconfig.cfg --- source file edited by configure script */
++/* see jconfig.txt for explanations */
++
++#define HAVE_PROTOTYPES 1
++#define HAVE_UNSIGNED_CHAR 1
++#define HAVE_UNSIGNED_SHORT 1
++/* #undef void */
++/* #undef const */
++/* #undef CHAR_IS_UNSIGNED */
++#define HAVE_STDDEF_H 1
++#define HAVE_STDLIB_H 1
++#define HAVE_LOCALE_H 1
++/* #undef NEED_BSD_STRINGS */
++/* #undef NEED_SYS_TYPES_H */
++/* #undef NEED_FAR_POINTERS */
++/* #undef NEED_SHORT_EXTERNAL_NAMES */
++/* Define this if you get warnings about undefined structures. */
++/* #undef INCOMPLETE_TYPES_BROKEN */
++
++/* Define "boolean" as unsigned char, not enum, on Windows systems. */
++#ifdef _WIN32
++#ifndef __RPCNDR_H__		/* don't conflict if rpcndr.h already read */
++typedef unsigned char boolean;
++#endif
++#ifndef FALSE			/* in case these macros already exist */
++#define FALSE	0		/* values of boolean */
++#endif
++#ifndef TRUE
++#define TRUE	1
++#endif
++#define HAVE_BOOLEAN		/* prevent jmorecfg.h from redefining it */
++#endif
++
++#ifdef JPEG_INTERNALS
++
++/* #undef RIGHT_SHIFT_IS_UNSIGNED */
++#define INLINE __inline__
++/* These are for configuring the JPEG memory manager. */
++/* #undef DEFAULT_MAX_MEM */
++/* #undef NO_MKTEMP */
++
++#endif /* JPEG_INTERNALS */
++
++#ifdef JPEG_CJPEG_DJPEG
++
++#define BMP_SUPPORTED		/* BMP image file format */
++#define GIF_SUPPORTED		/* GIF image file format */
++#define PPM_SUPPORTED		/* PBMPLUS PPM/PGM image file format */
++/* #undef RLE_SUPPORTED */
++#define TARGA_SUPPORTED		/* Targa image file format */
++
++/* #undef TWO_FILE_COMMANDLINE */
++/* #undef NEED_SIGNAL_CATCHER */
++/* #undef DONT_USE_B_MODE */
++
++/* Define this if you want percent-done progress reports from cjpeg/djpeg. */
++/* #undef PROGRESS_REPORT */
++
++#endif /* JPEG_CJPEG_DJPEG */
+--
+2.37.1
+

--- a/graphics/libjpeg/Kconfig
+++ b/graphics/libjpeg/Kconfig
@@ -1,0 +1,34 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config LIBJPEG
+	bool "libjpeg"
+	default n
+	---help---
+		Enable libjpeg.
+		This package contains C software to implement JPEG image encoding, decoding,
+		and transcoding.  JPEG is a standardized compression method for full-color
+		and grayscale images.
+		The distributed programs provide conversion between JPEG JFIF format and
+		image files in PBMPLUS PPM/PGM, GIF, BMP, and Targa file formats.  The
+		core compression and decompression library can easily be reused in other
+		programs, such as image viewers.  The package is highly portable C code;
+		we have tested it on many machines ranging from PCs to Crays.
+		libjpeg is provided from http://www.ijg.org/
+
+if LIBJPEG
+
+config LIBJPEG_VER
+	string "libjpeg version"
+	default "9c"
+
+config LIBJPEG_TEMP_DIR
+	string "Temporary directory"
+	default "/mnt/spif/"
+	---help---
+		This is the directory path including the trailing slash '/'
+		to store the temporary files created by libjpeg.
+
+endif # LIBJPEG

--- a/graphics/libjpeg/Make.defs
+++ b/graphics/libjpeg/Make.defs
@@ -1,0 +1,26 @@
+############################################################################
+# apps/graphics/libjpeg/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_LIBJPEG),)
+CONFIGURED_APPS += $(APPDIR)/graphics/libjpeg
+
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/graphics/libjpeg/libjpeg}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/graphics/libjpeg/libjpeg}
+endif

--- a/graphics/libjpeg/Makefile
+++ b/graphics/libjpeg/Makefile
@@ -1,0 +1,74 @@
+############################################################################
+# apps/graphics/libjpeg/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+SRC = libjpeg
+
+CSRCS += $(SRC)/jaricom.c
+CSRCS += $(SRC)/jcomapi.c
+CSRCS += $(SRC)/jdapimin.c
+CSRCS += $(SRC)/jdapistd.c
+CSRCS += $(SRC)/jdarith.c
+CSRCS += $(SRC)/jdatasrc.c
+CSRCS += $(SRC)/jdcoefct.c
+CSRCS += $(SRC)/jdcolor.c
+CSRCS += $(SRC)/jddctmgr.c
+CSRCS += $(SRC)/jdhuff.c
+CSRCS += $(SRC)/jdinput.c
+CSRCS += $(SRC)/jdmainct.c
+CSRCS += $(SRC)/jdmarker.c
+CSRCS += $(SRC)/jdmaster.c
+CSRCS += $(SRC)/jdmerge.c
+CSRCS += $(SRC)/jdpostct.c
+CSRCS += $(SRC)/jdsample.c
+CSRCS += $(SRC)/jdtrans.c
+CSRCS += $(SRC)/jerror.c
+CSRCS += $(SRC)/jidctflt.c
+CSRCS += $(SRC)/jidctfst.c
+CSRCS += $(SRC)/jidctint.c
+CSRCS += $(SRC)/jquant1.c
+CSRCS += $(SRC)/jquant2.c
+CSRCS += $(SRC)/jutils.c
+CSRCS += $(SRC)/jmemmgr.c
+CSRCS += $(SRC)/jmemname.c
+
+CFLAGS += -DTEMP_DIRECTORY=\"$(CONFIG_EXTERNALS_LIBJPEG_TEMP_DIR)\"
+
+CFLAGS += -Wno-shadow -Wno-strict-prototypes -Wno-unknown-pragmas
+
+MODULE = $(CONFIG_LIBJPEG)
+
+libjpeg.tar.gz:
+	$(Q) curl -L http://www.ijg.org/files/jpegsrc.v$(CONFIG_LIBJPEG_VER).tar.gz -o libjpeg.tar.gz
+	$(Q) tar xf libjpeg.tar.gz
+	$(Q) mv jpeg-$(CONFIG_LIBJPEG_VER) libjpeg
+	$(Q) patch -Np1 <0001-libjpeg-add-preconfigured-jconfig.h.patch
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard libjpeg/libjpeg),)
+context:: libjpeg.tar.gz
+
+distclean::
+	$(call DELDIR, libjpeg)
+	$(call DELFILE, libjpeg.tar.gz)
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
This package contains C software to implement JPEG image encoding, decoding, and transcoding.  JPEG is a standardized compression method for full-color and grayscale images.

The distributed programs provide conversion between JPEG JFIF format and image files in PBMPLUS PPM/PGM, GIF, BMP, and Targa file formats.  The core compression and decompression library can easily be reused in other programs, such as image viewers.  The package is highly portable C code; we have tested it on many machines ranging from PCs to Crays.

## Impact
JPEG support

## Testing
Spresense
