### PR TITLE
system/ping: remove depends since NETUTILS_PING already contains this check

### DIFF
--- a/system/ping/Kconfig
+++ b/system/ping/Kconfig
@@ -6,7 +6,6 @@
 config SYSTEM_PING
 	tristate "ICMP 'ping' command"
 	default n
-	depends on NET_ICMP || NET_ICMP_NO_STACK
 	select NETUTILS_PING
 	---help---
 		Enable support for the ICMP 'ping' command.

--- a/system/ping6/Kconfig
+++ b/system/ping6/Kconfig
@@ -6,7 +6,6 @@
 config SYSTEM_PING6
 	tristate "ICMPv6 'ping6' command"
 	default n
-	depends on NET_ICMPv6 || NET_ICMPv6_NO_STACK
 	select NETUTILS_PING6
 	---help---
 		Enable support for the ICMP 'ping' command.


### PR DESCRIPTION
## Summary

system/ping: remove depends since NETUTILS_PING already contains this check

## Impact

N/A

## Testing

icmp test