### PR TITLE
Fix CI crash because switch() was missing NMEA sentences

### DIFF
--- a/examples/gps/gps_main.c
+++ b/examples/gps/gps_main.c
@@ -133,6 +133,9 @@ int main(int argc, FAR char *argv[])
           case MINMEA_SENTENCE_GLL:
           case MINMEA_SENTENCE_GST:
           case MINMEA_SENTENCE_GSV:
+          case MINMEA_SENTENCE_GBS:
+          case MINMEA_SENTENCE_VTG:
+          case MINMEA_SENTENCE_ZDA:
             {
             }
             break;


### PR DESCRIPTION
## Summary
Fix CI crash because switch() as missing NMEA sentences
## Impact
Only for CI
## Testing
LilyGO_TBEAM_LoRa_GPS
