### PR TITLE
Fix slcd_trapezoids.cxx:38:5: error: array designators are a C99 extension

### DIFF
--- a/graphics/nxwidgets/src/cgraphicsport.cxx
+++ b/graphics/nxwidgets/src/cgraphicsport.cxx
@@ -579,7 +579,7 @@ void CGraphicsPort::drawBitmapGreyScale(nxgl_coord_t x, nxgl_coord_t y,
        src += bitmap->stride;
     }
 
-  delete run;
+  delete[] run;
 }
 
 /**
@@ -824,7 +824,7 @@ void CGraphicsPort::_drawText(struct nxgl_point_s *pos, CRect *bound,
       pos->x += fontWidth;
     }
 
-  delete glyph;
+  delete[] glyph;
 }
 
 /**
@@ -962,7 +962,7 @@ void CGraphicsPort::greyScale(nxgl_coord_t x, nxgl_coord_t y,
                        &origin, rowBitmap.stride) ;
     }
 
-  delete rowBuffer;
+  delete[] rowBuffer;
 }
 
 /**
@@ -1038,5 +1038,5 @@ void CGraphicsPort::invert(nxgl_coord_t x, nxgl_coord_t y,
                        &origin, rowBitmap.stride) ;
     }
 
-  delete rowBuffer;
+  delete[] rowBuffer;
 };

--- a/graphics/nxwidgets/src/cimage.cxx
+++ b/graphics/nxwidgets/src/cimage.cxx
@@ -254,7 +254,7 @@ void CImage::drawContents(CGraphicsPort *port, bool selected)
           if (!m_bitmap->getRun(0, srcRow, nLeftPixels, &buffer[m_origin.x]))
             {
               ginfo("IBitmap::getRun failed at image row %d\n", srcRow);
-              delete buffer;
+              delete[] buffer;
               return;
             }
 
@@ -325,7 +325,7 @@ void CImage::drawContents(CGraphicsPort *port, bool selected)
         }
     }
 
-   delete buffer;
+   delete[] buffer;
 }
 
 /**

--- a/graphics/nxwidgets/src/clabel.cxx
+++ b/graphics/nxwidgets/src/clabel.cxx
@@ -179,7 +179,7 @@ void CLabel::appendText(const CNxString &text)
  * @param index Index at which to insert the text.
  */
 
-void CLabel::insertText(const CNxString &text, const int index)
+void CLabel::insertText(const CNxString &text, const unsigned int index)
 {
   m_text.insert(text, index);
   onTextChange();

--- a/graphics/nxwidgets/src/cscaledbitmap.cxx
+++ b/graphics/nxwidgets/src/cscaledbitmap.cxx
@@ -433,7 +433,7 @@ bool CScaledBitmap::scaleColor(FAR const struct rgbcolor_s &incolor1,
                                FAR const struct rgbcolor_s &incolor2,
                                b16_t fraction, FAR struct rgbcolor_s &outcolor)
 {
-  uint8_t component;
+  uint32_t component;
   b16_t red;
   b16_t green;
   b16_t blue;

--- a/graphics/slcd/slcd_trapezoids.cxx
+++ b/graphics/slcd/slcd_trapezoids.cxx
@@ -35,25 +35,21 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GTop_Runs[NTOP_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 11703,
       .rightx = 31208,
       .y      = 0
     },
-    [1]       =
     {
       .leftx  = 8972,
       .rightx = 27323,
       .y      = 780
     },
-    [2]       =
     {
       .leftx  = 9655,
       .rightx = 34328,
       .y      = 1560
     },
-    [3]       =
     {
       .leftx  = 14434,
       .rightx = 28867,
@@ -65,25 +61,21 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GTopLeft_Runs[NTOPLEFT_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 7022,
       .rightx = 7022,
       .y      = 2341
     },
-    [1]       =
     {
       .leftx  = 5461,
       .rightx = 9362,
       .y      = 4681
     },
-    [2]       =
     {
       .leftx  = 5098,
       .rightx = 12873,
       .y      = 8192
     },
-    [3]       =
     {
       .leftx  = 3193,
       .rightx = 10923,
@@ -107,37 +99,31 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GTopRight_Runs[NTOPRIGHT_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 37059,
       .rightx = 37059,
       .y      = 3901
     },
-    [1]       =
     {
       .leftx  = 33997,
       .rightx = 37839,
       .y      = 6242
     },
-    [2]       =
     {
       .leftx  = 30427,
       .rightx = 37591,
       .y      = 8972
     },
-    [3]       =
     {
       .leftx  = 28477,
       .rightx = 35924,
       .y      = 27307
     },
-    [4]       =
     {
       .leftx  = 28518,
       .rightx = 35889,
       .y      = 27697
     },
-    [5]       =
     {
       .leftx  = 32378,
       .rightx = 32378,
@@ -149,19 +135,16 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GMiddle_Runs[NMIDDLE_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 12483,
       .rightx = 27307,
       .y      = 28867
     },
-    [1]       =
     {
       .leftx  = 8192,
       .rightx = 30427,
       .y      = 32378
     },
-    [2]       =
     {
       .leftx  = 11703,
       .rightx = 25746,
@@ -173,32 +156,27 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GBottomLeft_Runs[NBOTTOMLEFT_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 5851,
       .rightx = 5851,
       .y      = 33938
     ,
     },
-    [1]       =
     {
       .leftx  = 1950,
       .rightx = 9752,
       .y      = 37449
     },
-    [2]       =
     {
       .leftx  = 370,
       .rightx = 8192,
       .y      = 55784
     },
-    [3]       =
     {
       .leftx  = 0,
       .rightx = 3364,
       .y      = 60075
     },
-    [4]       =
     {
       .leftx  = 1170,
       .rightx = 1170,
@@ -210,37 +188,31 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GBottomRight_Runs[NBOTTOMRIGHT_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 31988,
       .rightx = 31988,
       .y      = 34328
     },
-    [1]       =
     {
       .leftx  = 28769,
       .rightx = 35109,
       .y      = 37059
     },
-    [2]       =
     {
       .leftx  = 27307,
       .rightx = 34996,
       .y      = 38229
     },
-    [3]       =
     {
       .leftx  = 25746,
       .rightx = 33183,
       .y      = 56954
     },
-    [4]       =
     {
       .leftx  = 30324,
       .rightx = 32768,
       .y      = 61245
     },
-    [5]       =
     {
       .leftx  = 31988,
       .rightx = 31988,
@@ -252,19 +224,16 @@ namespace SLcd
 
   const struct SLcdTrapezoidRun GBottom_Runs[NBOTTOM_TRAPEZOIDS + 1] =
   {
-    [0]       =
     {
       .leftx  = 9362,
       .rightx = 24576,
       .y      = 58124
     },
-    [1]       =
     {
       .leftx  = 2731,
       .rightx = 31988,
       .y      = 63976
     },
-    [2]       =
     {
       .leftx  = 4681,
       .rightx = 28477,

--- a/include/graphics/nxwidgets/clabel.hxx
+++ b/include/graphics/nxwidgets/clabel.hxx
@@ -285,7 +285,7 @@ namespace NXWidgets
      * @param index Index at which to insert the text.
      */
 
-    virtual void insertText(const CNxString &text, const int index);
+    virtual void insertText(const CNxString &text, const unsigned int index);
 
     /**
      * Control the highlight state.

--- a/include/graphics/nxwm/ccalibration.hxx
+++ b/include/graphics/nxwm/ccalibration.hxx
@@ -64,7 +64,7 @@ namespace NxWM
    * Forward references
    */
 
-  struct CTouchscreen;
+  class CTouchscreen;
 
   /**
    * Touchscreen calibration data

--- a/include/graphics/nxwm/ccalibration.hxx
+++ b/include/graphics/nxwm/ccalibration.hxx
@@ -164,7 +164,6 @@ namespace NxWM
     struct nxgl_point_s        m_touchPos;        /**< This is the last touch position */
     volatile uint8_t           m_calthread;       /**< Current calibration display state (See ECalibThreadState)*/
     uint8_t                    m_calphase;        /**< Current calibration display state (See ECalibrationPhase)*/
-    bool                       m_stop;            /**< True: We have been asked to stop the calibration */
     bool                       m_touched;         /**< True: The screen is touched */
     uint8_t                    m_touchId;         /**< The ID of the touch */
 #ifdef CONFIG_NXWM_CALIBRATION_AVERAGE

--- a/include/graphics/twm4nx/ciconmgr.hxx
+++ b/include/graphics/twm4nx/ciconmgr.hxx
@@ -77,7 +77,7 @@ namespace Twm4Nx
       NXWidgets::CNxString            m_name;       /**< The Icon Manager name */
       FAR struct SWindowEntry        *m_head;       /**< Head of the window list */
       FAR struct SWindowEntry        *m_tail;       /**< Tail of the window list */
-      FAR struct CWindow             *m_window;     /**< Parent window */
+      FAR CWindow                    *m_window;     /**< Parent window */
       FAR NXWidgets::CButtonArray    *m_buttons;    /**< The contained button array */
       uint16_t                        m_nWindows;   /**< The number of windows in the icon mgr. */
       uint8_t                         m_nColumns;   /**< Fixed number of columns per row */


### PR DESCRIPTION
## Summary
Reported here:  https://github.com/apache/incubator-nuttx/pull/7391

## Impact
Style change

## Testing
Pass CI
