### PR TITLE
Fix the compiler warning

### DIFF
--- a/netutils/discover/discover.c
+++ b/netutils/discover/discover.c
@@ -207,7 +207,8 @@ static int discover_daemon(int argc, char *argv[])
           continue;
         }
 
-      ninfo("Received discover from %08lx'\n", srcaddr.sin_addr.s_addr);
+      ninfo("Received discover from %08" PRIx32 "\n",
+            srcaddr.sin_addr.s_addr);
 
       discover_respond(&srcaddr.sin_addr.s_addr);
     }
@@ -356,7 +357,7 @@ static inline int discover_openlistener(void)
     }
 
   g_state.serverip = ((struct sockaddr_in *)&req.ifr_addr)->sin_addr.s_addr;
-  ninfo("serverip: %08lx\n", ntohl(g_state.serverip));
+  ninfo("serverip: %08" PRIx32 "\n", ntohl(g_state.serverip));
 
   /* Bind the socket to a local port. We have to bind to INADDRY_ANY to
    * receive broadcast messages.


### PR DESCRIPTION
## Summary
```
Error: discover.c:210:13: error: format '%lx' expects argument of type 'long unsigned int', but argument 3 has type 'in_addr_t' {aka 'unsigned int'} [-Werror=format=]
  210 |       ninfo("Received discover from %08lx'\n", srcaddr.sin_addr.s_addr);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                |
      |                                                                in_addr_t {aka unsigned int}
discover.c:210:41: note: format string is defined here
  210 |       ninfo("Received discover from %08lx'\n", srcaddr.sin_addr.s_addr);
      |                                     ~~~~^
      |                                         |
      |                                         long unsigned int
      |                                     %08x
In file included from discover.c:25:
discover.c: In function 'discover_openlistener':
Error: discover.c:359:9: error: format '%lx' expects argument of type 'long unsigned int', but argument 3 has type 'uint32_t' {aka 'unsigned int'} [-Werror=format=]
  359 |   ninfo("serverip: %08lx\n", ntohl(g_state.serverip));
      |         ^~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~
      |                              |
      |                              uint32_t {aka unsigned int}
discover.c:359:24: note: format string is defined here
  359 |   ninfo("serverip: %08lx\n", ntohl(g_state.serverip));
      |                    ~~~~^
      |                        |
      |                        long unsigned int
      |                    %08x
```

## Impact
Minor

## Testing
Pass CI
