### PR TITLE
Improve tcp_ipc_server LoraWAN module communication

### DIFF
--- a/examples/tcp_ipc_server/lorawan/uart_lorawan_layer.h
+++ b/examples/tcp_ipc_server/lorawan/uart_lorawan_layer.h
@@ -29,6 +29,7 @@
 #define APP_EUI_SIZE                    30
 #define DEVICE_ADDRESS_SIZE             15
 #define CHANNEL_MASK_SIZE               35
+#define ERR_AT_BUSY_ERROR               -1
 
 /****************************************************************************
  * Public Types

--- a/examples/tcp_ipc_server/protocol.c
+++ b/examples/tcp_ipc_server/protocol.c
@@ -80,7 +80,7 @@
 void send_msg_to_lpwan(unsigned char *msg, protocolo_ipc *pt_protocol)
 {
   protocolo_ipc tprotocol;
-  unsigned char buf_recv_downlink[13];
+  unsigned char buf_recv_downlink[12];
   int bytes_recv = 0;
 
   memcpy((unsigned char *)&tprotocol, msg, sizeof(protocolo_ipc));

--- a/examples/tcp_ipc_server/uart_lorawan_layer.c
+++ b/examples/tcp_ipc_server/uart_lorawan_layer.c
@@ -71,8 +71,8 @@ static void clear_uart_rx_buffer(void);
 static int send_uart_lorawan_at_commands(unsigned char * ptr_at_cmd,
                                          int size_at_cmd);
 static int read_uart_lorawan_resp(unsigned char * ptr_response_buffer,
-                                  int size_response_buffer,
-                                  int time_to_wait_ms);
+                                         int size_response_buffer,
+                                         int time_to_wait_ms);
 
 /****************************************************************************
  * Public Functions
@@ -85,6 +85,7 @@ static int read_uart_lorawan_resp(unsigned char * ptr_response_buffer,
 #define PATH_TO_UART1              "/dev/ttyS1"
 #define FULL_AT_CMD_MAX_SIZE       200    
 #define TIME_BETWEEN_AT_CMDS       1 //s
+#define MAX_ATTEMPTS_TO_SEND       3
 
 /****************************************************************************
  * Public variables
@@ -158,12 +159,13 @@ static int read_uart_lorawan_resp(unsigned char * ptr_response_buffer,
                                          int time_to_wait_ms)
 {
   int total_bytes_read_uart = 0;
-  int total_bytes_downlink_msg = 0;
   int bytes_read_uart = 0;
   bool keep_reading = true;
   useconds_t time_to_wait_us = 0;
   char full_response[50];
   char *pos_msg_downlink;
+  char *pos_msg_at_busy_error;
+  int status_read_uart_lorawan_resp = 0;
 
   memset(full_response, 0x00, sizeof(full_response));
 
@@ -204,23 +206,33 @@ static int read_uart_lorawan_resp(unsigned char * ptr_response_buffer,
     }
   while (keep_reading == true);
 
+  /* Check if response message is AT_BUSY_ERROR */
+
+  pos_msg_at_busy_error = strstr(full_response, "AT_BUSY_ERROR");
+
+  if (pos_msg_at_busy_error != NULL)
+    {
+      status_read_uart_lorawan_resp = ERR_AT_BUSY_ERROR;
+      goto END_UART_READ_AT_CMD;
+    }
+
   /* Check if response is a downlink message */
 
   pos_msg_downlink = strstr(full_response, "RX:");
 
   if (pos_msg_downlink == NULL)
     {
-      total_bytes_downlink_msg = 0;
+      status_read_uart_lorawan_resp = 0;
     }
   else
     {
       snprintf((char *)ptr_response_buffer, size_response_buffer, "%s",
                pos_msg_downlink + 3);
-      total_bytes_downlink_msg = strlen((char *)ptr_response_buffer);
+      status_read_uart_lorawan_resp = strlen((char *)ptr_response_buffer);
     }
 
 END_UART_READ_AT_CMD:
-  return total_bytes_downlink_msg;
+  return status_read_uart_lorawan_resp;
 }
 
 /****************************************************************************
@@ -445,7 +457,8 @@ int lorawan_radioenge_send_msg(unsigned char * pt_uplink_hexstring,
                                int max_size_downlink,
                                int time_to_wait_ms)
 {
-  int bytes_rcv_downlink_message = 0;
+  int bytes_rcv_downlink_msg = 0;
+  int number_of_attempts = 0;
   unsigned char at_cmd_send_message[FULL_AT_CMD_MAX_SIZE];
 
   memset(at_cmd_send_message, 0x00, sizeof(at_cmd_send_message));
@@ -465,29 +478,55 @@ int lorawan_radioenge_send_msg(unsigned char * pt_uplink_hexstring,
            FULL_AT_CMD_MAX_SIZE,
            "AT+SENDB=5:%s\n\r",
            pt_uplink_hexstring);
-  printf("\n\r\[LORAWAN] AT CMD: %s\n\r", at_cmd_send_message);
+  printf("\n\r[LORAWAN] AT CMD: %s\n\r", at_cmd_send_message);
 
-  /* Send uplink message */
+  /* Send uplink message (until success or number of attempts exceeds
+   *  what is defined in MAX_ATTEMPTS_TO_SEND)
+   */
 
-  if (send_uart_lorawan_at_commands(at_cmd_send_message,
-      strlen((char *)at_cmd_send_message)) <= 0)
+  while (number_of_attempts < MAX_ATTEMPTS_TO_SEND)
     {
-      printf("\n\r\Error when sending uplink message.\n\r");
-      goto END_SEND_MSG_WITH_DOWNLINK;
+      if (send_uart_lorawan_at_commands(at_cmd_send_message,
+          strlen((char *)at_cmd_send_message)) <= 0)
+        {
+          printf("\n\rError when sending uplink message.\n\r");
+          number_of_attempts++;
+          continue;
+        }
+
+      /* Get downlink message */
+
+      bytes_rcv_downlink_msg = read_uart_lorawan_resp(pt_downlink_hexstring,
+                                                          max_size_downlink,
+                                                          time_to_wait_ms);
+
+      /* If a AT_BUSY is received as command responde, command must
+       * be sent again
+       */
+
+      if (bytes_rcv_downlink_msg == ERR_AT_BUSY_ERROR)
+        {
+          number_of_attempts++;
+          continue;
+        }
+
+      /* If there isn't AT_BUSY_ERROR response, check for downlink
+       * message
+       */
+
+      if (bytes_rcv_downlink_msg == 0)
+        {
+          printf("\n\rNo downlink message has been received.\n\r");
+          break;
+        }
     }
 
-  /* Get downlink message */
-
-  bytes_rcv_downlink_message = read_uart_lorawan_resp(pt_downlink_hexstring,
-                                                      max_size_downlink,
-                                                      time_to_wait_ms);
-
-  if (bytes_rcv_downlink_message == 0)
+  if (number_of_attempts == MAX_ATTEMPTS_TO_SEND)
     {
-      printf("\n\rNo downlink message has been received.\n\r");
+      printf("\n\rError: failed to send command in all %d attempts\n\r",
+             MAX_ATTEMPTS_TO_SEND);
     }
 
-END_SEND_MSG_WITH_DOWNLINK:
   is_lorawan_busy = false;
-  return bytes_rcv_downlink_message;
+  return bytes_rcv_downlink_msg;
 }


### PR DESCRIPTION
## Summary

This PR improves the tcp_ipc_server code, by doing:

- "AT_BUSY_ERROR" (sent from LoRaWAN module) handling
- Retry to send LoRaWAN message (max. 3 times) when "AT_BUSY_ERROR" happens
- Fix downlink message buffer size

## Impact

There's no impact to other projects, it's just a set of improvements to tcp_ipc_server code

## Testing

It was successfully tested on a hardware set (ESP32 + Radioenge LoRaWAN module).
