### PR TITLE
examples/foc: various improvements and refactor

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -315,11 +315,13 @@ config EXAMPLES_FOC_FMODE
 config EXAMPLES_FOC_MMODE
 	int "Motor control mode"
 	default 2
-	range 1 3
+	range 1 5
 	---help---
 		1 - torque control
 		2 - velocity control
 		3 - position control
+		4 - align only
+		5 - ident only
 
 config EXAMPLES_FOC_OPENLOOP_Q
 	int "FOC open-loop Vq/Iq setting [x1000]"

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -236,6 +236,14 @@ struct foc_thr_cfg_s
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
   uint32_t posmax;              /* Position max (x1000) */
 #endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  uint32_t ident_res_ki;        /* Ident res Ki (x1000) */
+  uint32_t ident_res_curr;      /* Ident res current (x1000) */
+  uint32_t ident_res_sec;       /* Ident res sec */
+  uint32_t ident_ind_volt;      /* Ident res voltage (x1000) */
+  uint32_t ident_ind_sec;       /* Ident ind sec */
+#endif
 };
 
 #endif /* __APPS_EXAMPLES_FOC_FOC_CFG_H */

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -210,4 +210,32 @@
 #  endif
 #endif
 
+/****************************************************************************
+ * Public Type Definition
+ ****************************************************************************/
+
+struct foc_thr_cfg_s
+{
+  int      fmode;               /* FOC control mode */
+  int      mmode;               /* Motor control mode */
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
+  int      qparam;              /* Open-loop Q setting (x1000) */
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
+  uint32_t foc_pi_kp;           /* FOC PI Kp (x1000) */
+  uint32_t foc_pi_ki;           /* FOC PI Ki (x1000) */
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
+  uint32_t torqmax;             /* Torque max (x1000) */
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
+  uint32_t velmax;              /* Velocity max (x1000) */
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
+  uint32_t posmax;              /* Position max (x1000) */
+#endif
+};
+
 #endif /* __APPS_EXAMPLES_FOC_FOC_CFG_H */

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -343,24 +343,7 @@ int main(int argc, char *argv[])
     {
       /* Get configuration */
 
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-      foc[i].qparam   = g_args.cfg.qparam;
-#endif
-      foc[i].fmode    = g_args.cfg.fmode;
-      foc[i].mmode    = g_args.cfg.mmode;
-#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-      foc[i].foc_pi_kp = g_args.cfg.foc_pi_kp;
-      foc[i].foc_pi_ki = g_args.cfg.foc_pi_ki;
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-      foc[i].torqmax  = g_args.cfg.torqmax;
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-      foc[i].velmax   = g_args.cfg.velmax;
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-      foc[i].posmax   = g_args.cfg.posmax;
-#endif
+      foc[i].cfg = &g_args.cfg;
 
       if (g_args.en & (1 << i))
         {

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -96,6 +96,13 @@ struct args_s g_args =
     .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
 #  endif
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+    .ident_res_ki = CONFIG_EXAMPLES_FOC_IDENT_RES_KI,
+    .ident_res_curr = CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT,
+    .ident_res_sec = CONFIG_EXAMPLES_FOC_IDENT_RES_SEC,
+    .ident_ind_volt = CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE,
+    .ident_ind_sec = CONFIG_EXAMPLES_FOC_IDENT_IND_SEC,
+#endif
   }
 };
 

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -71,12 +71,10 @@ struct args_s g_args =
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
     .qparam = CONFIG_EXAMPLES_FOC_OPENLOOP_Q,
 #endif
-
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
     .foc_pi_kp = CONFIG_EXAMPLES_FOC_IDQ_KP,
     .foc_pi_ki = CONFIG_EXAMPLES_FOC_IDQ_KI,
 #endif
-
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
     .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
@@ -104,85 +102,6 @@ struct args_s g_args =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: validate_args
- ****************************************************************************/
-
-static int validate_args(FAR struct args_s *args)
-{
-  int ret = -EINVAL;
-
-#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  /* Current PI controller */
-
-  if (args->cfg.foc_pi_kp == 0 && args->cfg.foc_pi_ki == 0)
-    {
-      PRINTF("ERROR: missing FOC Kp/Ki configuration\n");
-      goto errout;
-    }
-#endif
-
-  /* FOC operation mode */
-
-  if (args->cfg.fmode != FOC_FMODE_IDLE &&
-      args->cfg.fmode != FOC_FMODE_VOLTAGE &&
-      args->cfg.fmode != FOC_FMODE_CURRENT)
-    {
-      PRINTF("Invalid op mode value %d s\n", args->cfg.fmode);
-      goto errout;
-    }
-
-  /* Example control mode */
-
-  if (
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-    args->cfg.mmode != FOC_MMODE_TORQ &&
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-    args->cfg.mmode != FOC_MMODE_VEL &&
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-    args->cfg.mmode != FOC_MMODE_POS &&
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
-    args->cfg.mmode != FOC_MMODE_ALIGN_ONLY &&
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
-    args->cfg.mmode != FOC_MMODE_IDENT_ONLY &&
-#endif
-    1)
-    {
-      PRINTF("Invalid ctrl mode value %d s\n", args->cfg.mmode);
-      goto errout;
-    }
-
-  /* Example state */
-
-  if (args->state != FOC_EXAMPLE_STATE_FREE &&
-      args->state != FOC_EXAMPLE_STATE_STOP &&
-      args->state != FOC_EXAMPLE_STATE_CW &&
-      args->state != FOC_EXAMPLE_STATE_CCW)
-    {
-      PRINTF("Invalid state value %d s\n", args->state);
-      goto errout;
-    }
-
-  /* Time parameter */
-
-  if (args->time <= 0 && args->time != -1)
-    {
-      PRINTF("Invalid time value %d s\n", args->time);
-      goto errout;
-    }
-
-  /* Otherwise OK */
-
-  ret = OK;
-
-errout:
-  return ret;
-}
 
 /****************************************************************************
  * Name: foc_mq_send

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -62,40 +62,43 @@
 struct args_s g_args =
 {
   .time  = CONFIG_EXAMPLES_FOC_TIME_DEFAULT,
-  .fmode = CONFIG_EXAMPLES_FOC_FMODE,
-  .mmode = CONFIG_EXAMPLES_FOC_MMODE,
+  .state = CONFIG_EXAMPLES_FOC_STATE_INIT,
+  .en    = INST_EN_DEFAULT,
+  .cfg =
+  {
+    .fmode = CONFIG_EXAMPLES_FOC_FMODE,
+    .mmode = CONFIG_EXAMPLES_FOC_MMODE,
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-  .qparam = CONFIG_EXAMPLES_FOC_OPENLOOP_Q,
+    .qparam = CONFIG_EXAMPLES_FOC_OPENLOOP_Q,
 #endif
 
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  .foc_pi_kp = CONFIG_EXAMPLES_FOC_IDQ_KP,
-  .foc_pi_ki = CONFIG_EXAMPLES_FOC_IDQ_KI,
+    .foc_pi_kp = CONFIG_EXAMPLES_FOC_IDQ_KP,
+    .foc_pi_ki = CONFIG_EXAMPLES_FOC_IDQ_KI,
 #endif
 
-  .state = CONFIG_EXAMPLES_FOC_STATE_INIT,
-  .en    = INST_EN_DEFAULT,
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-  .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+    .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
 #  endif
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-  .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+    .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
 #  endif
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-  .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+    .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
 #  endif
 #else
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-  .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+    .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
 #  endif
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-  .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+    .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
 #  endif
 #  ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-  .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+    .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
 #  endif
 #endif
+  }
 };
 
 /****************************************************************************
@@ -113,7 +116,7 @@ static int validate_args(FAR struct args_s *args)
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   /* Current PI controller */
 
-  if (args->foc_pi_kp == 0 && args->foc_pi_ki == 0)
+  if (args->cfg.foc_pi_kp == 0 && args->cfg.foc_pi_ki == 0)
     {
       PRINTF("ERROR: missing FOC Kp/Ki configuration\n");
       goto errout;
@@ -122,11 +125,11 @@ static int validate_args(FAR struct args_s *args)
 
   /* FOC operation mode */
 
-  if (args->fmode != FOC_FMODE_IDLE &&
-      args->fmode != FOC_FMODE_VOLTAGE &&
-      args->fmode != FOC_FMODE_CURRENT)
+  if (args->cfg.fmode != FOC_FMODE_IDLE &&
+      args->cfg.fmode != FOC_FMODE_VOLTAGE &&
+      args->cfg.fmode != FOC_FMODE_CURRENT)
     {
-      PRINTF("Invalid op mode value %d s\n", args->fmode);
+      PRINTF("Invalid op mode value %d s\n", args->cfg.fmode);
       goto errout;
     }
 
@@ -134,23 +137,23 @@ static int validate_args(FAR struct args_s *args)
 
   if (
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-    args->mmode != FOC_MMODE_TORQ &&
+    args->cfg.mmode != FOC_MMODE_TORQ &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-    args->mmode != FOC_MMODE_VEL &&
+    args->cfg.mmode != FOC_MMODE_VEL &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-    args->mmode != FOC_MMODE_POS &&
+    args->cfg.mmode != FOC_MMODE_POS &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
-    args->mmode != FOC_MMODE_ALIGN_ONLY &&
+    args->cfg.mmode != FOC_MMODE_ALIGN_ONLY &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
-    args->mmode != FOC_MMODE_IDENT_ONLY &&
+    args->cfg.mmode != FOC_MMODE_IDENT_ONLY &&
 #endif
     1)
     {
-      PRINTF("Invalid ctrl mode value %d s\n", args->mmode);
+      PRINTF("Invalid ctrl mode value %d s\n", args->cfg.mmode);
       goto errout;
     }
 
@@ -341,22 +344,22 @@ int main(int argc, char *argv[])
       /* Get configuration */
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-      foc[i].qparam   = g_args.qparam;
+      foc[i].qparam   = g_args.cfg.qparam;
 #endif
-      foc[i].fmode    = g_args.fmode;
-      foc[i].mmode    = g_args.mmode;
+      foc[i].fmode    = g_args.cfg.fmode;
+      foc[i].mmode    = g_args.cfg.mmode;
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-      foc[i].foc_pi_kp = g_args.foc_pi_kp;
-      foc[i].foc_pi_ki = g_args.foc_pi_ki;
+      foc[i].foc_pi_kp = g_args.cfg.foc_pi_kp;
+      foc[i].foc_pi_ki = g_args.cfg.foc_pi_ki;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-      foc[i].torqmax  = g_args.torqmax;
+      foc[i].torqmax  = g_args.cfg.torqmax;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-      foc[i].velmax   = g_args.velmax;
+      foc[i].velmax   = g_args.cfg.velmax;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-      foc[i].posmax   = g_args.posmax;
+      foc[i].posmax   = g_args.cfg.posmax;
 #endif
 
       if (g_args.en & (1 << i))

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -56,73 +56,51 @@
 #define INST_EN_DEFAULT (0xff)
 
 /****************************************************************************
- * Private Functions
+ * Private Data
  ****************************************************************************/
 
-/****************************************************************************
- * Name: init_args
- ****************************************************************************/
-
-static void init_args(FAR struct args_s *args)
+struct args_s g_args =
 {
-  args->time =
-    (args->time == 0 ? CONFIG_EXAMPLES_FOC_TIME_DEFAULT : args->time);
-  args->fmode =
-    (args->fmode == 0 ? CONFIG_EXAMPLES_FOC_FMODE : args->fmode);
-  args->mmode =
-    (args->mmode == 0 ? CONFIG_EXAMPLES_FOC_MMODE : args->mmode);
+  .time  = CONFIG_EXAMPLES_FOC_TIME_DEFAULT,
+  .fmode = CONFIG_EXAMPLES_FOC_FMODE,
+  .mmode = CONFIG_EXAMPLES_FOC_MMODE,
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-  args->qparam =
-    (args->qparam == 0 ? CONFIG_EXAMPLES_FOC_OPENLOOP_Q : args->qparam);
+  .qparam = CONFIG_EXAMPLES_FOC_OPENLOOP_Q,
 #endif
 
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  args->foc_pi_kp =
-    (args->foc_pi_kp == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KP : args->foc_pi_kp);
-  args->foc_pi_ki =
-    (args->foc_pi_ki == 0 ? CONFIG_EXAMPLES_FOC_IDQ_KI : args->foc_pi_ki);
+  .foc_pi_kp = CONFIG_EXAMPLES_FOC_IDQ_KP,
+  .foc_pi_ki = CONFIG_EXAMPLES_FOC_IDQ_KI,
 #endif
 
-  /* Setpoint configuration */
+  .state = CONFIG_EXAMPLES_FOC_STATE_INIT,
+  .en    = INST_EN_DEFAULT,
+#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
+  .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+#  endif
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
+  .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+#  endif
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
+  .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE,
+#  endif
+#else
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
+  .torqmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+#  endif
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
+  .velmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+#  endif
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
+  .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
+#  endif
+#endif
+};
 
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
-  args->torqmax =
-    (args->torqmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE : args->torqmax);
-#else
-  args->torqmax =
-    (args->torqmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_MAX : args->torqmax);
-#endif
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
-  args->velmax =
-    (args->velmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE : args->velmax);
-#else
-  args->velmax =
-    (args->velmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_MAX : args->velmax);
-#endif
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-#ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
-  args->posmax =
-    (args->posmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE : args->posmax);
-#else
-  args->posmax =
-    (args->posmax == 0 ?
-     CONFIG_EXAMPLES_FOC_SETPOINT_MAX : args->posmax);
-#endif
-#endif
-
-  args->state =
-    (args->state == 0 ? CONFIG_EXAMPLES_FOC_STATE_INIT : args->state);
-  args->en = (args->en == -1 ? INST_EN_DEFAULT : args->en);
-}
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: validate_args
@@ -297,7 +275,6 @@ int main(int argc, char *argv[])
   struct foc_ctrl_env_s  foc[CONFIG_MOTOR_FOC_INST];
   pthread_t              threads[CONFIG_MOTOR_FOC_INST];
   mqd_t                  mqd[CONFIG_MOTOR_FOC_INST];
-  struct args_s          args;
   struct foc_intf_data_s data;
   int                    ret          = OK;
   int                    i            = 0;
@@ -305,29 +282,20 @@ int main(int argc, char *argv[])
 
   /* Reset some data */
 
-  memset(&args, 0, sizeof(struct args_s));
   memset(mqd, 0, sizeof(mqd_t) * CONFIG_MOTOR_FOC_INST);
   memset(foc, 0, sizeof(struct foc_ctrl_env_s) * CONFIG_MOTOR_FOC_INST);
   memset(threads, 0, sizeof(pthread_t) * CONFIG_MOTOR_FOC_INST);
   memset(&data, 0, sizeof(struct foc_intf_data_s));
 
-  /* Initialize args before parse */
-
-  args.en = -1;
-
 #ifdef CONFIG_BUILTIN
   /* Parse the command line */
 
-  parse_args(&args, argc, argv);
+  parse_args(&g_args, argc, argv);
 #endif
-
-  /* Initialize args */
-
-  init_args(&args);
 
   /* Validate arguments */
 
-  ret = validate_args(&args);
+  ret = validate_args(&g_args);
   if (ret < 0)
     {
       PRINTF("ERROR: validate args failed\n");
@@ -373,25 +341,25 @@ int main(int argc, char *argv[])
       /* Get configuration */
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-      foc[i].qparam   = args.qparam;
+      foc[i].qparam   = g_args.qparam;
 #endif
-      foc[i].fmode    = args.fmode;
-      foc[i].mmode    = args.mmode;
+      foc[i].fmode    = g_args.fmode;
+      foc[i].mmode    = g_args.mmode;
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-      foc[i].foc_pi_kp = args.foc_pi_kp;
-      foc[i].foc_pi_ki = args.foc_pi_ki;
+      foc[i].foc_pi_kp = g_args.foc_pi_kp;
+      foc[i].foc_pi_ki = g_args.foc_pi_ki;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-      foc[i].torqmax  = args.torqmax;
+      foc[i].torqmax  = g_args.torqmax;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-      foc[i].velmax   = args.velmax;
+      foc[i].velmax   = g_args.velmax;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-      foc[i].posmax   = args.posmax;
+      foc[i].posmax   = g_args.posmax;
 #endif
 
-      if (args.en & (1 << i))
+      if (g_args.en & (1 << i))
         {
           /* Initialize controller thread if enabled */
 
@@ -422,7 +390,7 @@ int main(int argc, char *argv[])
 
   /* Controller state */
 
-  data.state = args.state;
+  data.state = g_args.state;
 
   /* Auxliary control loop */
 
@@ -445,7 +413,7 @@ int main(int argc, char *argv[])
         {
           for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
             {
-              if (args.en & (1 << i))
+              if (g_args.en & (1 << i))
                 {
                   PRINTFV("Send vbus to %d\n", i);
 
@@ -471,7 +439,7 @@ int main(int argc, char *argv[])
         {
           for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
             {
-              if (args.en & (1 << i))
+              if (g_args.en & (1 << i))
                 {
                   PRINTFV("Send state %" PRIu32 " to %d\n", data.state, i);
 
@@ -497,7 +465,7 @@ int main(int argc, char *argv[])
         {
           for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
             {
-              if (args.en & (1 << i))
+              if (g_args.en & (1 << i))
                 {
                   PRINTFV("Send setpoint = %" PRIu32 "to %d\n",
                           data.sp_raw, i);
@@ -524,7 +492,7 @@ int main(int argc, char *argv[])
         {
           for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
             {
-              if (args.en & (1 << i))
+              if (g_args.en & (1 << i))
                 {
                   PRINTFV("Send start to %d\n", i);
 
@@ -548,9 +516,9 @@ int main(int argc, char *argv[])
 
       time += 1;
 
-      if (args.time != -1)
+      if (g_args.time != -1)
         {
-          if (time >= (args.time * (1000000 / MAIN_LOOP_USLEEP)))
+          if (time >= (g_args.time * (1000000 / MAIN_LOOP_USLEEP)))
             {
               /* Exit loop */
 
@@ -574,7 +542,7 @@ errout:
 
   for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
     {
-      if (args.en & (1 << i))
+      if (g_args.en & (1 << i))
         {
           if (mqd[i] != (mqd_t)-1)
             {
@@ -600,7 +568,7 @@ errout:
 
   for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
     {
-      if (args.en & (1 << i))
+      if (g_args.en & (1 << i))
         {
           /* Close FOC control thread queue */
 

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -988,16 +988,16 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
   /* Initialize motor identification data */
 
   ident_cfg.per         = motor->per;
-  ident_cfg.res_current = ftob16(CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT /
+  ident_cfg.res_current = ftob16(motor->envp->cfg->ident_res_curr /
                                  1000.0f);
-  ident_cfg.res_ki      = ftob16(CONFIG_EXAMPLES_FOC_IDENT_RES_KI /
+  ident_cfg.res_ki      = ftob16(motor->envp->cfg->ident_res_ki /
                                  1000.0f);
-  ident_cfg.ind_volt    = ftob16(CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE /
+  ident_cfg.ind_volt    = ftob16(motor->envp->cfg->ident_ind_volt /
                                  1000.0f);
   ident_cfg.res_steps   = (CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ *
-                           CONFIG_EXAMPLES_FOC_IDENT_RES_SEC / 1000);
+                           motor->envp->cfg->ident_res_sec / 1000);
   ident_cfg.ind_steps   = (CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ *
-                           CONFIG_EXAMPLES_FOC_IDENT_IND_SEC / 1000);
+                           motor->envp->cfg->ident_ind_sec / 1000);
   ident_cfg.idle_steps  = CONFIG_EXAMPLES_FOC_IDENT_IDLE;
 
   ret = foc_routine_cfg_b16(&motor->ident, &ident_cfg);

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -972,13 +972,13 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
   /* Initialize motor identification data */
 
   ident_cfg.per         = motor->per;
-  ident_cfg.res_current = (CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT / 1000.0f);
-  ident_cfg.res_ki      = (CONFIG_EXAMPLES_FOC_IDENT_RES_KI / 1000.0f);
-  ident_cfg.ind_volt    = (CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE / 1000.0f);
+  ident_cfg.res_current = (motor->envp->cfg->ident_res_curr / 1000.0f);
+  ident_cfg.res_ki      = (motor->envp->cfg->ident_res_ki / 1000.0f);
+  ident_cfg.ind_volt    = (motor->envp->cfg->ident_ind_volt / 1000.0f);
   ident_cfg.res_steps   = (CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ * \
-                           CONFIG_EXAMPLES_FOC_IDENT_RES_SEC / 1000);
+                           motor->envp->cfg->ident_res_sec / 1000);
   ident_cfg.ind_steps   = (CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ * \
-                           CONFIG_EXAMPLES_FOC_IDENT_IND_SEC / 1000);
+                           motor->envp->cfg->ident_ind_sec / 1000);
   ident_cfg.idle_steps  = CONFIG_EXAMPLES_FOC_IDENT_IDLE;
 
   ret = foc_routine_cfg_f32(&motor->ident, &ident_cfg);

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -39,6 +39,12 @@
 #define OPT_FKI     (SCHAR_MAX + 1)
 #define OPT_FKP     (SCHAR_MAX + 2)
 
+#define OPT_IRKI    (SCHAR_MAX + 3)
+#define OPT_IRC     (SCHAR_MAX + 4)
+#define OPT_IRS     (SCHAR_MAX + 5)
+#define OPT_IIV     (SCHAR_MAX + 6)
+#define OPT_IIS     (SCHAR_MAX + 7)
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -66,6 +72,13 @@ static struct option g_long_options[] =
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
     { "fkp", required_argument, 0, OPT_FKP },
     { "fki", required_argument, 0, OPT_FKI },
+#endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+    { "irki", required_argument, 0, OPT_IRKI },
+    { "irc", required_argument, 0, OPT_IRC },
+    { "irs", required_argument, 0, OPT_IRS },
+    { "iiv", required_argument, 0, OPT_IIV },
+    { "iis", required_argument, 0, OPT_IIS },
 #endif
     { 0, 0, 0, 0 }
   };
@@ -127,6 +140,18 @@ static void foc_help(void)
   PRINTF("  [--fkp] PI Ki coefficient [x1000] (default: %d)\n",
          CONFIG_EXAMPLES_FOC_IDQ_KI);
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  PRINTF("  [--irki] res Ki coefficient [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDENT_RES_KI);
+  PRINTF("  [--irc] res current [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT);
+  PRINTF("  [--irs] res sec (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDENT_RES_SEC);
+  PRINTF("  [--iiv] ind voltage [x1000] (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE);
+  PRINTF("  [--iis] ind sec (default: %d)\n",
+         CONFIG_EXAMPLES_FOC_IDENT_IND_SEC);
+#endif
 }
 
 /****************************************************************************
@@ -164,6 +189,38 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
           case OPT_FKI:
             {
               args->cfg.foc_pi_ki = atoi(optarg);
+              break;
+            }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+          case OPT_IRKI:
+            {
+              args->cfg.ident_res_ki = atoi(optarg);
+              break;
+            }
+
+          case OPT_IRC:
+            {
+              args->cfg.ident_res_curr = atoi(optarg);
+              break;
+            }
+
+          case OPT_IRS:
+            {
+              args->cfg.ident_res_sec = atoi(optarg);
+              break;
+            }
+
+          case OPT_IIV:
+            {
+              args->cfg.ident_ind_volt = atoi(optarg);
+              break;
+            }
+
+          case OPT_IIS:
+            {
+              args->cfg.ident_ind_sec = atoi(optarg);
               break;
             }
 #endif
@@ -326,6 +383,23 @@ int validate_args(FAR struct args_s *args)
       PRINTF("Invalid time value %d s\n", args->time);
       goto errout;
     }
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
+  /* Motor identification parameters */
+
+  if (args->cfg.ident_res_ki == 0 || args->cfg.ident_res_curr == 0 ||
+      args->cfg.ident_res_sec == 0)
+    {
+      PRINTF("ERROR: missing motor res ident configuration\n");
+      goto errout;
+    }
+
+  if (args->cfg.ident_ind_volt == 0 || args->cfg.ident_ind_sec == 0)
+    {
+      PRINTF("ERROR: missing motor ind ident configuration\n");
+      goto errout;
+    }
+#endif
 
   /* Otherwise OK */
 

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -156,13 +156,13 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
           case OPT_FKP:
             {
-              args->foc_pi_kp = atoi(optarg);
+              args->cfg.foc_pi_kp = atoi(optarg);
               break;
             }
 
           case OPT_FKI:
             {
-              args->foc_pi_ki = atoi(optarg);
+              args->cfg.foc_pi_ki = atoi(optarg);
               break;
             }
 #endif
@@ -181,20 +181,20 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 
           case 'f':
             {
-              args->fmode = atoi(optarg);
+              args->cfg.fmode = atoi(optarg);
               break;
             }
 
           case 'm':
             {
-              args->mmode = atoi(optarg);
+              args->cfg.mmode = atoi(optarg);
               break;
             }
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
           case 'r':
             {
-              args->torqmax = atoi(optarg);
+              args->cfg.torqmax = atoi(optarg);
               break;
             }
 #endif
@@ -202,7 +202,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
           case 'v':
             {
-              args->velmax = atoi(optarg);
+              args->cfg.velmax = atoi(optarg);
               break;
             }
 #endif
@@ -210,7 +210,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
           case 'x':
             {
-              args->posmax = atoi(optarg);
+              args->cfg.posmax = atoi(optarg);
               break;
             }
 #endif
@@ -230,7 +230,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
           case 'o':
             {
-              args->qparam = atoi(optarg);
+              args->cfg.qparam = atoi(optarg);
               break;
             }
 #endif

--- a/examples/foc/foc_parseargs.h
+++ b/examples/foc/foc_parseargs.h
@@ -62,4 +62,10 @@ struct args_s
 
 void parse_args(FAR struct args_s *args, int argc, FAR char **argv);
 
+/****************************************************************************
+ * Name: validate_args
+ ****************************************************************************/
+
+int validate_args(FAR struct args_s *args);
+
 #endif /* __APPS_EXAMPLES_FOC_FOC_THR_H */

--- a/examples/foc/foc_parseargs.h
+++ b/examples/foc/foc_parseargs.h
@@ -28,6 +28,7 @@
 #include <nuttx/config.h>
 
 #include "foc_device.h"
+#include "foc_cfg.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -41,29 +42,10 @@
 
 struct args_s
 {
-  int      time;                /* Run time limit in sec, -1 if forever */
-  int      fmode;               /* FOC control mode */
-  int      mmode;               /* Motor control mode */
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-  int      qparam;              /* Open-loop Q setting (x1000) */
-#endif
-
-#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  uint32_t foc_pi_kp;           /* FOC PI Kp (x1000) */
-  uint32_t foc_pi_ki;           /* FOC PI Ki (x1000) */
-#endif
-
-  int      state;               /* Example state (FREE, CW, CCW, STOP) */
-  int8_t   en;                  /* Enabled instances (bit-encoded) */
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-  uint32_t torqmax;             /* Torque max (x1000) */
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-  uint32_t velmax;              /* Velocity max (x1000) */
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-  uint32_t posmax;              /* Position max (x1000) */
-#endif
+  int                  time;    /* Run time limit in sec, -1 if forever */
+  int                  state;   /* Example state (FREE, CW, CCW, STOP) */
+  int8_t               en;      /* Enabled instances (bit-encoded) */
+  struct foc_thr_cfg_s cfg;     /* Control thread configuration */
 };
 
 /****************************************************************************

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -105,30 +105,11 @@ enum foc_controller_state_e
 
 struct foc_ctrl_env_s
 {
-  mqd_t               mqd;      /* Control msg queue */
-  int                 id;       /* FOC device id */
-  int                 inst;     /* Type specific instance counter */
-  int                 type;     /* Controller type */
-  int                 fmode;    /* FOC control mode */
-  int                 mmode;    /* Motor control mode */
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
-  int                 qparam;   /* Open-loop Q setting (x1000) */
-#endif
-
-#ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
-  uint32_t            foc_pi_kp; /* FOC PI Kp (x1000) */
-  uint32_t            foc_pi_ki; /* FOC PI Ki (x1000) */
-#endif
-
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-  uint32_t            torqmax;  /* Torque max (x1000) */
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-  uint32_t            velmax;   /* Velocity max (x1000) */
-#endif
-#ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-  uint32_t            posmax;   /* Position max (x1000) */
-#endif
+  mqd_t                mqd;     /* Control msg queue */
+  int                  id;      /* FOC device id */
+  int                  inst;    /* Type specific instance counter */
+  int                  type;    /* Controller type */
+  struct foc_thr_cfg_s *cfg;    /* Control thread configuration */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- examples/foc: refactor args
- examples/foc: separate control thread configuration from general args
- examples/foc: simplify control thread configuration
- examples/foc: move validate_args to parseargs file
- examples/foc/Kconfig: update EXAMPLES_FOC_MMODE range
- examples/foc: control motor identification parameters from cmd line

## Impact

## Testing
nucleo-g431rb/ihm16m1
