### PR TITLE
system/vi: fix nxstyle warning

### DIFF
--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -537,8 +537,8 @@ static const char g_fmtmodified[]   =
                             "No write since last change (add ! to override)";
 static const char g_fmtnotvalid[]   = "Command not valid";
 static const char g_fmtnotcmd[]     = "Not an editor command: %s";
-static const char g_fmtsrcbot[]     = "search hit BOTTOM, continuing at TOP";
-static const char g_fmtsrctop[]     = "search hit TOP, continuing at BOTTOM";
+static const char g_fmtsrcbot[]     = "search hit BOTTOM(continuing at TOP)";
+static const char g_fmtsrctop[]     = "search hit TOP(continuing at BOTTOM)";
 static const char g_fmtinsert[]     = "--INSERT--";
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

```
system/vi: fix nxstyle warning

system/vi/vi.c:540:57: error: Multiple data definitions
system/vi/vi.c:541:54: error: Multiple data definitions

Signed-off-by: chao an <anchao@xiaomi.com>
```
## Impact

N/A

## Testing

ci-check