### PR TITLE
README.md: remove inaccessible links

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,7 @@ A: Here are three:
       You can copy any pieces that you like from the old apps/directory to your
       custom apps directory as necessary.
 
-      This is documented in `NuttX/boards/README.txt` and
-      `nuttx/Documentation/NuttXPortingGuide.html` (Online at
-      https://bitbucket.org/nuttx/nuttx/src/master/Documentation/NuttXPortingGuide.html#apndxconfigs
-      under _Build options_). And in the `apps/README.txt` file.
+      This is documented in `NuttX/boards/README.txt`.
 
    3) If you like the random collection of stuff in the `apps/` directory but
       just want to expand the existing components with your own, external


### PR DESCRIPTION
## Summary
When try to access `nuttx/Documentation/NuttXPortingGuide.html` online, it will prompt that `the repository has been deleted`, and the prompt information is as follows:
```
This repository has been deleted

Our apologies, but the repository "nuttx/nuttx" has been deleted. 
It now lives at https://bitbucket.org/patacongo/nuttx.
```
Also the file `nuttx/Documentation/NuttXPortingGuide.html` has been removed under `nuttx/Documentation`, so this link is not needed here.

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
None

## Testing


