### PR TITLE
industry/foc/fixed16/foc_ident.c: improvements

### DIFF
--- a/industry/foc/fixed16/foc_ident.c
+++ b/industry/foc/fixed16/foc_ident.c
@@ -314,8 +314,8 @@ int foc_ident_ind_run_b16(FAR struct foc_ident_b16_s *ident,
       tmp1 = b16muli(ident->curr1_sum, 2);
       tmp2 = b16muli(ident->curr2_sum, 2);
 
-      curr1_avg = b16divb16(tmp1, ident->cntr);
-      curr2_avg = b16divb16(tmp2, ident->cntr);
+      curr1_avg = b16divi(tmp1, ident->cntr);
+      curr2_avg = b16divi(tmp2, ident->cntr);
 
       /* Average delta current */
 
@@ -374,7 +374,7 @@ int foc_ident_ind_run_b16(FAR struct foc_ident_b16_s *ident,
 int foc_routine_ident_init_b16(FAR foc_routine_b16_t *r)
 {
   FAR struct foc_ident_b16_s *i   = NULL;
- int ret = OK;
+  int ret = OK;
 
   DEBUGASSERT(r);
 

--- a/industry/foc/fixed16/foc_ident.c
+++ b/industry/foc/fixed16/foc_ident.c
@@ -39,6 +39,7 @@
  ****************************************************************************/
 
 #define IDENT_PI_KP           (ftob16(0.0f))
+#define B16UPPERLIMIT         (0x7e000000)
 
 /****************************************************************************
  * Private Data Types
@@ -211,6 +212,15 @@ int foc_ident_res_run_b16(FAR struct foc_ident_b16_s *ident,
       ident->curr_sum += vector2d_mag_b16(in->foc_state->idq.q,
                                           in->foc_state->idq.d);
     }
+
+  /* Overflow protection */
+
+  if (ident->volt_sum > B16UPPERLIMIT || ident->curr_sum > B16UPPERLIMIT)
+    {
+      ret = -EOVERFLOW;
+      goto errout;
+    }
+
   if (ident->cntr > ident->cfg.res_steps)
     {
       /* Get resistance */
@@ -243,6 +253,7 @@ int foc_ident_res_run_b16(FAR struct foc_ident_b16_s *ident,
       ident->volt_sum = 0;
     }
 
+errout:
   return ret;
 }
 
@@ -287,6 +298,14 @@ int foc_ident_ind_run_b16(FAR struct foc_ident_b16_s *ident,
       /* Average top current */
 
       ident->curr2_sum += in->foc_state->idq.d;
+    }
+
+  /* Overflow protection */
+
+  if (ident->curr1_sum > B16UPPERLIMIT || ident->curr2_sum > B16UPPERLIMIT)
+    {
+      ret = -EOVERFLOW;
+      goto errout;
     }
 
   /* Invert voltage to generate square wave D voltage */
@@ -357,6 +376,7 @@ int foc_ident_ind_run_b16(FAR struct foc_ident_b16_s *ident,
       ident->curr2_sum = 0;
     }
 
+errout:
   return ret;
 }
 

--- a/industry/foc/float/foc_ident.c
+++ b/industry/foc/float/foc_ident.c
@@ -81,6 +81,7 @@ struct foc_ident_f32_s
   float                                sign;
   float                                curr1_sum;
   float                                curr2_sum;
+
 #ifdef CONFIG_INDUSTRY_FOC_IDENT_FLUX
   /* global data in flux linkage identification */
 


### PR DESCRIPTION
## Summary

- industry/foc/fixed16/foc_ident.c: port changes from float32 implementation
- industry/foc/fixed16/foc_ident.c: fix div operation
- industry/foc/fixed16/foc_ident.c: add b16_t overflow protection

## Impact

## Testing
nucleo-g431rb/ihm16m1
