### PR TITLE
add tinycrypt to crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,4 @@ Regulations, Section 740.13) for both object code and source code.
 
 The following provides more details on the included cryptographic software:
 https://tls.mbed.org/supported-ssl-ciphersuites.
+https://github.com/intel/tinycrypt

--- a/boot/mcuboot/Make.defs
+++ b/boot/mcuboot/Make.defs
@@ -31,11 +31,4 @@ CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboo
 CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/boot/bootutil/include}
 CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/boot/bootutil/include}
 
-# It allows import of MCUboot's crypto backend library headers.
-
-ifneq ($(CONFIG_MCUBOOT_USE_TINYCRYPT),)
-CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/ext/tinycrypt/lib/include}
-CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/boot/mcuboot/mcuboot/ext/tinycrypt/lib/include}
-endif
-
 endif

--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -71,6 +71,9 @@ CSRCS += $(MCUBOOT_UNPACK)/ext/tinycrypt/lib/source/aes_encrypt.c \
          $(MCUBOOT_UNPACK)/ext/tinycrypt/lib/source/ecc_dh.c \
          $(MCUBOOT_UNPACK)/ext/tinycrypt/lib/source/sha256.c \
          $(MCUBOOT_UNPACK)/ext/tinycrypt/lib/source/utils.c
+
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" mcuboot/ext/tinycrypt/lib/include}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" mcuboot/ext/tinycrypt/lib/include}
 endif
 
 $(MCUBOOT_TARBALL):

--- a/crypto/tinycrypt/.gitignore
+++ b/crypto/tinycrypt/.gitignore
@@ -1,0 +1,2 @@
+*.zip
+tinycrypt/*

--- a/crypto/tinycrypt/Kconfig
+++ b/crypto/tinycrypt/Kconfig
@@ -1,0 +1,98 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menu "Crypto: TinyCrypt cryptography library"
+
+config TINYCRYPT
+	bool "TinyCrypt Support"
+	help
+		This option enables the TinyCrypt cryptography library.
+
+if TINYCRYPT
+config TINYCRYPT_VERSION
+	string "Tinycrypt Version"
+	default "0.2.8"
+
+config TINYCRYPT_CTR_PRNG
+	bool "PRNG in counter mode"
+	default n
+	help
+	This option enables support for the pseudo-random number
+		generator in counter mode.
+
+config TINYCRYPT_SHA256
+	bool "SHA-256 Hash function support"
+	default n
+	help
+		This option enables support for SHA-256
+		hash function primitive.
+
+config TINYCRYPT_SHA256_HMAC
+	bool "HMAC (via SHA256) message auth support"
+	default n
+	help
+		This option enables support for HMAC using SHA-256
+		message authentication code.
+
+config TINYCRYPT_SHA256_HMAC_PRNG
+	bool "PRNG (via HMAC-SHA256) support"
+	default n
+	help
+		This option enables support for pseudo-random number
+		generator.
+
+config TINYCRYPT_ECC_DH
+	bool "ECC_DH anonymous key agreement protocol"
+	default n
+	help
+		This option enables support for the Elliptic curve
+		Diffie-Hellman anonymous key agreement protocol.
+
+		Enabling ECC requires a cryptographically secure random number
+		generator.
+
+config TINYCRYPT_ECC_DSA
+	bool "ECC_DSA digital signature algorithm"
+	default n
+	help
+		This option enables support for the Elliptic Curve Digital
+		Signature Algorithm (ECDSA).
+
+		Enabling ECC requires a cryptographically secure random number
+		generator.
+
+config TINYCRYPT_AES
+	bool "AES-128 decrypt/encrypt"
+	default n
+	help
+		This option enables support for AES-128 decrypt and encrypt.
+
+config TINYCRYPT_AES_CBC
+	bool "AES-128 block cipher"
+	default n
+	help
+		This option enables support for AES-128 block cipher mode.
+
+config TINYCRYPT_AES_CTR
+	bool "AES-128 counter mode"
+	default n
+	help
+		This option enables support for AES-128 counter mode.
+
+config TINYCRYPT_AES_CCM
+	bool "AES-128 CCM mode"
+	default n
+	help
+		This option enables support for AES-128 CCM mode.
+
+config TINYCRYPT_AES_CMAC
+	bool "AES-128 CMAC mode"
+	default n
+	help
+		This option enables support for AES-128 CMAC mode.
+
+endif
+
+endmenu

--- a/crypto/tinycrypt/Make.defs
+++ b/crypto/tinycrypt/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/crypto/tinycrypt/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_TINYCRYPT),)
+CONFIGURED_APPS += $(APPDIR)/crypto/tinycrypt
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/tinycrypt/tinycrypt/lib/include}
+CXXFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(APPDIR)/crypto/tinycrypt/tinycrypt/lib/include}
+endif

--- a/crypto/tinycrypt/Makefile
+++ b/crypto/tinycrypt/Makefile
@@ -1,0 +1,99 @@
+############################################################################
+# apps/crypto/tinycrypt/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+TINYCRYPT_VERSION = $(patsubst "%",%,$(strip $(CONFIG_TINYCRYPT_VERSION)))
+TINYCRYPT_URL ?= "https://github.com/intel/tinycrypt/archive/refs/tags/v$(TINYCRYPT_VERSION).zip"
+
+TINYCRYPT_ZIP = v$(TINYCRYPT_VERSION).zip
+
+TINYCRYPT_UNPACKNAME = tinycrypt
+UNPACK ?= unzip -q -o
+
+$(TINYCRYPT_ZIP):
+	@echo "Downloading: $(TINYCRYPT_URL)/$(TINYCRYPT_ZIP)"
+	$(Q) curl -O -L $(TINYCRYPT_URL)
+
+$(TINYCRYPT_UNPACKNAME): $(TINYCRYPT_ZIP)
+	@echo "Unpacking: $(TINYCRYPT_ZIP) -> $(TINYCRYPT_UNPACKNAME)"
+	$(Q) $(UNPACK) $(TINYCRYPT_ZIP)
+	$(Q) mv	tinycrypt-$(TINYCRYPT_VERSION) $(TINYCRYPT_UNPACKNAME)
+	$(Q) touch $(TINYCRYPT_UNPACKNAME)
+
+ifeq ($(wildcard $(TINYCRYPT_UNPACKNAME)/.git),)
+context:: $(TINYCRYPT_UNPACKNAME)
+
+distclean::
+	$(Q) rm -rf $(TINYCRYPT_UNPACKNAME)
+endif
+
+CSRCS += tinycrypt/lib/source/utils.c
+CSRCS += tinycrypt/lib/source/ecc.c
+
+ifeq ($(CONFIG_TINYCRYPT_ECC_DH),y)
+	CSRCS += tinycrypt/lib/source/ecc_dh.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_ECC_DSA),y)
+	CSRCS += tinycrypt/lib/source/ecc_dsa.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES),y)
+	CSRCS += tinycrypt/lib/source/aes_decrypt.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES),y)
+	CSRCS += tinycrypt/lib/source/aes_encrypt.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES_CBC),y)
+	CSRCS += tinycrypt/lib/source/cbc_mode.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES_CTR),y)
+	CSRCS += tinycrypt/lib/source/ctr_mode.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES_CCM),y)
+	CSRCS += tinycrypt/lib/source/ccm_mode.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_AES_CMAC),y)
+	CSRCS += tinycrypt/lib/source/cmac_mode.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_SHA256),y)
+	CSRCS += tinycrypt/lib/source/sha256.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_SHA256_HMAC),y)
+	CSRCS += tinycrypt/lib/source/hmac.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_SHA256_HMAC_PRNG),y)
+	CSRCS += tinycrypt/lib/source/hmac_prng.c
+endif
+
+ifeq ($(CONFIG_TINYCRYPT_CTR_PRNG),y)
+	CSRCS += tinycrypt/lib/source/ctr_prng.c
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
add tinycrypt to crypto
and then inside of mucboot internal used lib
## Impact
mcuboot
## Testing

