### PR TITLE
Remove DISCLAIMER. Apache NuttX has graduated the Incubator.

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,6 +1,0 @@
-Apache NuttX is an effort undergoing incubation at The Apache Software Foundation (ASF),
-sponsored by the Apache Incubator. Incubation is required of all newly accepted projects
-until a further review indicates that the infrastructure, communications, and decision
-making process have stabilized in a manner consistent with other successful ASF projects.
-While incubation status is not necessarily a reflection of the completeness or stability
-of the code, it does indicate that the project has yet to be fully endorsed by the ASF.


### PR DESCRIPTION
## Summary

NuttX has graduated the Incubator!

- Removing the DISCLAIMER file.

## Impact

None.

## Testing

N/A.