### PR TITLE
CI: Update worker base OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: Fetch-Source
     strategy:
       matrix:
@@ -186,6 +186,12 @@ jobs:
 
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
+
+      # Released version of Cython has issues with Python 11. Set runner to use Python 3.10
+      # https://github.com/cython/cython/issues/4500
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout nuttx repo


### PR DESCRIPTION
## Summary
Update base OS versions:
Linux
 * Only the check job is updated from  Ubuntu 18.04 [deprecated]  to "latest" (20.04). Others were already on "latest" which is  Ubuntu 20.04 
MacOS
 * Update from  macOS Catalina 10.15 [deprecated] to  macOS Monterey 12

## Impact
Builds are moved off deprecated runner images.  The Linux build itself should not change as it was already running in a container with a pinned version.

## Testing
Passing CI provides coverage for this change.
