### PR TITLE
alarm: using timegm instead of mktime beacuse rtc is gmt time

### DIFF
--- a/examples/alarm/alarm_main.c
+++ b/examples/alarm/alarm_main.c
@@ -334,14 +334,14 @@ int main(int argc, FAR char *argv[])
            * alarm expiring in year 1900.
            */
 
-          timeleft = mktime((struct tm *)&rd.time) - now;
+          timeleft = timegm((struct tm *)&rd.time) - now;
         }
       else
         {
           struct tm now_tm;
 
           /* Periodic extend "partial" alarms by "unfolding" months,
-           * until we get alarm that is in future. Note that mktime()
+           * until we get alarm that is in future. Note that timegm()
            * normalizes fields that are out of their valid values,
            * so we don't have to handle carry to tm_year by ourselves.
            */
@@ -352,7 +352,7 @@ int main(int argc, FAR char *argv[])
 
           do
           {
-            timeleft = mktime((struct tm *)&rd.time) - now;
+            timeleft = timegm((struct tm *)&rd.time) - now;
             if (timeleft < 0)
               {
                 rd.time.tm_mon++;


### PR DESCRIPTION

## Summary

alarm: using timegm instead of mktime beacuse rtc is gmt time

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>

## Impact
correct for command: alarm -r 
## Testing
local test
