### PR TITLE
dhcpc:fix xid error clear bug.

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -532,6 +532,10 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
   pdhcpc = malloc(sizeof(struct dhcpc_state_s) + maclen - 1);
   if (pdhcpc)
     {
+      /* Initialize the allocated structure */
+
+      memset(pdhcpc, 0, sizeof(struct dhcpc_state_s));
+
       /* RFC2131: A DHCP client MUST choose 'xid's in such a
        * way as to minimize the chance of using an 'xid' identical to one
        * used by another client.
@@ -547,9 +551,6 @@ FAR void *dhcpc_open(FAR const char *interface, FAR const void *macaddr,
             }
         }
 
-      /* Initialize the allocated structure */
-
-      memset(pdhcpc, 0, sizeof(struct dhcpc_state_s));
       pdhcpc->interface = interface;
       pdhcpc->maclen    = maclen;
       memcpy(pdhcpc->macaddr, macaddr, pdhcpc->maclen);


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
A bug causing xid to be 0.

## Impact
DHCP xid

## Testing
Tested on BL602 
