### PR TITLE
testing/ostest: Remove the code which reference CONFIG_SEM_NNESTPRIO

### DIFF
--- a/testing/ostest/prioinherit.c
+++ b/testing/ostest/prioinherit.c
@@ -57,19 +57,7 @@
 #  define NLOWPRI_THREADS 1
 #endif
 
-#ifndef CONFIG_SEM_NNESTPRIO
-#  define CONFIG_SEM_NNESTPRIO 0
-#endif
-
-/* Where resources configured for lots of waiters?  If so then run 3 high
- * priority threads.  Otherwise, just one.
- */
-
-#if CONFIG_SEM_NNESTPRIO > 3
-#  define NHIGHPRI_THREADS 3
-#else
-#  define NHIGHPRI_THREADS 1
-#endif
+#define NHIGHPRI_THREADS 1
 
 #define NUMBER_OF_COMPETING_THREADS     3
 #define COMPETING_THREAD_START_PRIORITY 200


### PR DESCRIPTION
## Summary
since CONFIG_SEM_NNESTPRIO is removed by:
https://github.com/apache/incubator-nuttx/pull/6318

## Impact
Remove the dead code

## Testing
Pass CI
