### PR TITLE
wapi: fix save_config can not update if string prefix is same

### DIFF
--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -148,7 +148,7 @@ static bool wapi_json_update(FAR cJSON *root,
           int len = strlen(obj->valuestring);
           if (len > 0)
             {
-              if (!strncmp(value, obj->valuestring, len))
+              if (!strcmp(value, obj->valuestring))
                 {
                   return false;
                 }


### PR DESCRIPTION
Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>

## Summary

## Impact

## Testing

