### PR TITLE
Add iptlite packet filter app

### DIFF
--- a/netutils/iptlite/Kconfig
+++ b/netutils/iptlite/Kconfig
@@ -1,0 +1,36 @@
+#############################################################################
+#
+# netutils/iptlite/Kconfig
+# iptlite networking application
+#
+#############################################################################
+
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_IPTLITE
+	bool "iptlite packet filter"
+	default n
+	depends on NET_TCP
+	---help---
+		Enable the iptlite packet filter
+
+if NETUTILS_IPTLITE
+
+config NETUTILS_IPTLITE_PROGNAME
+	string "Program name"
+	default "iptlite"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config NETUTILS_IPTLITE_PRIORITY
+	int "iptlite task priority"
+	default 100
+
+config NETUTILS_IPTLITE_STACKSIZE
+	int "iptlite stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/netutils/iptlite/Make.defs
+++ b/netutils/iptlite/Make.defs
@@ -1,0 +1,10 @@
+############################################################################
+#
+# netutils/iptlite/Make.defs
+# iptlite sample networking application
+#
+############################################################################
+
+ifneq ($(CONFIG_NETUTILS_IPTLITE),)
+CONFIGURED_APPS += $(APPDIR)/netutils/iptlite
+endif

--- a/netutils/iptlite/Makefile
+++ b/netutils/iptlite/Makefile
@@ -1,0 +1,18 @@
+############################################################################
+#
+# netutils/iptlite/Makefile
+# iptlite networking application
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# built-in application info
+
+MODULE    = $(CONFIG_NETUTILS_IPTLITE)
+PROGNAME  = $(CONFIG_NETUTILS_IPTLITE_PROGNAME)
+PRIORITY  = $(CONFIG_NETUTILS_IPTLITE_PRIORITY)
+STACKSIZE = $(CONFIG_NETUTILS_IPTLITE_STACKSIZE)
+MAINSRC = iptlite_main.c
+
+include $(APPDIR)/Application.mk

--- a/netutils/iptlite/iptlite_main.c
+++ b/netutils/iptlite/iptlite_main.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * apps/netutils/iptlite/iptlite_main.c
+ * iptlite networking application
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "../../../nuttx/net/devif/devif.h"
+#include <nuttx/config.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+void listall_rules(void)
+{
+  int rules_counter = nflite_get_rules_counter();
+  char** table = nflite_listall();
+
+  printf("%3s %10s %16s %16s %9s %9s\n", \
+  "ID", "RULE", "SRC IPADDR", "DEST IPADDR", "SRC PORT", "DEST PORT");
+
+  for (int i = 0; i < rules_counter; i++)
+    {
+      for (int j = 0; j < RULE_INFO_MAX_SIZE; j++)
+        {
+          printf("%c", table[i][j]);
+        }
+
+      printf("\n");
+    }
+}
+
+void add_rule(int rule, char * srcip, char * destip, char * srcprt, \
+char * destprt)
+{
+  in_addr_t srcipaddr, destipaddr;
+  in_port_t srcport, destport;
+  bool rule_added;
+
+  inet_pton(AF_INET, srcip, &srcipaddr);
+  inet_pton(AF_INET, destip, &destipaddr);
+  srcport = htons(strtoul(srcprt, NULL, 10));
+  destport = htons(strtoul(destprt, NULL, 10));
+
+  rule_added = nflite_addrule(
+    rule, srcipaddr, destipaddr, srcport, destport);
+
+  printf("rule_added? %s\n", rule_added ? "true" : "false");
+}
+
+/****************************************************************************
+ * iptlite_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int rule;
+
+  if (argc < 2)
+    {
+      printf("Not enough arguments!\n");
+      return -1;
+    }
+
+  if (strcmp(argv[1], "DROP") == 0 && argc == 6)
+    {
+      rule = 0;
+      add_rule(rule, argv[2], argv[3], argv[4], argv[5]);
+    }
+  else if (strcmp(argv[1], "FLUSHALL") == 0 && argc == 2)
+    {
+      rule = 1;
+      nflite_flushall();
+    }
+  else if (strcmp(argv[1], "LISTALL") == 0 && argc == 2)
+    {
+      rule = 2;
+      listall_rules();
+    }
+  else
+    {
+      printf("Invalid command! Verify command pattern.\n");
+      return -1;
+    }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
This merge request aims to add a lightweight packet filter to NuttX, called iptlite (iptables lite), which was based on Linux firewall, iptables and netfilter. This first implementation was focused on the essential commands, such as adding a drop rule based on the 4-tuple (source IP address, destination IP address, source port and destination port), flush all rules and list all rules, for all ingress TCP packets.

The implementation was divided in two parts: the iptlite app, the CLI to the user, and the nflite modules (netfilter lite), which will provide the APIs to the iptlite app, that can be seen in another MR on the incubator-nuttx repository.

This project was considered the third-best security tool in the XXII Brazilian Symposium on Information Security and Computer Systems, and the [related paper](https://sol.sbc.org.br/index.php/sbseg_estendido/article/view/21705) was accepted by this conference as well.

## Impact
This lightweight packet filter could be an additional security feature, especially in the IoT environment, allowing the users to adopt, for instance, a zero trust policy, consequently, denying all ingress packet filter, except by the preset ones.

## Testing
In order to give more context about the implementation that it was made, this following link will show a [quick video demo](https://drive.google.com/file/d/18mRSa_Vd_XRkorHnBmdGTAF5x2dykjLR/view) of the project.
