### PR TITLE
ostest:add sem protocl to priority inheritance

### DIFF
--- a/testing/ostest/prioinherit.c
+++ b/testing/ostest/prioinherit.c
@@ -530,6 +530,8 @@ void priority_inheritance(void)
   g_medpri = my_pri - 1;
 
   sem_init(&g_sem, 0, NLOWPRI_THREADS);
+  sem_setprotocol(&g_sem, SEM_PRIO_INHERIT);
+
   dump_nfreeholders("priority_inheritance:");
 
   /* Start the low priority threads */


### PR DESCRIPTION
## Summary
ostest,sem use lock need set protocl `SEM_PRIO_INHERIT`
[patch](https://github.com/apache/incubator-nuttx/pull/5070)

## impact
use sem as lock,need do is change

## Testing
ostest
