### PR TITLE
Libapps for kernel build

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -42,11 +42,9 @@ else
 CWD = $(CURDIR)
 endif
 
-# Add the static application library to the linked libraries. Don't do this
-# with CONFIG_BUILD_KERNEL as there is no static app library
-ifneq ($(CONFIG_BUILD_KERNEL),y)
-  LDLIBS += $(call CONVERT_PATH,$(BIN))
-endif
+# Add the static application library to the linked libraries.
+
+LDLIBS += $(call CONVERT_PATH,$(BIN))
 
 # When building a module, link with the compiler runtime.
 # This should be linked after libapps. Consider that mbedtls in libapps

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,12 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
 
 install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
-.import: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) for app in ${CONFIGURED_APPS}; do \
 		$(MAKE) -C "$${app}" archive ; \
 	done
+
+.import: $(BIN)
 	$(Q) install libapps.a $(APPDIR)$(DELIM)import$(DELIM)libs
 	$(Q) $(MAKE) install
 

--- a/import/Make.defs
+++ b/import/Make.defs
@@ -66,7 +66,7 @@ LDLIBPATH = $(addprefix -L,$(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs))
 # Link with user libraries
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
-  LDLIBS = -lapps -lmm -lc -lproxies
+  LDLIBS += -lmm -lc -lproxies
   ifeq ($(CONFIG_HAVE_CXX),y)
     LDLIBS += -lxx
   endif


### PR DESCRIPTION
## Summary
Allows building the static "libapps.a" library separately for CONFIG_BUILD_KERNEL=y
## Impact
Almost nothing, kernel mode build only. The result for make import remains the same, this merely allows building libapps.a separately if it is needed.
## Testing
icicle:knsh
