### PR TITLE
Fix Error: vi.c:888:57: error: format string is not a string literal(potentially insecure)

### DIFF
--- a/examples/ft80x/ft80x_coprocessor.c
+++ b/examples/ft80x/ft80x_coprocessor.c
@@ -3907,7 +3907,8 @@ int ft80x_coproc_calibrate(int fd, FAR struct ft80x_dlbuffer_s *buffer)
       return ret;
     }
 
-  ft80x_info("Transform A-F: {%08lx, %08lx, %08lx, %08lx, %08lx, %08lx}\n",
+  ft80x_info("Transform A-F: {%08" PRIx32 ", %08" PRIx32 ", %08"
+             PRIx32 ", %08" PRIx32 ", %08" PRIx32 ", %08" PRIx32 "}\n",
              matrix[0], matrix[1], matrix[2],
              matrix[3], matrix[4], matrix[5]);
   return OK;

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -885,7 +885,7 @@ static void vi_printf(FAR struct vi_s *vi, FAR const char *prefix,
 
   /* Expand the prefix message in the scratch buffer */
 
-  len = prefix ? snprintf(vi->scratch, SCRATCH_BUFSIZE, prefix) : 0;
+  len = prefix ? snprintf(vi->scratch, SCRATCH_BUFSIZE, "%s", prefix) : 0;
 
   va_start(ap, fmt);
   len += vsnprintf(vi->scratch + len, SCRATCH_BUFSIZE - len, fmt, ap);


### PR DESCRIPTION
## Summary
Found by https://github.com/apache/incubator-nuttx/pull/7391
please ignore the following false warning:
```
/home/xiaoxiang/backup/os/nuttx/apps/system/vi/vi.c:540:57: error: Multiple data definitions
/home/xiaoxiang/backup/os/nuttx/apps/system/vi/vi.c:541:54: error: Multiple data definitions
```

## Impact
Minor change

## Testing
Pass CI
