### PR TITLE
disable BOOTP flag by default during DHCP

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -32,7 +32,7 @@ config NETUTILS_DHCPC_RETRIES
 
 config NETUTILS_DHCPC_BOOTP_FLAGS
 	hex "Flags of Bootstrap"
-	default 0x8000
+	default 0x0000
 	---help---
 		This setting to set the BOOTP broadcast flags.
 		Reference RFC1542: Clarifications and Extensions for the


### PR DESCRIPTION
## Summary
Issue
DHCP server will send DHCP offer/ack via broadcast packet if broadcast flag is enabled in DHCP discover/request.
There's no retransmition mechanism for broadcast frame in 802.11 MAC layer, thus transmit fail rate might be very high. This will increase DHCP fail rate.

Solution
Disable broadcast flag by default

## Impact
DHCP

## Testing
Internal compatibility test
