### PR TITLE
Fix Error: slcd_trapezoids.cxx:84:5: error: array designators are a C99 extension [-Werror,-Wc99-designator]

### DIFF
--- a/graphics/slcd/slcd_trapezoids.cxx
+++ b/graphics/slcd/slcd_trapezoids.cxx
@@ -81,13 +81,11 @@ namespace SLcd
       .rightx = 10923,
       .y      = 26526
     },
-    [4]       =
     {
       .leftx  = 3121,
       .rightx = 9986,
       .y      = 27307
     },
-    [5]       =
     {
       .leftx  = 6242,
       .rightx = 6242,


### PR DESCRIPTION
## Summary

## Impact
Minor

## Testing
Pass CI
