### PR TITLE
Fix Error: ftpd.c:1773:9: error: variable 'pos' set but not used [-Werror,-Wunused-but-set-variable]

### DIFF
--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1770,7 +1770,6 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
   size_t wantsize;
   ssize_t rdbytes;
   ssize_t wrbytes;
-  off_t pos = 0;
   int errval = 0;
   int ret;
 
@@ -1899,8 +1898,6 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
           ret = -errval;
           goto errout_with_session;
         }
-
-      pos += (off_t)seekoffs;
     }
 
   /* Send success message */
@@ -2063,10 +2060,6 @@ static int ftpd_stream(FAR struct ftpd_session_s *session, int cmdtype)
           ret = -errval;
           break;
         }
-
-      /* Get the next file offset */
-
-      pos += (off_t)wrbytes;
     }
 
 errout_with_session:;


### PR DESCRIPTION
## Summary
Report by: https://github.com/apache/incubator-nuttx/actions/runs/3318241409/jobs/5482179373

## Impact
Fix warning

## Testing
Pass CI
