### PR TITLE
Added poweroff in fs and mm tests.

### DIFF
--- a/testing/fstest/Kconfig
+++ b/testing/fstest/Kconfig
@@ -71,4 +71,9 @@ config TESTING_FSTEST_VERBOSE
 	bool "Verbose output"
 	default n
 
+config TESTING_FSTEST_POWEROFF
+	bool "Terminate on test completion"
+	default n
+	depends on BOARDCTL_POWEROFF
+
 endif

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -28,6 +28,10 @@
 #include <sys/ioctl.h>
 #include <sys/statfs.h>
 
+#ifdef CONFIG_TESTING_FSTEST_POWEROFF
+#include <sys/boardctl.h>
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1175,5 +1179,14 @@ int main(int argc, FAR char *argv[])
   fstest_endmemusage(ctx);
   fflush(stdout);
   free(ctx);
+
+#ifdef CONFIG_TESTING_FSTEST_POWEROFF
+  /* Power down. This is useful when used with the simulator and gcov,
+   * as the graceful shutdown allows for the generation of the .gcda files.
+   */
+
+  boardctl(BOARDIOC_POWEROFF, 0);
+#endif
+
   return 0;
 }

--- a/testing/mm/Kconfig
+++ b/testing/mm/Kconfig
@@ -26,4 +26,9 @@ config TESTING_MM_STACKSIZE
 	int "Stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config TESTING_MM_POWEROFF
+	bool "Terminate on test completion"
+	default n
+	depends on BOARDCTL_POWEROFF
+
 endif

--- a/testing/mm/mm_main.c
+++ b/testing/mm/mm_main.c
@@ -22,11 +22,17 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
 #include <string.h>
 #include <assert.h>
+
+#ifdef CONFIG_TESTING_MM_POWEROFF
+#include <sys/boardctl.h>
+#endif
 
 #include <nuttx/queue.h>
 
@@ -354,5 +360,14 @@ int main(int argc, FAR char *argv[])
   do_frees(g_allocs, g_alloc_small_sizes, g_random1, NTEST_ALLOCS);
 
   printf("TEST COMPLETE\n");
+
+#ifdef CONFIG_TESTING_MM_POWEROFF
+  /* Power down. This is useful when used with the simulator and gcov,
+   * as the graceful shutdown allows for the generation of the .gcda files.
+   */
+
+  boardctl(BOARDIOC_POWEROFF, 0);
+#endif
+
   return 0;
 }


### PR DESCRIPTION
## Summary

Adds a poweroff call at the end of the FS and MM tests.  
This is needed, as the graceful shutdown allows the generation of .gcda files.

This allows our CI to get code coverage data for these tests when run on the simulator.

## Impact

By default the option is disabled, so there is no impact on any current system.

## Testing

Tested execution of both tests, and then I got code coverage information on both tests using lcov.
