### PR TITLE
ostest: reset g_restartstep when test case restart

### DIFF
--- a/testing/ostest/restart.c
+++ b/testing/ostest/restart.c
@@ -155,6 +155,8 @@ void restart_test(void)
 {
   int ret;
 
+  g_restartstep = 0;
+
   /* Start the children and wait for first one to complete */
 
   printf("\nTest task_restart()\n");


### PR DESCRIPTION

## Summary

The g_restartstep value is not initialized when ostest repeated.

## Impact

NA

## Testing

sim:nsh ostest
