### PR TITLE
Fixed unused variable and improved Kconfig for TCP IPC Client & Server

### DIFF
--- a/examples/tcp_ipc_client/Kconfig
+++ b/examples/tcp_ipc_client/Kconfig
@@ -6,9 +6,15 @@
 config EXAMPLES_TCP_IPC_CLIENT
 	bool "Client for TCP IPC NuttX"
 	default n
-	depends on NET_TCP
-	depends on NET_SOCKOPTS
+	select ARCH_HAVE_NET
+	select ARCH_HAVE_NETDEV_STATISTICS
+	select NET_READAHEAD
+	select NET_TCP
+	select NET
+	select NET_SOCKOPTS
 	select NET_LOOPBACK
+	select NETDEV_LATEINIT
+	select SCHED_HPWORK
 	---help---
 		Enable the Client for TCP IPC NuttX example
 

--- a/examples/tcp_ipc_client/tcp_ipc_client_main.c
+++ b/examples/tcp_ipc_client/tcp_ipc_client_main.c
@@ -105,7 +105,6 @@ int main(int argc, char *argv[])
   int bytes_read_from_server = 0;
   struct sockaddr_in serv_addr;
   protocolo_ipc tprotocol;
-  int ndx;
 
   /* Check if there are sufficient arguments passed to this program */
 
@@ -115,7 +114,6 @@ int main(int argc, char *argv[])
       return 1;
     }
 
-  ndx = 1;
   if (strcmp(argv[1], "-h") == 0)
     {
       show_usage(argv[0]);

--- a/examples/tcp_ipc_server/Kconfig
+++ b/examples/tcp_ipc_server/Kconfig
@@ -6,9 +6,15 @@
 config EXAMPLES_TCP_IPC_SERVER
 	bool "Server for TCP IPC NuttX"
 	default n
-	depends on NET_TCP
-	depends on NET_SOCKOPTS
+	select ARCH_HAVE_NET
+	select ARCH_HAVE_NETDEV_STATISTICS
+	select NET_READAHEAD
+	select NET_TCP
+	select NET
+	select NET_SOCKOPTS
 	select NET_LOOPBACK
+	select NETDEV_LATEINIT
+	select SCHED_HPWORK
 	---help---
 		Enable the TCP SERVER example
 


### PR DESCRIPTION
## Summary

This PR makes the following:

- Fixes unusable variable warning (ndx variable)
- Improve Kconfig of TCP IPC Client and Server examples, by automatically configuring all configs needed when enabling these examples.

## Impact

There's no impact on other examples

## Testing

This was successfully tested and validated on a hardware test set (ESP32 + Radioenge LoraWAN module)
