### PR TITLE
examples/tcp_ipc_server: fix wrong file path typo

### DIFF
--- a/examples/tcp_ipc_server/Makefile
+++ b/examples/tcp_ipc_server/Makefile
@@ -28,7 +28,7 @@ STACKSIZE = $(CONFIG_EXAMPLES_TCP_IPC_SERVER_STACKSIZE)
 MODULE    = $(CONFIG_EXAMPLES_TCP_IPC_SERVER)
 
 # SERVIDOR Example
-CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/examples/server_tcp/lorawan
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/examples/tcp_ipc_server/lorawan
 CSRCS  = uart_lorawan_layer.c protocol.c
 
 MAINSRC = tcp_ipc_server_main.c


### PR DESCRIPTION
## Summary

The `lorawan` folder is under the path of `examples/tcp_ipc_server`, the `server_tcp` folder does not exist here, so fix it.
```
➜  /home/mi/xiaomi/nuttx/apps/examples/tcp_ipc_server/lorawan git:(makefile) pwd
/home/mi/xiaomi/nuttx/apps/examples/tcp_ipc_server/lorawan
➜  /home/mi/xiaomi/nuttx/apps/examples/tcp_ipc_server/lorawan git:(makefile)
```

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

## Testing

