### PR TITLE
system/ping[6]: ping[6] should also be enabled if NET_ICMP[v6]_NO_STACK == y

### DIFF
--- a/system/ping/Kconfig
+++ b/system/ping/Kconfig
@@ -6,7 +6,7 @@
 config SYSTEM_PING
 	tristate "ICMP 'ping' command"
 	default n
-	depends on NET_ICMP
+	depends on NET_ICMP || NET_ICMP_NO_STACK
 	select NETUTILS_PING
 	---help---
 		Enable support for the ICMP 'ping' command.

--- a/system/ping6/Kconfig
+++ b/system/ping6/Kconfig
@@ -6,7 +6,7 @@
 config SYSTEM_PING6
 	tristate "ICMPv6 'ping6' command"
 	default n
-	depends on NET_ICMPv6
+	depends on NET_ICMPv6 || NET_ICMPv6_NO_STACK
 	select NETUTILS_PING6
 	---help---
 		Enable support for the ICMP 'ping' command.


### PR DESCRIPTION
## Summary

system/ping[6]: ping[6] should also be enabled if NET_ICMP[v6]_NO_STACK == y

## Impact

N/A

## Testing

icmp ping