### PR TITLE
README.md: Update NuttX Porting Guide Online link

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ A: Here are three:
       You can copy any pieces that you like from the old apps/directory to your
       custom apps directory as necessary.
 
-      This is documented in `NuttX/boards/README.txt`.
+      This is documented in `NuttX/boards/README.txt` and `NuttX Porting Guide`
+      online at <https://cwiki.apache.org/confluence/display/NUTTX/Porting+Guide>.
 
    3) If you like the random collection of stuff in the `apps/` directory but
       just want to expand the existing components with your own, external


### PR DESCRIPTION
## Summary

Removing NuttX Porting Guide Online link directly is unfriendly, please refer to https://github.com/apache/incubator-nuttx-apps/pull/1380#issuecomment-1288098689, so update this link to make it easier for users.

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

## Testing

