### PR TITLE
wireless: gs2200m: Change usrsock xid from uint64_t to uint32_t

### DIFF
--- a/wireless/gs2200m/gs2200m_main.c
+++ b/wireless/gs2200m/gs2200m_main.c
@@ -244,7 +244,7 @@ static int _write_to_usock(int fd, void *buf, size_t count)
 
 static int _send_ack_common(int fd,
                             uint16_t events,
-                            uint64_t xid,
+                            uint32_t xid,
                             FAR struct usrsock_message_req_ack_s *resp)
 {
   resp->head.msgid  = USRSOCK_MESSAGE_RESPONSE_ACK;


### PR DESCRIPTION
## Summary
Fix the type to match usrsock.h has been changed by https://github.com/apache/incubator-nuttx/pull/6893

## Impact

## Testing

