### PR TITLE
apps: getpid should return process id not thread id

### DIFF
--- a/graphics/pdcurs34/nuttx/pdcthread.c
+++ b/graphics/pdcurs34/nuttx/pdcthread.c
@@ -116,9 +116,9 @@ static FAR struct pdc_context_s *PDC_ctx_new(void)
   ctx->panel_ctx = pdc_alloc_panel_ctx();
   ctx->term_ctx  = pdc_alloc_term_ctx();
 
-  /* Get our PID */
+  /* Get our TID */
 
-  pid = getpid();
+  pid = gettid();
 
 #ifdef CONFIG_PDCURSES_MULTITHREAD_HASH
 
@@ -177,9 +177,9 @@ FAR struct pdc_context_s * PDC_ctx(void)
       PDC_ctx_initialize();
     }
 
-  /* Get our PID */
+  /* Get our TID */
 
-  pid = getpid();
+  pid = gettid();
 
 #ifdef CONFIG_PDCURSES_MULTITHREAD_HASH
 
@@ -262,9 +262,9 @@ void PDC_ctx_free(void)
 #ifdef CONFIG_PDCURSES_MULTITHREAD_HASH
   int pid;
 
-  /* Get a unique hash key from the PID */
+  /* Get a unique hash key from the TID */
 
-  pid = PIDHASH(getpid());
+  pid = PIDHASH(gettid());
   ctx = g_pdc_ctx_per_pid[pid];
 
   /* Free the context memory */

--- a/netutils/netlib/netlib_getarptab.c
+++ b/netutils/netlib/netlib_getarptab.c
@@ -122,7 +122,7 @@ ssize_t netlib_get_arptable(FAR struct arp_entry_s *arptab,
 
   /* Bind the socket so that we can use send() and receive() */
 
-  pid            = getpid();
+  pid            = gettid();
   addr.nl_family = AF_NETLINK;
   addr.nl_pad    = 0;
   addr.nl_pid    = pid;

--- a/netutils/netlib/netlib_getdevs.c
+++ b/netutils/netlib/netlib_getdevs.c
@@ -110,7 +110,7 @@ ssize_t netlib_get_devices(FAR struct netlib_device_s *devlist,
 
   /* Bind the socket so that we can use send() and receive() */
 
-  pid            = getpid();
+  pid            = gettid();
   addr.nl_family = AF_NETLINK;
   addr.nl_pad    = 0;
   addr.nl_pid    = pid;

--- a/netutils/netlib/netlib_getnbtab.c
+++ b/netutils/netlib/netlib_getnbtab.c
@@ -123,7 +123,7 @@ ssize_t netlib_get_nbtable(FAR struct neighbor_entry_s *nbtab,
 
   /* Bind the socket so that we can use send() and receive() */
 
-  pid            = getpid();
+  pid            = gettid();
   addr.nl_family = AF_NETLINK;
   addr.nl_pad    = 0;
   addr.nl_pid    = pid;

--- a/netutils/netlib/netlib_getroute.c
+++ b/netutils/netlib/netlib_getroute.c
@@ -140,7 +140,7 @@ ssize_t netlib_get_route(FAR struct rtentry *rtelist,
 
   /* Bind the socket so that we can use send() and receive() */
 
-  pid            = getpid();
+  pid            = gettid();
   addr.nl_family = AF_NETLINK;
   addr.nl_pad    = 0;
   addr.nl_pid    = pid;

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -2135,9 +2135,9 @@ FAR httpd_server *httpd_initialize(FAR httpd_sockaddr *sa)
 {
   FAR httpd_server *hs;
 
-  /* Save the PID of the main thread */
+  /* Save the TID of the main thread */
 
-  main_thread = getpid();
+  main_thread = gettid();
 
   /* Allocate the server structure */
 
@@ -2203,7 +2203,7 @@ void httpd_write_response(httpd_conn *hc)
 {
   /* If we are in a sub-task, turn off no-delay mode. */
 
-  if (main_thread != getpid())
+  if (main_thread != gettid())
     {
        httpd_clear_ndelay(hc->conn_fd);
     }

--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -160,7 +160,7 @@ int main(int argc, FAR char *argv[])
               strcat(command, " ");
             }
 
-          sched_setaffinity(getpid(), sizeof(cpu_set_t), &cpuset);
+          sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset);
           system(command);
         }
     }

--- a/testing/ostest/prioinherit.c
+++ b/testing/ostest/prioinherit.c
@@ -100,7 +100,7 @@ static void sleep_and_display(int n, int us)
 
   do
     {
-      int status = sched_getparam(getpid(), &sparam);
+      int status = sched_getparam(gettid(), &sparam);
 
       if (status != 0)
         {
@@ -503,7 +503,7 @@ void priority_inheritance(void)
   for (i = 0; i < NHIGHPRI_THREADS; i++) g_highstate[i] = NOTSTARTED;
   for (i = 0; i < NLOWPRI_THREADS; i++)  g_lowstate[i]  = NOTSTARTED;
 
-  status = sched_getparam(getpid(), &sparam);
+  status = sched_getparam(gettid(), &sparam);
   if (status != 0)
     {
       printf("priority_inheritance: ERROR sched_getparam failed\n");

--- a/testing/ostest/timedwait.c
+++ b/testing/ostest/timedwait.c
@@ -158,7 +158,7 @@ void timedwait_test(void)
     }
 
   prio_max = sched_get_priority_max(SCHED_FIFO);
-  status = sched_getparam (getpid(), &sparam);
+  status = sched_getparam (gettid(), &sparam);
   if (status != 0)
     {
       printf("timedwait_test: sched_getparam failed\n");


### PR DESCRIPTION
## Summary
   following the change in the nuttx kernel, implement the right semantics:
1. getpid should return the main thread id
2. gettid should return the current thread id
update apps code

Refer:
 https://github.com/apache/incubator-nuttx/issues/2499
 https://github.com/apache/incubator-nuttx/pull/2518

Nuttx Kernel PR:
 https://github.com/apache/incubator-nuttx/pull/7597

## Impact
any code that use getpid/gettid need to check

## Testing
ostest PASSED at qemu with configure
1. ARM 32bit: ./tools/configure.sh -l sabre-6quad:nsh
2. ARM 64bit: ./tools/configure.sh -l qemu-armv8a:nsh
Let's ignore the false nxstyle warning.