### PR TITLE
Fix fatal error: array: No such file or directory

### DIFF
--- a/testing/cxxtest/cxxtest_main.cxx
+++ b/testing/cxxtest/cxxtest_main.cxx
@@ -36,7 +36,7 @@
 #ifdef CONFIG_CXX_EXCEPTION
 #include <stdexcept>
 #endif
-#if __cplusplus >= 201703L
+#if defined(CONFIG_LIBCXX) && __cplusplus >= 201703L
 #include <array>
 #include <utility>
 #endif
@@ -61,7 +61,7 @@ public:
   }
 };
 
-#if __cplusplus >= 201703L
+#if defined(CONFIG_LIBCXX) && __cplusplus >= 201703L
 class File
 {
 public:
@@ -193,7 +193,7 @@ static void test_stl()
 // Name: test_stl2
 //***************************************************************************/
 
-#if __cplusplus >= 201703L
+#if defined(CONFIG_LIBCXX) && __cplusplus >= 201703L
 auto test_stl2() -> void
 {
   std::cout << "Test C++17 features ==========================" << std::endl;
@@ -274,7 +274,7 @@ extern "C" int main(int argc, char *argv[])
   test_ofstream();
   test_iostream();
   test_stl();
-#if __cplusplus >= 201703L
+#if defined(CONFIG_LIBCXX) && __cplusplus >= 201703L
   test_stl2();
 #endif
 #ifdef CONFIG_CXX_RTTI


### PR DESCRIPTION
## Summary
enable test_stl2 only when CONFIG_LIBCXX is enabled since uClibc++/minic++ doesn't have array header file

## Impact
Fixed the build break report here: https://github.com/apache/incubator-nuttx/actions/runs/3305999084/jobs/5456570758

## Testing
Pass CI
