### PR TITLE
ltp: fix build fail with "argument too long" issue on 20.04

### DIFF
--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -25,32 +25,45 @@ ifeq ($(CONFIG_FS_AIO),)
 BLACKWORDS  += "aio.h"
 BLACKWORDS  += "SIGPOLL"
 endif
+BLACKWORDS  += "SA_RESTART"
+BLACKWORDS  += "pthread_atfork"
+BLACKWORDS  += "pthread_condattr_setpshared"
+BLACKWORDS  += "pthread_condattr_getpshared"
+BLACKWORDS  += "pthread_mutex_getprioceiling"
+BLACKWORDS  += "pthread_mutexattr_setprioceiling"
+BLACKWORDS  += "pthread_mutexattr_getprioceiling"
+BLACKWORDS  += "pthread_getattr_np"
+BLACKWORDS  += "pthread_getcpuclockid"
+BLACKWORDS  += "pthread_rwlockattr_init"
+BLACKWORDS  += "pthread_rwlockattr_destroy"
+BLACKWORDS  += "pthread_mutex_getprioceiling"
+BLACKWORDS  += "clock_getcpuclockid"
+BLACKWORDS  += "shm_unlink"
+BLACKWORDS  += "shm_open"
+BLACKWORDS  += "mlock"
+BLACKWORDS  += "munlock"
+BLACKWORDS  += "mlockall"
+BLACKWORDS  += "msync"
+BLACKWORDS  += "getpgrp"
+BLACKWORDS  += "lfind"
+BLACKWORDS += "killpg"
+BLACKWORDS  += "setpwent"
+ifeq ($(CONFIG_PTHREAD_SPINLOCKS),)
+BLACKWORDS += "pthread_spin_init"
+BLACKWORDS += "pthread_spin_destroy"
+BLACKWORDS += "pthread_spin_trylock"
+endif
+
 BLACKWORDS  += "affinity.h"
-BLACKWORDS  += "endpwent"
 BLACKWORDS  += "langinfo.h"
 BLACKWORDS  += "ucontext.h"
 BLACKWORDS  += "noatime.h"
-BLACKWORDS  += "clock_getcpuclockid"
 BLACKWORDS  += "CLOCK_PROCESS_CPUTIME_ID"
 BLACKWORDS  += "CLOCK_THREAD_CPUTIME_ID"
 BLACKWORDS  += "fork()"
-BLACKWORDS  += "getpwent"
-BLACKWORDS  += "killpg"
-BLACKWORDS  += "pthread_atfork"
 BLACKWORDS  += "pthread_attr_setscope"
-BLACKWORDS  += "pthread_condattr_setpshared"
-BLACKWORDS  += "pthread_condattr_getpshared"
-BLACKWORDS  += "pthread_getattr_np"
-BLACKWORDS  += "pthread_getcpuclockid"
-BLACKWORDS  += "pthread_mutex_getprioceiling"
-BLACKWORDS  += "pthread_mutexattr_getprioceiling"
-BLACKWORDS  += "pthread_mutexattr_setprioceiling"
-BLACKWORDS  += "pthread_rwlockattr_destroy"
-BLACKWORDS  += "pthread_rwlockattr_getpshared"
-BLACKWORDS  += "pthread_rwlockattr_init"
 BLACKWORDS  += "RLIMIT_MEMLOCK"
 BLACKWORDS  += "PTHREAD_SCOPE_PROCESS"
-BLACKWORDS  += "setpwent"
 BLACKWORDS  += "SIGABRT"
 BLACKWORDS  += "SIGBUS"
 BLACKWORDS  += "SIGFPE"
@@ -71,6 +84,8 @@ BLACKWORDS  += "SIGSTKSZ"
 BLACKWORDS  += "stack_t"
 BLACKWORDS  += "siginterrupt"
 BLACKWORDS  += "threads_scenarii.c"
+BLACKWORDS  += "PTHREAD_PRIO_PROTECT"
+BLACKWORDS  += "pthread_mutex_lock"
 
 BLACKWORDS  += "ILL_[A-Z]"
 BLACKWORDS  += "FPE_[A-Z]"
@@ -94,28 +109,61 @@ BLACKSRCS += 22-31-buildonly.c
 BLACKSRCS += 22-32-buildonly.c
 BLACKSRCS += 25-1-buildonly.c
 BLACKSRCS += 27-1-buildonly.c
+BLACKSRCS += 34-1-buildonly.c
 BLACKSRCS += 35-1-buildonly.c
 BLACKSRCS += 35-2-buildonly.c
+BLACKSRCS += 27-2.c
+ifeq ($(CONFIG_PTHREAD_SPINLOCKS),)
+BLACKSRCS += 3-12-buildonly.c
+endif
+BLACKSRCS += 35-3-buildonly.c
 
 MAINWORDS    += "main("
 
-$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell find $(TESTDIR) -name *.c |xargs grep -lr $(word))))
-$(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(shell find $(TESTDIR) -name *.c))))
+LTP_ORIGS_1  := $(shell find $(TESTDIR) -name *.c | head -n 500)
+LTP_ORIGS_2  := $(shell find $(TESTDIR) -name *.c | head -n 1000|tail -n +501)
+LTP_ORIGS_3  := $(shell find $(TESTDIR) -name *.c | head -n 1500|tail -n +1001)
+LTP_ORIGS_4  := $(shell find $(TESTDIR) -name *.c | head -n 2000|tail -n +1501)
 
-LTP_ORIGINS  := $(filter-out $(BLACKLIST), $(shell find $(TESTDIR) -name *.c))
+$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell grep -lr $(word) $(LTP_ORIGS_1))))
+$(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(LTP_ORIGS_1))))
 
-$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS+=$(shell grep -lr $(word) $(LTP_ORIGINS))))
+$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell grep -lr $(word) $(LTP_ORIGS_2))))
+$(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(LTP_ORIGS_2))))
 
-LTP_CSRCS    := $(filter-out $(LTP_MAINCSRCS), $(LTP_ORIGINS))
+$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell grep -lr $(word) $(LTP_ORIGS_3))))
+$(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(LTP_ORIGS_3))))
 
-PROGNAME     := $(basename $(shell echo $(LTP_MAINCSRCS) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))
-MAINSRC       = $(LTP_MAINCSRCS)
+$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell grep -lr $(word) $(LTP_ORIGS_4))))
+$(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(LTP_ORIGS_4))))
+
+LTP_ORIGS_1  := $(filter-out $(BLACKLIST), $(LTP_ORIGS_1))
+LTP_ORIGS_2  := $(filter-out $(BLACKLIST), $(LTP_ORIGS_2))
+LTP_ORIGS_3  := $(filter-out $(BLACKLIST), $(LTP_ORIGS_3))
+LTP_ORIGS_4  := $(filter-out $(BLACKLIST), $(LTP_ORIGS_4))
+
+$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS_1+=$(shell grep -lr $(word) $(LTP_ORIGS_1))))
+$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS_2+=$(shell grep -lr $(word) $(LTP_ORIGS_2))))
+$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS_3+=$(shell grep -lr $(word) $(LTP_ORIGS_3))))
+$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS_4+=$(shell grep -lr $(word) $(LTP_ORIGS_4))))
+
+LTP_CSRCS_1  := $(filter-out $(LTP_MAINCSRCS_1), $(LTP_ORIGS_1))
+LTP_CSRCS_2  := $(filter-out $(LTP_MAINCSRCS_2), $(LTP_ORIGS_2))
+LTP_CSRCS_3  := $(filter-out $(LTP_MAINCSRCS_3), $(LTP_ORIGS_3))
+LTP_CSRCS_4  := $(filter-out $(LTP_MAINCSRCS_4), $(LTP_ORIGS_4))
+
+
+PROGNAME     := $(basename $(shell echo $(LTP_MAINCSRCS_1) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))
+PROGNAME     += $(basename $(shell echo $(LTP_MAINCSRCS_2) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))
+PROGNAME     += $(basename $(shell echo $(LTP_MAINCSRCS_3) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))
+PROGNAME     += $(basename $(shell echo $(LTP_MAINCSRCS_4) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))
+MAINSRC       = $(LTP_MAINCSRCS_1) $(LTP_MAINCSRCS_2) $(LTP_MAINCSRCS_3) $(LTP_MAINCSRCS_4)
 PRIORITY      = SCHED_PRIORITY_DEFAULT
 STACKSIZE     = $(CONFIG_DEFAULT_TASK_STACKSIZE)
 MODULE        = $(CONFIG_TESTING_LTP)
 
-CSRCS        := $(LTP_CSRCS)
-CFLAGS       += -I$(LTP_UNPACK)
+CSRCS        := $(LTP_CSRCS_1) $(LTP_CSRCS_2) $(LTP_CSRCS_3) $(LTP_CSRCS_4)
+CFLAGS       += -I$(CURDIR)
 CFLAGS       += -I$(TESTDIR)/include
 endif
 


### PR DESCRIPTION
Signed-off-by: nietingting <nietingting@xiaomi.com>

## Summary
ltp: fix build fail with "argument too long" issue on 20.04
## Impact
no
## Testing
test on local
