### PR TITLE
netutils/iperf: add more default device name

### DIFF
--- a/netutils/iperf/Kconfig
+++ b/netutils/iperf/Kconfig
@@ -32,6 +32,12 @@ config NETUTILS_IPERF_STACKSIZE
 
 config NETUTILS_IPERFTEST_DEVNAME
 	string "iperf Network device"
-	default "wlan0"
+	default "wlan0" if DRIVERS_IEEE80211
+	default "wpan0" if NET_6LOWPAN
+	default "sl0"   if NET_SLIP
+	default "tun0"  if NET_TUN
+	default "can0"  if NET_CAN
+	default "eth0"  if NET_ETHERNET
+	default "lo" # if NET_LOOPBACK
 
 endif


### PR DESCRIPTION
## Summary

netutils/iperf: add more default device name

## Impact

N/A

## Testing

iperf test