### PR TITLE
netutils: webserver: Fix directory handling

### DIFF
--- a/netutils/webserver/httpd_dirlist.c
+++ b/netutils/webserver/httpd_dirlist.c
@@ -109,7 +109,7 @@ bool httpd_is_file(FAR const char *filename)
 {
   char *path;
   int fd;
-  bool ret = false;
+  bool ret = true;
 
   path = malloc(CONFIG_NAME_MAX);
   ASSERT(path);
@@ -117,12 +117,12 @@ bool httpd_is_file(FAR const char *filename)
   snprintf(path, CONFIG_NAME_MAX, "%s/%s",
            CONFIG_NETUTILS_HTTPD_PATH, filename);
 
-  fd = open(path, O_RDONLY);
+  fd = open(path, O_DIRECTORY);
 
   if (-1 != fd)
     {
       close(fd);
-      ret = true;
+      ret = false;
     }
 
   free(path);

--- a/netutils/webserver/httpd_sendfile.c
+++ b/netutils/webserver/httpd_sendfile.c
@@ -83,7 +83,16 @@ int httpd_sendfile_open(const char *name, struct httpd_fs_file *file)
 
   file->len = (int) st.st_size;
 
-  file->fd = open(file->path, O_RDONLY);
+  if (S_ISDIR(st.st_mode))
+    {
+      /* we assume -1 as a directory */
+
+      file->fd = -1;
+    }
+  else
+    {
+      file->fd = open(file->path, O_RDONLY);
+    }
 
 #ifndef CONFIG_NETUTILS_HTTPD_DIRLIST
   if (file->fd == -1)


### PR DESCRIPTION
## Summary

- I noticed that the webserver can not handle a directory.
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with spresense:wifi_smp
