### PR TITLE
usrsock:fix stack-buffer-overflow issue when running basic_send test case

### DIFF
--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -1579,7 +1579,7 @@ static int handle_usrsock_request(int fd, FAR struct daemon_priv_s *priv)
         },
     };
 
-  uint8_t hdrbuf[16];
+  uint8_t hdrbuf[32];
   FAR struct usrsock_request_common_s *common_hdr = (FAR void *)hdrbuf;
   ssize_t rlen;
 
@@ -1601,7 +1601,8 @@ static int handle_usrsock_request(int fd, FAR struct daemon_priv_s *priv)
       return -EIO;
     }
 
-  assert(handlers[common_hdr->reqid].hdrlen < sizeof(hdrbuf));
+  assert(handlers[common_hdr->reqid].hdrlen <
+         (sizeof(hdrbuf) - sizeof(*common_hdr)));
 
   rlen = read_req(fd, common_hdr, hdrbuf,
                   handlers[common_hdr->reqid].hdrlen);


### PR DESCRIPTION
## Summary
The following error was reported when runing usrsocktest with KASAN check enabled.
    ==1348590==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xf20ec610 at pc 0x56ac61ba bp 0xf20ec278 sp 0xf20ec268

rootcause:
hdrbuf's size is not large enough to store the data in usrsock's request.

solution:
double herbuf's size to make sure the space, used to store usrsock's request, is enough.

## Impact
usrsocktest

## Testing

